### PR TITLE
Fix issue #372

### DIFF
--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -43,6 +43,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
+using System.Web;
 
 namespace ShareX.HelpersLib
 {
@@ -215,7 +216,7 @@ namespace ShareX.HelpersLib
         public static string GetValidURL(string url, bool replaceSpace = false)
         {
             if (replaceSpace) url = url.Replace(' ', '_');
-            return new string(url.Where(c => ValidURLCharacters.Contains(c)).ToArray());
+            return HttpUtility.UrlPathEncode(url);
         }
 
         public static string GetXMLValue(string input, string tag)

--- a/ShareX.UploadersLib/FileUploaders/FTP.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP.cs
@@ -110,7 +110,7 @@ namespace ShareX.UploadersLib.FileUploaders
             UploadResult result = new UploadResult();
 
             fileName = Helpers.GetValidURL(fileName);
-            string subFolderPath = Account.GetSubFolderPath();
+            string subFolderPath = Account.GetSubFolderPath(null, NameParserType.FolderPath);
             string path = subFolderPath.CombineURL(fileName);
             bool uploadResult;
 

--- a/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
@@ -138,9 +138,9 @@ namespace ShareX.UploadersLib
             FTPSCertificateLocation = string.Empty;
         }
 
-        public string GetSubFolderPath(string filename = null)
+        public string GetSubFolderPath(string filename = null, NameParserType nameParserType = NameParserType.URL)
         {
-            string path = NameParser.Parse(NameParserType.URL, SubFolderPath.Replace("%host", Host));
+            string path = NameParser.Parse(nameParserType, SubFolderPath.Replace("%host", Host));
             return URLHelpers.CombineURL(path, filename);
         }
 
@@ -174,8 +174,6 @@ namespace ShareX.UploadersLib
             {
                 subFolderPath = GetSubFolderPath();
             }
-
-            subFolderPath = URLHelpers.URLPathEncode(subFolderPath);
 
             UriBuilder httpHomeUri;
             var httpHomePath = GetHttpHomePath();
@@ -242,7 +240,7 @@ namespace ShareX.UploadersLib
                 return string.Empty;
             }
 
-            return URLHelpers.CombineURL(FTPAddress, GetSubFolderPath(filemame));
+            return URLHelpers.CombineURL(FTPAddress, GetSubFolderPath(filemame, NameParserType.FolderPath));
         }
 
         public override string ToString()


### PR DESCRIPTION
Several changes were made to fix the encoding of ftp dirpaths and allow
uploads to folders with non-ascii characters:

- [x] Fixed encoding of valid urls in ShareX.HelpersLib.NameParser.cs
- [x] Fixed subfolder path generation and wrong url re-encoding in
FTPAccount.cs
- [x] Fixed preview paths in FTP Destination settings (FTPAccount.cs)
- [x] Fixed subfolder path generation in FTP.cs

This fixes issue #372, which was reproduced with the following account
config on a local ftp server (import from clipboard on destination
settings):

```json
{
"Protocol": "FTP",
"Name": "New account",
"Host": "localhost",
"Port": 21,
"Username": "test",
"Password": "test",
"ServerProtocol": "ftp",
"SubFolderPath": "DEV/grhh本人%",
"BrowserProtocol": "http",
"HttpHomePath": "",
"HttpHomePathAutoAddSubFolderPath": true,
"HttpHomePathNoExtension": false,
"IsActive": false,
"FTPSEncryption": "Explicit",
"FTPSCertificateLocation": "",
"Passphrase": null,
"Keypath": null
}
```