### PR TITLE
Added support for custom Amazon S3 endpoints, and DreamObjects compatibility.

### DIFF
--- a/UploadersLib/FileUploaders/AmazonS3.cs
+++ b/UploadersLib/FileUploaders/AmazonS3.cs
@@ -63,7 +63,7 @@ namespace UploadersLib.FileUploaders
         {
             var policyDocument = new
             {
-                expiration = DateTime.UtcNow.AddDays(2).ToString("o"), // The policy is valid for 2 days
+                expiration = DateTime.UtcNow.AddDays(2).ToString("yyyy-MM-ddTHH:mm:ssZ"), // The policy is valid for 2 days
                 conditions = new List<S3PolicyCondition> {
                     new S3PolicyCondition("acl", "public-read"),
                     new S3PolicyCondition("bucket", S3Settings.Bucket),

--- a/UploadersLib/GUI/UploadersConfigForm.Designer.cs
+++ b/UploadersLib/GUI/UploadersConfigForm.Designer.cs
@@ -1902,7 +1902,6 @@
             // 
             // cbAmazonS3Endpoint
             // 
-            this.cbAmazonS3Endpoint.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbAmazonS3Endpoint.FormattingEnabled = true;
             this.cbAmazonS3Endpoint.Items.AddRange(new object[] {
             "https://s3-ap-northeast-1.amazonaws.com/",


### PR DESCRIPTION
Added support for custom Amazon S3 endpoints. ShareX is now compatible with DreamObjects - the format of the policy timestamp sent up has been tweaked slightly to allow the DreamObjects API to work.
