### PR TITLE
Retrieve JIRA issue summary async to not block UI

### DIFF
--- a/UploadersLib/Forms/JiraUpload.cs
+++ b/UploadersLib/Forms/JiraUpload.cs
@@ -31,9 +31,9 @@ using UploadersLib.Properties;
 
 namespace UploadersLib.GUI
 {
-  using System.Threading.Tasks;
+    using System.Threading.Tasks;
 
-  public partial class JiraUpload : Form
+    public partial class JiraUpload : Form
     {
         public delegate string GetSummaryHandler(string issueId);
 


### PR DESCRIPTION
With this change, the UI is not blocked when you enter a new character in Jira upload form. This is useful when you have a high latency with the Jira server.
