### PR TITLE
Fix issue #436

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
@@ -29,7 +29,6 @@ using System;
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.IO;
-using System.Web;
 
 namespace ShareX.UploadersLib
 {
@@ -169,7 +168,7 @@ namespace ShareX.UploadersLib
                 filename = Path.GetFileNameWithoutExtension(filename);
             }
 
-            filename = HttpUtility.UrlEncode(filename);
+            filename = URLHelpers.URLEncode(filename);
 
             if (subFolderPath == null)
             {

--- a/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
@@ -29,6 +29,7 @@ using System;
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.IO;
+using System.Web;
 
 namespace ShareX.UploadersLib
 {
@@ -168,7 +169,7 @@ namespace ShareX.UploadersLib
                 filename = Path.GetFileNameWithoutExtension(filename);
             }
 
-            filename = URLHelpers.URLEncode(filename);
+            filename = HttpUtility.UrlEncode(filename);
 
             if (subFolderPath == null)
             {
@@ -176,6 +177,7 @@ namespace ShareX.UploadersLib
             }
 
             UriBuilder httpHomeUri;
+
             var httpHomePath = GetHttpHomePath();
 
             if (string.IsNullOrEmpty(httpHomePath))
@@ -230,7 +232,7 @@ namespace ShareX.UploadersLib
             }
 
             httpHomeUri.Scheme = BrowserProtocol.GetDescription();
-            return Uri.EscapeUriString(httpHomeUri.Uri.ToString());
+            return httpHomeUri.Uri.ToString();
         }
 
         public string GetFtpPath(string filemame)

--- a/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP/FTPAccount.cs
@@ -231,7 +231,7 @@ namespace ShareX.UploadersLib
             }
 
             httpHomeUri.Scheme = BrowserProtocol.GetDescription();
-            return httpHomeUri.Uri.ToString();
+            return httpHomeUri.Uri.AbsoluteUri;
         }
 
         public string GetFtpPath(string filemame)


### PR DESCRIPTION
Fix issue #436 

This return statement was double encoding filename hence the extra encoding on the "%" sign in the URL in clipboard.

return Uri.EscapeUriString(httpHomeUri.Uri.ToString());
