### PR TITLE
Implemented Strategy Pattern within HelpersLib

### DIFF
--- a/HelpersLib/Colors/Blue.cs
+++ b/HelpersLib/Colors/Blue.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Blue : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Red / 255);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Green / 255));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Blue / 255);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Red = Round(255 * (double)lastPos.X / (ClientWidth - 1));
+            selectedColor.RGBA.Green = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
+            selectedColor.RGBAUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Blue = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
+            selectedColor.RGBAUpdate();
+        }
+    }
+}

--- a/HelpersLib/Colors/Brightness.cs
+++ b/HelpersLib/Colors/Brightness.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Brightness : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Hue);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Saturation));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Brightness);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Hue = (double)lastPos.X / (ClientWidth - 1);
+            selectedColor.HSB.Saturation = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+    }
+}

--- a/HelpersLib/Colors/ColorUserControl.cs
+++ b/HelpersLib/Colors/ColorUserControl.cs
@@ -48,6 +48,14 @@ namespace HelpersLib
         protected Point lastPos;
         protected Timer mouseMoveTimer;
 
+        iDrawStyles iDS;
+        iDrawStyles iHue = new Hue();
+        iDrawStyles iSaturation = new Saturation();
+        iDrawStyles iBrightness = new Brightness();
+        iDrawStyles iRed = new Red();
+        iDrawStyles iBlue = new Blue();
+        iDrawStyles iGreen = new Green();
+
         public MyColor SelectedColor
         {
             get
@@ -80,6 +88,33 @@ namespace HelpersLib
             set
             {
                 drawStyle = value;
+                switch (drawStyle)
+                {
+                    case DrawStyle.Hue:
+                        iDS = iHue;
+                        break;
+
+                    case DrawStyle.Saturation:
+                        iDS = iSaturation;
+                        break;
+
+                    case DrawStyle.Brightness:
+                        iDS = iBrightness;
+                        break;
+
+                    case DrawStyle.Red:
+                        iDS = iRed;
+                        break;
+
+                    case DrawStyle.Blue:
+                        iDS = iBlue;
+                        break;
+
+                    case DrawStyle.Green:
+                        iDS = iGreen;
+                        break;
+                }
+
 
                 if (this is ColorBox)
                 {
@@ -106,6 +141,7 @@ namespace HelpersLib
             ClientWidth = this.ClientRectangle.Width;
             ClientHeight = this.ClientRectangle.Height;
             bmp = new Bitmap(ClientWidth, ClientHeight, PixelFormat.Format32bppArgb);
+            iDS = iHue;
             SelectedColor = Color.Red;
             DrawStyle = DrawStyle.Hue;
 
@@ -206,6 +242,8 @@ namespace HelpersLib
 
         #endregion Events
 
+
+
         #region Protected Methods
 
         protected void OnColorChanged()
@@ -243,129 +281,25 @@ namespace HelpersLib
 
         protected void SetBoxMarker()
         {
-            switch (DrawStyle)
-            {
-                case DrawStyle.Hue:
-                    lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Saturation);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Brightness));
-                    break;
-                case DrawStyle.Saturation:
-                    lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Hue);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Brightness));
-                    break;
-                case DrawStyle.Brightness:
-                    lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Hue);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Saturation));
-                    break;
-                case DrawStyle.Red:
-                    lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Blue / 255);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Green / 255));
-                    break;
-                case DrawStyle.Green:
-                    lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Blue / 255);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Red / 255));
-                    break;
-                case DrawStyle.Blue:
-                    lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Red / 255);
-                    lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Green / 255));
-                    break;
-            }
-
+            iDS.SetBoxMarker(lastPos, SelectedColor, ClientWidth, ClientHeight);
             lastPos = GetPoint(lastPos);
         }
 
         protected void GetBoxColor()
         {
-            switch (DrawStyle)
-            {
-                case DrawStyle.Hue:
-                    selectedColor.HSB.Saturation = (double)lastPos.X / (ClientWidth - 1);
-                    selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Saturation:
-                    selectedColor.HSB.Hue = (double)lastPos.X / (ClientWidth - 1);
-                    selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Brightness:
-                    selectedColor.HSB.Hue = (double)lastPos.X / (ClientWidth - 1);
-                    selectedColor.HSB.Saturation = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Red:
-                    selectedColor.RGBA.Blue = Round(255 * (double)lastPos.X / (ClientWidth - 1));
-                    selectedColor.RGBA.Green = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
-                    selectedColor.RGBAUpdate();
-                    break;
-                case DrawStyle.Green:
-                    selectedColor.RGBA.Blue = Round(255 * (double)lastPos.X / (ClientWidth - 1));
-                    selectedColor.RGBA.Red = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
-                    selectedColor.RGBAUpdate();
-                    break;
-                case DrawStyle.Blue:
-                    selectedColor.RGBA.Red = Round(255 * (double)lastPos.X / (ClientWidth - 1));
-                    selectedColor.RGBA.Green = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
-                    selectedColor.RGBAUpdate();
-                    break;
-            }
+            iDS.GetBoxColor(lastPos, selectedColor, ClientWidth, ClientHeight);
         }
 
         protected void SetSliderMarker()
         {
-            switch (DrawStyle)
-            {
-                case DrawStyle.Hue:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Hue);
-                    break;
-                case DrawStyle.Saturation:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Saturation);
-                    break;
-                case DrawStyle.Brightness:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Brightness);
-                    break;
-                case DrawStyle.Red:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Red / 255);
-                    break;
-                case DrawStyle.Green:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Green / 255);
-                    break;
-                case DrawStyle.Blue:
-                    lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Blue / 255);
-                    break;
-            }
+            iDS.SetSliderMarker(lastPos, SelectedColor, ClientHeight);
             lastPos = GetPoint(lastPos);
         }
 
         protected void GetSliderColor()
         {
-            switch (DrawStyle)
-            {
-                case DrawStyle.Hue:
-                    selectedColor.HSB.Hue = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Saturation:
-                    selectedColor.HSB.Saturation = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Brightness:
-                    selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
-                    selectedColor.HSBUpdate();
-                    break;
-                case DrawStyle.Red:
-                    selectedColor.RGBA.Red = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
-                    selectedColor.RGBAUpdate();
-                    break;
-                case DrawStyle.Green:
-                    selectedColor.RGBA.Green = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
-                    selectedColor.RGBAUpdate();
-                    break;
-                case DrawStyle.Blue:
-                    selectedColor.RGBA.Blue = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
-                    selectedColor.RGBAUpdate();
-                    break;
-            }
+            iDS.GetBoxColor(lastPos, selectedColor, ClientWidth, ClientHeight);
+
         }
 
         protected abstract void DrawCrosshair(Graphics g);

