### PR TITLE
Added API keys

### DIFF
--- a/UploadersLib/ApiKeys/APIKeysLocal.cs
+++ b/UploadersLib/ApiKeys/APIKeysLocal.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UploadersLib
+{
+    public static partial class APIKeys
+    {
+        static APIKeys()
+        {
+            APIKeys.ImageShackKey = "5DEFHIMQ81951c9e786e00f21774fec39382b6ad";
+            APIKeys.TinyPicID = "e2aabb8d555322fa";
+            APIKeys.TinyPicKey = "00a68ed73ddd54da52dc2d5803fa35ee";
+            APIKeys.ImgurClientID = "d297fd441566f99";
+            APIKeys.ImgurClientSecret = "e7d67e86cafa32e313930100607c7ed953c5ad83";
+            APIKeys.FlickrKey = "fbe042faa01e6af0371b6d87be75436a";
+            APIKeys.FlickrSecret = "9f85687dcccc7ef9";
+            APIKeys.PhotobucketConsumerKey = "149828681";
+            APIKeys.PhotobucketConsumerSecret = "d2638b653e88315aac528087e9db54e3";
+            APIKeys.TwitsnapsKey = "694aaea3bc8f28479c383cbcc094fb55";
+            APIKeys.TwitPicKey = "816528c0152003a64e45402370805a5a";
+            APIKeys.DropboxConsumerKey = "0te7j9ype9lrdfn";
+            APIKeys.DropboxConsumerSecret = "r5d3aptd9a0cwp9";
+            APIKeys.MinusConsumerKey = "b57b69843f7a302a276dde89890fc6";
+            APIKeys.MinusConsumerSecret = "3fb097f08314d713959b1f41d543b0";
+            APIKeys.BoxKey = "5vd8549xmn9a7zil4iupb0ciroj7cvee";
+            APIKeys.BoxClientID = "5vd8549xmn9a7zil4iupb0ciroj7cvee";
+            APIKeys.BoxClientSecret = "52VncS5clEEdV4ck8NspYECWvsZo69LA";
+            APIKeys.SendSpaceKey = "LV6OS1R0Q3";
+            APIKeys.Ge_ttKey = "tdrrlb84kq2dquxrh4dw79gr3act0529";
+            APIKeys.JiraConsumerKey = "NJgrJ4EhAahDwYuxLTtT";
+            APIKeys.PastebinKey = "4b23be71ec78bbd4fb96735320aa09ef";
+            APIKeys.PastebinCaKey = "KxTofLKQThSBZ63Gpa7hYLlMdyQlMD6u";
+            APIKeys.GistId = "badfa7b5e0a67e31da88";
+            APIKeys.GistSecret = "a538eff39300680f43d123a59ab9c1d9d4763640";
+            APIKeys.BitlyClientID = "0bf9726bea922ab7d5760a913d6749b441e5176a";
+            APIKeys.BitlyClientSecret = "1156e02a228deccbe8c7f100711411063249497b";
+            APIKeys.GoogleAPIKey = "AIzaSyDjW0ATw7G-72iAoNsnkGbQKplasWG3eSA";
+            APIKeys.GoogleClientID = "810697162603.apps.googleusercontent.com";
+            APIKeys.GoogleClientSecret = "BzjPSjDufImJM6Dcg-WBZvoh";
+            APIKeys.TwitterConsumerKey = "Dw9iuniatwgsk4nwOcKGNg";
+            APIKeys.TwitterConsumerSecret = "q2fGaWzuHbbRwQPast1lYZjFnpuiI6axTYWwTytj8";
+        }
+    }
+}


### PR DESCRIPTION
Looks like API keys are missing in latest ShareX repo for some reason, this adds them back.
