### PR TITLE
Makes annotation hint text center on primary monitor

### DIFF
--- a/ScreenCaptureLib/Forms/RectangleAnnotate.cs
+++ b/ScreenCaptureLib/Forms/RectangleAnnotate.cs
@@ -388,12 +388,19 @@ namespace ScreenCaptureLib
             Size textSize = g.MeasureString(tipText, tipFont).ToSize();
             int rectWidth = textSize.Width + padding * 2;
             int rectHeight = textSize.Height + padding * 2;
-            Rectangle activeMonitor = CaptureHelpers.GetActiveScreenBounds();
-            Rectangle textRectangle = new Rectangle(activeMonitor.Width / 2 - rectWidth / 2, offset, rectWidth, rectHeight);
+            Rectangle primaryScreenBounds = Screen.PrimaryScreen.Bounds;
+            foreach(Screen screen in Screen.AllScreens)
+            {
+                if(screen.Bounds.Left < 0)
+                {
+                    primaryScreenBounds.X -= screen.Bounds.Left;
+                }
+            }
+            Rectangle textRectangle = new Rectangle(primaryScreenBounds.X + (primaryScreenBounds.Width / 2) - (rectWidth / 2), offset, rectWidth, rectHeight);
 
             if (textRectangle.RectangleOffset(10).Contains(CurrentMousePosition0Based))
             {
-                textRectangle.Y = ScreenRectangle0Based.Height - rectHeight - offset;
+                textRectangle.Y = primaryScreenBounds.Height - rectHeight - offset - offset;
             }
 
             using (Brush brush = new SolidBrush(Color.FromArgb(175, Color.White)))


### PR DESCRIPTION
Makes the annotation hint text appear in the center of the primary monitor. Currently, if you have 2 monitors (or an even number, i presume) it will appear across their edges.

Tested. Known issues are that it might not work with vertically arranged monitors.