--- a/HelpersLib/Colors/Green.cs
+++ b/HelpersLib/Colors/Green.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Green : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Blue / 255);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Red / 255));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Green / 255);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Blue = Round(255 * (double)lastPos.X / (ClientWidth - 1));
+            selectedColor.RGBA.Red = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
+            selectedColor.RGBAUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Green = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
+            selectedColor.RGBAUpdate();
+        }
+    }
+}

--- a/HelpersLib/Colors/Hue.cs
+++ b/HelpersLib/Colors/Hue.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Hue : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Saturation);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Brightness));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Saturation);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Saturation = (double)lastPos.X / (ClientWidth - 1);
+            selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Hue = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+    }
+}
+
+
+

--- a/HelpersLib/Colors/Red.cs
+++ b/HelpersLib/Colors/Red.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Red : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * (double)SelectedColor.RGBA.Blue / 255);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - (double)SelectedColor.RGBA.Green / 255));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * (double)SelectedColor.RGBA.Red / 255);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Blue = Round(255 * (double)lastPos.X / (ClientWidth - 1));
+            selectedColor.RGBA.Green = Round(255 * (1.0 - (double)lastPos.Y / (ClientHeight - 1)));
+            selectedColor.RGBAUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.RGBA.Red = 255 - Round(255 * (double)lastPos.Y / (ClientHeight - 1));
+            selectedColor.RGBAUpdate();
+        }
+    }
+}

--- a/HelpersLib/Colors/Saturation.cs
+++ b/HelpersLib/Colors/Saturation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Drawing;
+
+
+namespace HelpersLib
+{
+    class Saturation : iDrawStyles
+    {
+        public override void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight)
+        {
+            lastPos.X = Round((ClientWidth - 1) * SelectedColor.HSB.Hue);
+            lastPos.Y = Round((ClientHeight - 1) * (1.0 - SelectedColor.HSB.Brightness));
+        }
+        public override void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight)
+        {
+            lastPos.Y = (ClientHeight - 1) - Round((ClientHeight - 1) * SelectedColor.HSB.Saturation);
+        }
+        public override void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Hue = (double)lastPos.X / (ClientWidth - 1);
+            selectedColor.HSB.Brightness = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+        public override void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight)
+        {
+            selectedColor.HSB.Saturation = 1.0 - (double)lastPos.Y / (ClientHeight - 1);
+            selectedColor.HSBUpdate();
+        }
+    }
+}

--- a/HelpersLib/Colors/iDrawStyles.cs
+++ b/HelpersLib/Colors/iDrawStyles.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Drawing;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HelpersLib
+{
+    public abstract class iDrawStyles
+    {
+
+         
+     public abstract void SetBoxMarker(Point lastPos, MyColor SelectedColor, int ClientWidth, int ClientHeight);
+     public abstract void SetSliderMarker(Point lastPos, MyColor SelectedColor, int ClientHeight);
+     public abstract void GetBoxColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight);
+     public abstract void GetSliderColor(Point lastPos, MyColor selectedColor, int ClientWidth, int ClientHeight);
+
+
+
+
+        protected int Round(double val)
+        {
+            int ret_val = (int)val;
+
+            int temp = (int)(val * 100);
+
+            if ((temp % 100) >= 50)
+                ret_val += 1;
+
+            return ret_val;
+        }
+    }
+}


### PR DESCRIPTION
Hello,

```
       I am requesting a pull for my refactoring of the ColorUserControl.cs in the HelpersLib. What I have provided is the Strategy design pattern, in hopes that it might be used to implement future Draw Styles. From my understanding two possible additions that would make sense would be Levels (Control over black grey white) and Curves (control all Red Green Blue together and then individually)
```

An abstract class iDrawStyles, was created. The class holds the four methods needed for each DrawStyle; SetBoxMarker(), GetBoxColor(), SetSliderMarker(), GetSliderColor().  which are implemented by six other classes used to represent the six draw styles; Hue, Saturation, Brightness, Red, Green and Blue. 

By overwriting these functions with the definitions provided in ColorUserControl and creating an instance of iDrawStyles in ColorUserControl, the four functions can have their switch statements replaced with a single call from iDrawStyle instance iDS, which has its DrawStyle set with a switch statement found in "public DrawStyle DrawStyle"

With this the code is slightly more efficient, with ColorUserControl having to use less switch statements, being more readable, and having overall better cohesion since some of its responsibilities have been delegated to iDrawStyles.

Please rest assured that everything runs as it should.  I hope you find this work helpful. 

Tanjil
