### PR TITLE
Enable persistent connection for HTTP file upload

### DIFF
--- a/UploadersLib/Uploader.cs
+++ b/UploadersLib/Uploader.cs
@@ -355,7 +355,7 @@ namespace UploadersLib
             request.CookieContainer = new CookieContainer();
             if (cookies != null) request.CookieContainer.Add(cookies);
             if (headers != null) request.Headers.Add(headers);
-            request.KeepAlive = false;
+            request.KeepAlive = true;
             request.Method = method.ToString();
             request.Pipelined = false;
             request.ProtocolVersion = HttpVersion.Version11;


### PR DESCRIPTION
This seems to fix the following error issued when trying to upload files > ~200Kb to certain HTTP servers

> Message:
> Unable to write data to the transport connection: An existing connection was forcibly closed by the remote host.
> 
> StackTrace:
> at System.Net.Sockets.NetworkStream.Write(Byte[] buffer, Int32 offset, Int32 size)
> at System.Net.PooledStream.Write(Byte[] buffer, Int32 offset, Int32 size)
> at System.Net.ConnectStream.InternalWrite(Boolean async, Byte[] buffer, Int32 offset, Int32 size, AsyncCallback callback, Object state)
> at System.Net.ConnectStream.Write(Byte[] buffer, Int32 offset, Int32 size)
> at UploadersLib.Uploader.TransferData(Stream dataStream, Stream requestStream)
> at UploadersLib.Uploader.UploadData(Stream dataStream, String url, String fileName, String fileFormName, Dictionary`2 arguments, NameValueCollection headers, CookieCollection cookies, ResponseType responseType, HttpMethod method)
