### PR TITLE
Fixes unencoded spaces in PreviewHttpPath for the FTP uploader.

### DIFF
--- a/UploadersLib/FileUploaders/FTP/FTPAccount.cs
+++ b/UploadersLib/FileUploaders/FTP/FTPAccount.cs
@@ -231,7 +231,7 @@ namespace UploadersLib
             }
 
             httpHomeUri.Scheme = BrowserProtocol.GetDescription();
-            return httpHomeUri.Uri.ToString();
+            return Uri.EscapeUriString(httpHomeUri.Uri.ToString());
         }
 
         public string GetFtpPath(string filemame)


### PR DESCRIPTION
This is a quick fix for #364.

I noticed that you can't use paths that contain URL encoded characters like `/imgs/New%20Folder` or non-ascii characters like `/imgs/アニメ` from user input. It looks like things have been that way since before I started tinkering with this, so I'll create an Issue for it and work on it when I get a chance.
