### PR TITLE
Added URL decoding to fix #249

### DIFF
--- a/ShareX/UploadManager.cs
+++ b/ShareX/UploadManager.cs
@@ -454,6 +454,22 @@ namespace ShareX
                         {
                             using (WebClient wc = new WebClient())
                             {
+                                string oldURL, oldPath;
+
+                                do
+                                {
+                                    oldURL = url;
+                                    url = HttpUtility.UrlDecode(url);
+                                }
+                                while(url != oldURL);
+
+                                do
+                                {
+                                    oldPath = downloadPath;
+                                    downloadPath = HttpUtility.UrlDecode(downloadPath);
+                                }
+                                while (downloadPath != oldPath);
+
                                 wc.Proxy = ProxyInfo.Current.GetWebProxy();
                                 wc.DownloadFile(url, downloadPath);
                             }


### PR DESCRIPTION
Added URL decoding before file upload to avoid
System.IO.PathTooLongException when using the URL uploader with an
encoded string