### PR TITLE
The S3 object name is no longer generated twice, previously resulting in...

### DIFF
--- a/UploadersLib/FileUploaders/AmazonS3.cs
+++ b/UploadersLib/FileUploaders/AmazonS3.cs
@@ -59,7 +59,7 @@ namespace UploadersLib.FileUploaders
             }
         }
 
-        private string GetPolicyDocument(string fileName)
+        private string GetPolicyDocument(string fileName, string objectKey)
         {
             var policyDocument = new
             {
@@ -68,7 +68,7 @@ namespace UploadersLib.FileUploaders
                     new S3PolicyCondition("acl", "public-read"),
                     new S3PolicyCondition("bucket", S3Settings.Bucket),
                     new S3PolicyCondition("Content-Type", Helpers.GetMimeType(fileName)),
-                    new S3PolicyCondition("key", GetObjectKey(fileName)),
+                    new S3PolicyCondition("key", objectKey),
                     new S3PolicyCondition("x-amz-storage-class", GetObjectStorageClass())
                 }
             };
@@ -122,7 +122,7 @@ namespace UploadersLib.FileUploaders
 
         private Dictionary<string, string> GetParameters(string fileName, string objectKey)
         {
-            var policyDocument = GetPolicyDocument(fileName);
+            var policyDocument = GetPolicyDocument(fileName, objectKey);
             var policyBytes = Encoding.ASCII.GetBytes(policyDocument);
             var signature = CreateSignature(S3Settings.SecretAccessKey, policyBytes);
 

--- a/UploadersLib/GUI/UploadersConfigForm.Designer.cs
+++ b/UploadersLib/GUI/UploadersConfigForm.Designer.cs
@@ -1952,7 +1952,6 @@
             this.txtAmazonS3ObjectPrefix.Name = "txtAmazonS3ObjectPrefix";
             this.txtAmazonS3ObjectPrefix.Size = new System.Drawing.Size(348, 20);
             this.txtAmazonS3ObjectPrefix.TabIndex = 14;
-            this.ttHelpTip.SetToolTip(this.txtAmazonS3ObjectPrefix, "The name to prefix objects with when storing them.");
             this.txtAmazonS3ObjectPrefix.TextChanged += new System.EventHandler(this.txtAmazonS3ObjectPrefix_TextChanged);
             // 
             // lblAmazonS3ObjectPrefix
@@ -1960,9 +1959,9 @@
             this.lblAmazonS3ObjectPrefix.AutoSize = true;
             this.lblAmazonS3ObjectPrefix.Location = new System.Drawing.Point(26, 135);
             this.lblAmazonS3ObjectPrefix.Name = "lblAmazonS3ObjectPrefix";
-            this.lblAmazonS3ObjectPrefix.Size = new System.Drawing.Size(69, 13);
+            this.lblAmazonS3ObjectPrefix.Size = new System.Drawing.Size(68, 13);
             this.lblAmazonS3ObjectPrefix.TabIndex = 13;
-            this.lblAmazonS3ObjectPrefix.Text = "Object prefix:";
+            this.lblAmazonS3ObjectPrefix.Text = "Upload path:";
             // 
             // cbAmazonS3UseRRS
             // 

--- a/UploadersLib/GUI/UploadersConfigForm.cs
+++ b/UploadersLib/GUI/UploadersConfigForm.cs
@@ -48,6 +48,8 @@ namespace UploadersLib
             CreateUserControlEvents();
             LoadSettings(uploadersConfig);
             Text = "ShareX - Outputs Configuration" + (string.IsNullOrEmpty(uploadersConfig.FilePath) ? string.Empty : " - " + uploadersConfig.FilePath);
+
+            NameParser.CreateCodesMenu(this.txtAmazonS3ObjectPrefix, ReplacementVariables.n, ReplacementVariables.t, ReplacementVariables.pn);
         }
 
         private void UploadersConfigForm_FormClosed(object sender, FormClosedEventArgs e)


### PR DESCRIPTION
... failed uploads where random characters were used. Amazon S3 object prefix option changed to "upload path" (consistent with Dropbox). Added help dropdown to upload path.
