### PR TITLE
Add a toggle for screen dimming when selecting a region.

### DIFF
--- a/ScreenCaptureLib/Forms/FreeHandRegion.cs
+++ b/ScreenCaptureLib/Forms/FreeHandRegion.cs
@@ -107,11 +107,14 @@ namespace ScreenCaptureLib
             {
                 g.SmoothingMode = SmoothingMode.HighQuality;
 
-                using (Region region = new Region(regionFillPath))
+                if (Config.UseDimming)
                 {
-                    g.Clip = region;
-                    g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
-                    g.ResetClip();
+                    using (Region region = new Region(regionFillPath))
+                    {
+                        g.Clip = region;
+                        g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
+                        g.ResetClip();
+                    }
                 }
 
                 g.DrawPath(borderPen, regionFillPath);

--- a/ScreenCaptureLib/Forms/PolygonRegion.cs
+++ b/ScreenCaptureLib/Forms/PolygonRegion.cs
@@ -124,11 +124,14 @@ namespace ScreenCaptureLib
             {
                 regionFillPath.CloseFigure();
 
-                using (Region region = new Region(regionFillPath))
+                if (Config.UseDimming)
                 {
-                    g.Clip = region;
-                    g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
-                    g.ResetClip();
+                    using (Region region = new Region(regionFillPath))
+                    {
+                        g.Clip = region;
+                        g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
+                        g.ResetClip();
+                    }
                 }
 
                 g.DrawRectangleProper(borderPen, currentArea);

--- a/ScreenCaptureLib/Forms/RectangleRegion.cs
+++ b/ScreenCaptureLib/Forms/RectangleRegion.cs
@@ -166,11 +166,14 @@ namespace ScreenCaptureLib
 
                 if (areas.Count > 0)
                 {
-                    using (Region region = new Region(regionDrawPath))
+                    if (Config.UseDimming)
                     {
-                        g.Clip = region;
-                        g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
-                        g.ResetClip();
+                        using (Region region = new Region(regionDrawPath))
+                        {
+                            g.Clip = region;
+                            g.FillRectangle(lightBackgroundBrush, ScreenRectangle0Based);
+                            g.ResetClip();
+                        }
                     }
 
                     g.DrawPath(borderPen, regionDrawPath);

--- a/ScreenCaptureLib/Forms/Surface.cs
+++ b/ScreenCaptureLib/Forms/Surface.cs
@@ -113,14 +113,21 @@ namespace ScreenCaptureLib
                 SurfaceImage = Screenshot.CaptureFullscreen();
             }
 
-            using (Image darkSurfaceImage = ColorMatrixManager.Contrast(0.9f).Apply(SurfaceImage))
+            if (Config.UseDimming)
             {
-                darkBackgroundBrush = new TextureBrush(darkSurfaceImage) { WrapMode = WrapMode.Clamp };
-            }
+                using (Image darkSurfaceImage = ColorMatrixManager.Contrast(0.9f).Apply(SurfaceImage))
+                {
+                    darkBackgroundBrush = new TextureBrush(darkSurfaceImage) { WrapMode = WrapMode.Clamp };
+                }
 
-            using (Image lightSurfaceImage = ColorMatrixManager.Contrast(1.1f).Apply(SurfaceImage))
+                using (Image lightSurfaceImage = ColorMatrixManager.Contrast(1.1f).Apply(SurfaceImage))
+                {
+                    lightBackgroundBrush = new TextureBrush(lightSurfaceImage) { WrapMode = WrapMode.Clamp };
+                }
+            }
+            else
             {
-                lightBackgroundBrush = new TextureBrush(lightSurfaceImage) { WrapMode = WrapMode.Clamp };
+                darkBackgroundBrush = new TextureBrush(SurfaceImage);
             }
         }
 

--- a/ScreenCaptureLib/SurfaceOptions.cs
+++ b/ScreenCaptureLib/SurfaceOptions.cs
@@ -49,6 +49,9 @@ namespace ScreenCaptureLib
         [DefaultValue(true), Description("Show screen wide crosshair.")]
         public bool ShowCrosshair { get; set; }
 
+        [DefaultValue(true), Description("Cropping move will dim the screen during selection. Can be intensive at high resolutions.")]
+        public bool UseDimming { get; set; }
+
         [DefaultValue(false), Description("Show frames per second.")]
         public bool ShowFPS { get; set; }
 


### PR DESCRIPTION
I am not sure about others, but I have around a 2 second delay while
attempting to capture a screen region. Coming from puush (a similar
application I had a hand in writing) which did not draw screen overlays
but instead worked with a live image, this feels very cumbersome.

By disabling this option ShareX will not longer render the two darkness
levels before displaying the capture form. I have left the default as
enabled as to not change the default user experience.

As a further suggestion, it may be feasible to do away with the
"lightBackgroundBrush" layer, instead replacing it with the original
image. This would halve the processing time and still provide the a
level of contrast.
