### PR TITLE
Potential fix for #404

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
+++ b/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
@@ -221,7 +221,7 @@ namespace ShareX.UploadersLib.FileUploaders
         {
             if (!CheckAuthorization()) return null;
 
-            UploadResult result = UploadData(stream, "https://www.googleapis.com/upload/drive/v2/files", fileName, headers: GetAuthHeaders());
+            UploadResult result = UploadData(stream, "https://www.googleapis.com/upload/drive/v2/files?uploadType=media", fileName, headers: GetAuthHeaders());
 
             if (!string.IsNullOrEmpty(result.Response))
             {


### PR DESCRIPTION
The addition of the "uploadType=media" has solved the issue of the error
400 when uploading to Google Drive. This however means that it is not a
multipart upload. My research has lead me to believe that the issue
behind it is that there is no metadata being sent with the request.

My suggestion would be to add the metadata as a new part, and as well
change the query parameter to "uploadType=multipart".