### PR TITLE
Added gfycat support. Anonymous uploads only, supports gif and ffmpeg video

### DIFF
--- a/ShareX/UploadTask.cs
+++ b/ShareX/UploadTask.cs
@@ -815,6 +815,9 @@ namespace ShareX
                         Share = Program.UploadersConfig.BoxShare
                     };
                     break;
+                case FileDestination.Gfycat:
+                    fileUploader = new GfycatUploader();
+                    break;
                 case FileDestination.Ge_tt:
                     if (Program.UploadersConfig.IsActive(FileDestination.Ge_tt))
                     {

--- a/UploadersLib/Enums.cs
+++ b/UploadersLib/Enums.cs
@@ -86,6 +86,8 @@ namespace UploadersLib
         Dropbox,
         [Description("FTP Server")]
         FTP,
+        [Description("gfycat.com")]
+        Gfycat,
         [Description("mega.co.nz")]
         Mega,
         [Description("s3.amazon.com")]

--- a/UploadersLib/FileUploaders/GfycatUploader.cs
+++ b/UploadersLib/FileUploaders/GfycatUploader.cs
@@ -1,0 +1,88 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (C) 2007-2014 ShareX Developers
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using HelpersLib;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using UploadersLib.HelperClasses;
+
+namespace UploadersLib.FileUploaders
+{
+    public class GfycatUploader : FileUploader
+    {
+        public override UploadResult Upload(Stream stream, string fileName)
+        {
+            Dictionary<string, string> args = new Dictionary<string, string>();
+
+            // Magical official values from http://www.reddit.com/r/gfycat/comments/20xbth/any_word_on_allowing_uploading_a_gif_through_the/
+            args.Add("key", Helpers.GetRandomAlphanumeric(10));
+            args.Add("acl", "private");
+            args.Add("AWSAccessKeyId", "AKIAIT4VU4B7G2LQYKZQ");
+            args.Add("policy", "eyAiZXhwaXJhdGlvbiI6ICIyMDIwLTEyLTAxVDEyOjAwOjAwLjAwMFoiLAogICAgICAgICAgICAiY29uZGl0aW9ucyI6IFsKICAgICAgICAgICAgeyJidWNrZXQiOiAiZ2lmYWZmZSJ9LAogICAgICAgICAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAiIl0sCiAgICAgICAgICAgIHsiYWNsIjogInByaXZhdGUifSwKCSAgICB7InN1Y2Nlc3NfYWN0aW9uX3N0YXR1cyI6ICIyMDAifSwKICAgICAgICAgICAgWyJzdGFydHMtd2l0aCIsICIkQ29udGVudC1UeXBlIiwgIiJdLAogICAgICAgICAgICBbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMCwgNTI0Mjg4MDAwXQogICAgICAgICAgICBdCiAgICAgICAgICB9");
+            args.Add("success_action_status", "200");
+            args.Add("signature", "mk9t/U/wRN4/uU01mXfeTe2Kcoc=");
+            args.Add("Content-Type", MimeTypes.GetMimeType(Path.GetExtension(fileName).ToLower()));
+            UploadResult result = UploadData(stream, "https://gifaffe.s3.amazonaws.com/", fileName, "file", args);
+
+            if (!result.IsError)
+            {
+                TranscodeFile(args["key"], result);
+            }
+
+            return result;
+        }
+
+        private void TranscodeFile(string key, UploadResult result)
+        {
+            string json = SendRequest(HttpMethod.GET, "https://upload.gfycat.com/transcode/" + key);
+            GfycatTranscodeResponse response = JsonConvert.DeserializeObject<GfycatTranscodeResponse>(json);
+
+            if (response.Task == GfycatTask.COMPLETE)
+            {
+                result.URL = "http://gfycat.com/" + response.GfyName;
+            }
+            else
+            {
+                result.Errors.Add(response.Error);
+                result.IsSuccess = false;
+            }
+        }
+    }
+
+    public class GfycatTranscodeResponse
+    {
+        public GfycatTask Task { get; set; }
+        public string GfyName { get; set; }
+        public string Error { get; set; }
+    }
+
+    public enum GfycatTask {
+        ERROR,
+        COMPLETE
+    }
+}

--- a/UploadersLib/UploadersLib.csproj
+++ b/UploadersLib/UploadersLib.csproj
@@ -174,6 +174,7 @@
       <DependentUpon>UploadersConfigForm.cs</DependentUpon>
     </Compile>
     <Compile Include="FileUploaders\Pushbullet.cs" />
+    <Compile Include="FileUploaders\GfycatUploader.cs" />
     <Compile Include="TextUploaders\Upaste.cs" />
     <Compile Include="UploadersConfig.cs" />
     <Compile Include="GUI\UserPassBox.cs">


### PR DESCRIPTION
Gfycat is an image host for gifs and short-soundless-videos, it provides much better hosting and playback than gifs on most browsers by using html5 where available. Generally, uploading gifs to imgur or videos to a file host will result in worse playback than uploading them to gfycat, so I've added support for it as an uploader.

The one caveat is that the ShareX uploader is a file uploader and not an image uploader. This is because it supports ffmpeg, which is considered a file not an image. This could possible be changed in the future by asking each target uploader if they support a given type, before trying to guess it ourselves.
