### PR TITLE
Fixed #532: Filename text length will now check/uncheck 'Filename filter...

### DIFF
--- a/ShareX.HistoryLib/HistoryForm.Designer.cs
+++ b/ShareX.HistoryLib/HistoryForm.Designer.cs
@@ -29,246 +29,248 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HistoryForm));
-            this.dtpFilterFrom = new System.Windows.Forms.DateTimePicker();
-            this.cbDateFilter = new System.Windows.Forms.CheckBox();
-            this.lblFilterFrom = new System.Windows.Forms.Label();
-            this.lblFilterTo = new System.Windows.Forms.Label();
-            this.dtpFilterTo = new System.Windows.Forms.DateTimePicker();
-            this.btnApplyFilters = new System.Windows.Forms.Button();
-            this.txtFilenameFilter = new System.Windows.Forms.TextBox();
-            this.cbFilenameFilterMethod = new System.Windows.Forms.ComboBox();
-            this.cbFilenameFilterCulture = new System.Windows.Forms.ComboBox();
-            this.cbFilenameFilter = new System.Windows.Forms.CheckBox();
-            this.cbFilenameFilterCase = new System.Windows.Forms.CheckBox();
-            this.ssMain = new System.Windows.Forms.StatusStrip();
-            this.tsslStatus = new System.Windows.Forms.ToolStripStatusLabel();
-            this.gbFilters = new System.Windows.Forms.GroupBox();
-            this.btnRemoveFilters = new System.Windows.Forms.Button();
-            this.txtHostFilter = new System.Windows.Forms.TextBox();
-            this.cbTypeFilterSelection = new System.Windows.Forms.ComboBox();
-            this.cbHostFilter = new System.Windows.Forms.CheckBox();
-            this.cbTypeFilter = new System.Windows.Forms.CheckBox();
-            this.lvHistory = new ShareX.HelpersLib.MyListView();
-            this.chDateTime = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chFilename = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chHost = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chURL = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.pbThumbnail = new ShareX.HelpersLib.MyPictureBox();
-            this.ssMain.SuspendLayout();
-            this.gbFilters.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // dtpFilterFrom
-            // 
-            resources.ApplyResources(this.dtpFilterFrom, "dtpFilterFrom");
-            this.dtpFilterFrom.Name = "dtpFilterFrom";
-            // 
-            // cbDateFilter
-            // 
-            resources.ApplyResources(this.cbDateFilter, "cbDateFilter");
-            this.cbDateFilter.Name = "cbDateFilter";
-            this.cbDateFilter.UseVisualStyleBackColor = true;
-            // 
-            // lblFilterFrom
-            // 
-            resources.ApplyResources(this.lblFilterFrom, "lblFilterFrom");
-            this.lblFilterFrom.Name = "lblFilterFrom";
-            // 
-            // lblFilterTo
-            // 
-            resources.ApplyResources(this.lblFilterTo, "lblFilterTo");
-            this.lblFilterTo.Name = "lblFilterTo";
-            // 
-            // dtpFilterTo
-            // 
-            resources.ApplyResources(this.dtpFilterTo, "dtpFilterTo");
-            this.dtpFilterTo.Name = "dtpFilterTo";
-            // 
-            // btnApplyFilters
-            // 
-            resources.ApplyResources(this.btnApplyFilters, "btnApplyFilters");
-            this.btnApplyFilters.Name = "btnApplyFilters";
-            this.btnApplyFilters.UseVisualStyleBackColor = true;
-            this.btnApplyFilters.Click += new System.EventHandler(this.btnApplyFilters_Click);
-            // 
-            // txtFilenameFilter
-            // 
-            resources.ApplyResources(this.txtFilenameFilter, "txtFilenameFilter");
-            this.txtFilenameFilter.Name = "txtFilenameFilter";
-            // 
-            // cbFilenameFilterMethod
-            // 
-            this.cbFilenameFilterMethod.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbFilenameFilterMethod.FormattingEnabled = true;
-            this.cbFilenameFilterMethod.Items.AddRange(new object[] {
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HistoryForm));
+			this.dtpFilterFrom = new System.Windows.Forms.DateTimePicker();
+			this.cbDateFilter = new System.Windows.Forms.CheckBox();
+			this.lblFilterFrom = new System.Windows.Forms.Label();
+			this.lblFilterTo = new System.Windows.Forms.Label();
+			this.dtpFilterTo = new System.Windows.Forms.DateTimePicker();
+			this.btnApplyFilters = new System.Windows.Forms.Button();
+			this.txtFilenameFilter = new System.Windows.Forms.TextBox();
+			this.cbFilenameFilterMethod = new System.Windows.Forms.ComboBox();
+			this.cbFilenameFilterCulture = new System.Windows.Forms.ComboBox();
+			this.cbFilenameFilter = new System.Windows.Forms.CheckBox();
+			this.cbFilenameFilterCase = new System.Windows.Forms.CheckBox();
+			this.ssMain = new System.Windows.Forms.StatusStrip();
+			this.tsslStatus = new System.Windows.Forms.ToolStripStatusLabel();
+			this.gbFilters = new System.Windows.Forms.GroupBox();
+			this.btnRemoveFilters = new System.Windows.Forms.Button();
+			this.txtHostFilter = new System.Windows.Forms.TextBox();
+			this.cbTypeFilterSelection = new System.Windows.Forms.ComboBox();
+			this.cbHostFilter = new System.Windows.Forms.CheckBox();
+			this.cbTypeFilter = new System.Windows.Forms.CheckBox();
+			this.lvHistory = new ShareX.HelpersLib.MyListView();
+			this.chDateTime = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.chFilename = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.chType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.chHost = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.chURL = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+			this.pbThumbnail = new ShareX.HelpersLib.MyPictureBox();
+			this.ssMain.SuspendLayout();
+			this.gbFilters.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// dtpFilterFrom
+			// 
+			resources.ApplyResources(this.dtpFilterFrom, "dtpFilterFrom");
+			this.dtpFilterFrom.Name = "dtpFilterFrom";
+			// 
+			// cbDateFilter
+			// 
+			resources.ApplyResources(this.cbDateFilter, "cbDateFilter");
+			this.cbDateFilter.Name = "cbDateFilter";
+			this.cbDateFilter.UseVisualStyleBackColor = true;
+			// 
+			// lblFilterFrom
+			// 
+			resources.ApplyResources(this.lblFilterFrom, "lblFilterFrom");
+			this.lblFilterFrom.Name = "lblFilterFrom";
+			// 
+			// lblFilterTo
+			// 
+			resources.ApplyResources(this.lblFilterTo, "lblFilterTo");
+			this.lblFilterTo.Name = "lblFilterTo";
+			// 
+			// dtpFilterTo
+			// 
+			resources.ApplyResources(this.dtpFilterTo, "dtpFilterTo");
+			this.dtpFilterTo.Name = "dtpFilterTo";
+			// 
+			// btnApplyFilters
+			// 
+			resources.ApplyResources(this.btnApplyFilters, "btnApplyFilters");
+			this.btnApplyFilters.Name = "btnApplyFilters";
+			this.btnApplyFilters.UseVisualStyleBackColor = true;
+			this.btnApplyFilters.Click += new System.EventHandler(this.btnApplyFilters_Click);
+			// 
+			// txtFilenameFilter
+			// 
+			resources.ApplyResources(this.txtFilenameFilter, "txtFilenameFilter");
+			this.txtFilenameFilter.Name = "txtFilenameFilter";
+			this.txtFilenameFilter.TextChanged += new System.EventHandler(this.txtFilenameFilter_TextChanged);
+			// 
+			// cbFilenameFilterMethod
+			// 
+			this.cbFilenameFilterMethod.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cbFilenameFilterMethod.FormattingEnabled = true;
+			this.cbFilenameFilterMethod.Items.AddRange(new object[] {
             resources.GetString("cbFilenameFilterMethod.Items"),
             resources.GetString("cbFilenameFilterMethod.Items1"),
             resources.GetString("cbFilenameFilterMethod.Items2"),
             resources.GetString("cbFilenameFilterMethod.Items3")});
-            resources.ApplyResources(this.cbFilenameFilterMethod, "cbFilenameFilterMethod");
-            this.cbFilenameFilterMethod.Name = "cbFilenameFilterMethod";
-            // 
-            // cbFilenameFilterCulture
-            // 
-            this.cbFilenameFilterCulture.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbFilenameFilterCulture.FormattingEnabled = true;
-            this.cbFilenameFilterCulture.Items.AddRange(new object[] {
+			resources.ApplyResources(this.cbFilenameFilterMethod, "cbFilenameFilterMethod");
+			this.cbFilenameFilterMethod.Name = "cbFilenameFilterMethod";
+			// 
+			// cbFilenameFilterCulture
+			// 
+			this.cbFilenameFilterCulture.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cbFilenameFilterCulture.FormattingEnabled = true;
+			this.cbFilenameFilterCulture.Items.AddRange(new object[] {
             resources.GetString("cbFilenameFilterCulture.Items"),
             resources.GetString("cbFilenameFilterCulture.Items1"),
             resources.GetString("cbFilenameFilterCulture.Items2")});
-            resources.ApplyResources(this.cbFilenameFilterCulture, "cbFilenameFilterCulture");
-            this.cbFilenameFilterCulture.Name = "cbFilenameFilterCulture";
-            // 
-            // cbFilenameFilter
-            // 
-            resources.ApplyResources(this.cbFilenameFilter, "cbFilenameFilter");
-            this.cbFilenameFilter.Name = "cbFilenameFilter";
-            this.cbFilenameFilter.UseVisualStyleBackColor = true;
-            // 
-            // cbFilenameFilterCase
-            // 
-            resources.ApplyResources(this.cbFilenameFilterCase, "cbFilenameFilterCase");
-            this.cbFilenameFilterCase.Name = "cbFilenameFilterCase";
-            this.cbFilenameFilterCase.UseVisualStyleBackColor = true;
-            // 
-            // ssMain
-            // 
-            this.ssMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			resources.ApplyResources(this.cbFilenameFilterCulture, "cbFilenameFilterCulture");
+			this.cbFilenameFilterCulture.Name = "cbFilenameFilterCulture";
+			// 
+			// cbFilenameFilter
+			// 
+			resources.ApplyResources(this.cbFilenameFilter, "cbFilenameFilter");
+			this.cbFilenameFilter.Name = "cbFilenameFilter";
+			this.cbFilenameFilter.UseVisualStyleBackColor = true;
+			// 
+			// cbFilenameFilterCase
+			// 
+			resources.ApplyResources(this.cbFilenameFilterCase, "cbFilenameFilterCase");
+			this.cbFilenameFilterCase.Name = "cbFilenameFilterCase";
+			this.cbFilenameFilterCase.UseVisualStyleBackColor = true;
+			// 
+			// ssMain
+			// 
+			this.ssMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsslStatus});
-            resources.ApplyResources(this.ssMain, "ssMain");
-            this.ssMain.Name = "ssMain";
-            // 
-            // tsslStatus
-            // 
-            this.tsslStatus.Name = "tsslStatus";
-            resources.ApplyResources(this.tsslStatus, "tsslStatus");
-            // 
-            // gbFilters
-            // 
-            this.gbFilters.Controls.Add(this.btnRemoveFilters);
-            this.gbFilters.Controls.Add(this.btnApplyFilters);
-            this.gbFilters.Controls.Add(this.txtHostFilter);
-            this.gbFilters.Controls.Add(this.cbTypeFilterSelection);
-            this.gbFilters.Controls.Add(this.cbHostFilter);
-            this.gbFilters.Controls.Add(this.cbTypeFilter);
-            this.gbFilters.Controls.Add(this.dtpFilterFrom);
-            this.gbFilters.Controls.Add(this.lblFilterFrom);
-            this.gbFilters.Controls.Add(this.cbFilenameFilter);
-            this.gbFilters.Controls.Add(this.lblFilterTo);
-            this.gbFilters.Controls.Add(this.cbFilenameFilterCase);
-            this.gbFilters.Controls.Add(this.cbDateFilter);
-            this.gbFilters.Controls.Add(this.dtpFilterTo);
-            this.gbFilters.Controls.Add(this.cbFilenameFilterCulture);
-            this.gbFilters.Controls.Add(this.txtFilenameFilter);
-            this.gbFilters.Controls.Add(this.cbFilenameFilterMethod);
-            resources.ApplyResources(this.gbFilters, "gbFilters");
-            this.gbFilters.Name = "gbFilters";
-            this.gbFilters.TabStop = false;
-            // 
-            // btnRemoveFilters
-            // 
-            resources.ApplyResources(this.btnRemoveFilters, "btnRemoveFilters");
-            this.btnRemoveFilters.Name = "btnRemoveFilters";
-            this.btnRemoveFilters.UseVisualStyleBackColor = true;
-            this.btnRemoveFilters.Click += new System.EventHandler(this.btnRemoveFilters_Click);
-            // 
-            // txtHostFilter
-            // 
-            resources.ApplyResources(this.txtHostFilter, "txtHostFilter");
-            this.txtHostFilter.Name = "txtHostFilter";
-            // 
-            // cbTypeFilterSelection
-            // 
-            this.cbTypeFilterSelection.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbTypeFilterSelection.FormattingEnabled = true;
-            this.cbTypeFilterSelection.Items.AddRange(new object[] {
+			resources.ApplyResources(this.ssMain, "ssMain");
+			this.ssMain.Name = "ssMain";
+			// 
+			// tsslStatus
+			// 
+			this.tsslStatus.Name = "tsslStatus";
+			resources.ApplyResources(this.tsslStatus, "tsslStatus");
+			// 
+			// gbFilters
+			// 
+			this.gbFilters.Controls.Add(this.btnRemoveFilters);
+			this.gbFilters.Controls.Add(this.btnApplyFilters);
+			this.gbFilters.Controls.Add(this.txtHostFilter);
+			this.gbFilters.Controls.Add(this.cbTypeFilterSelection);
+			this.gbFilters.Controls.Add(this.cbHostFilter);
+			this.gbFilters.Controls.Add(this.cbTypeFilter);
+			this.gbFilters.Controls.Add(this.dtpFilterFrom);
+			this.gbFilters.Controls.Add(this.lblFilterFrom);
+			this.gbFilters.Controls.Add(this.cbFilenameFilter);
+			this.gbFilters.Controls.Add(this.lblFilterTo);
+			this.gbFilters.Controls.Add(this.cbFilenameFilterCase);
+			this.gbFilters.Controls.Add(this.cbDateFilter);
+			this.gbFilters.Controls.Add(this.dtpFilterTo);
+			this.gbFilters.Controls.Add(this.cbFilenameFilterCulture);
+			this.gbFilters.Controls.Add(this.txtFilenameFilter);
+			this.gbFilters.Controls.Add(this.cbFilenameFilterMethod);
+			resources.ApplyResources(this.gbFilters, "gbFilters");
+			this.gbFilters.Name = "gbFilters";
+			this.gbFilters.TabStop = false;
+			// 
+			// btnRemoveFilters
+			// 
+			resources.ApplyResources(this.btnRemoveFilters, "btnRemoveFilters");
+			this.btnRemoveFilters.Name = "btnRemoveFilters";
+			this.btnRemoveFilters.UseVisualStyleBackColor = true;
+			this.btnRemoveFilters.Click += new System.EventHandler(this.btnRemoveFilters_Click);
+			// 
+			// txtHostFilter
+			// 
+			resources.ApplyResources(this.txtHostFilter, "txtHostFilter");
+			this.txtHostFilter.Name = "txtHostFilter";
+			// 
+			// cbTypeFilterSelection
+			// 
+			this.cbTypeFilterSelection.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.cbTypeFilterSelection.FormattingEnabled = true;
+			this.cbTypeFilterSelection.Items.AddRange(new object[] {
             resources.GetString("cbTypeFilterSelection.Items"),
             resources.GetString("cbTypeFilterSelection.Items1"),
             resources.GetString("cbTypeFilterSelection.Items2")});
-            resources.ApplyResources(this.cbTypeFilterSelection, "cbTypeFilterSelection");
-            this.cbTypeFilterSelection.Name = "cbTypeFilterSelection";
-            // 
-            // cbHostFilter
-            // 
-            resources.ApplyResources(this.cbHostFilter, "cbHostFilter");
-            this.cbHostFilter.Name = "cbHostFilter";
-            this.cbHostFilter.UseVisualStyleBackColor = true;
-            // 
-            // cbTypeFilter
-            // 
-            resources.ApplyResources(this.cbTypeFilter, "cbTypeFilter");
-            this.cbTypeFilter.Name = "cbTypeFilter";
-            this.cbTypeFilter.UseVisualStyleBackColor = true;
-            // 
-            // lvHistory
-            // 
-            this.lvHistory.AllowColumnSort = true;
-            resources.ApplyResources(this.lvHistory, "lvHistory");
-            this.lvHistory.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+			resources.ApplyResources(this.cbTypeFilterSelection, "cbTypeFilterSelection");
+			this.cbTypeFilterSelection.Name = "cbTypeFilterSelection";
+			// 
+			// cbHostFilter
+			// 
+			resources.ApplyResources(this.cbHostFilter, "cbHostFilter");
+			this.cbHostFilter.Name = "cbHostFilter";
+			this.cbHostFilter.UseVisualStyleBackColor = true;
+			// 
+			// cbTypeFilter
+			// 
+			resources.ApplyResources(this.cbTypeFilter, "cbTypeFilter");
+			this.cbTypeFilter.Name = "cbTypeFilter";
+			this.cbTypeFilter.UseVisualStyleBackColor = true;
+			// 
+			// lvHistory
+			// 
+			this.lvHistory.AllowColumnSort = true;
+			resources.ApplyResources(this.lvHistory, "lvHistory");
+			this.lvHistory.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.chDateTime,
             this.chFilename,
             this.chType,
             this.chHost,
             this.chURL});
-            this.lvHistory.FullRowSelect = true;
-            this.lvHistory.HideSelection = false;
-            this.lvHistory.Name = "lvHistory";
-            this.lvHistory.UseCompatibleStateImageBehavior = false;
-            this.lvHistory.View = System.Windows.Forms.View.Details;
-            this.lvHistory.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.lvHistory_ItemSelectionChanged);
-            this.lvHistory.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvHistory_KeyDown);
-            this.lvHistory.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvHistory_MouseDoubleClick);
-            this.lvHistory.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lvHistory_MouseUp);
-            // 
-            // chDateTime
-            // 
-            resources.ApplyResources(this.chDateTime, "chDateTime");
-            // 
-            // chFilename
-            // 
-            resources.ApplyResources(this.chFilename, "chFilename");
-            // 
-            // chType
-            // 
-            resources.ApplyResources(this.chType, "chType");
-            // 
-            // chHost
-            // 
-            resources.ApplyResources(this.chHost, "chHost");
-            // 
-            // chURL
-            // 
-            resources.ApplyResources(this.chURL, "chURL");
-            // 
-            // pbThumbnail
-            // 
-            resources.ApplyResources(this.pbThumbnail, "pbThumbnail");
-            this.pbThumbnail.BackColor = System.Drawing.Color.White;
-            this.pbThumbnail.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pbThumbnail.DrawCheckeredBackground = true;
-            this.pbThumbnail.FullscreenOnClick = true;
-            this.pbThumbnail.Name = "pbThumbnail";
-            // 
-            // HistoryForm
-            // 
-            resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.lvHistory);
-            this.Controls.Add(this.pbThumbnail);
-            this.Controls.Add(this.gbFilters);
-            this.Controls.Add(this.ssMain);
-            this.KeyPreview = true;
-            this.Name = "HistoryForm";
-            this.Shown += new System.EventHandler(this.HistoryForm_Shown);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HistoryForm_KeyDown);
-            this.ssMain.ResumeLayout(false);
-            this.ssMain.PerformLayout();
-            this.gbFilters.ResumeLayout(false);
-            this.gbFilters.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.lvHistory.FullRowSelect = true;
+			this.lvHistory.HideSelection = false;
+			this.lvHistory.Name = "lvHistory";
+			this.lvHistory.UseCompatibleStateImageBehavior = false;
+			this.lvHistory.View = System.Windows.Forms.View.Details;
+			this.lvHistory.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.lvHistory_ItemSelectionChanged);
+			this.lvHistory.KeyDown += new System.Windows.Forms.KeyEventHandler(this.lvHistory_KeyDown);
+			this.lvHistory.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvHistory_MouseDoubleClick);
+			this.lvHistory.MouseUp += new System.Windows.Forms.MouseEventHandler(this.lvHistory_MouseUp);
+			// 
+			// chDateTime
+			// 
+			resources.ApplyResources(this.chDateTime, "chDateTime");
+			// 
+			// chFilename
+			// 
+			resources.ApplyResources(this.chFilename, "chFilename");
+			// 
+			// chType
+			// 
+			resources.ApplyResources(this.chType, "chType");
+			// 
+			// chHost
+			// 
+			resources.ApplyResources(this.chHost, "chHost");
+			// 
+			// chURL
+			// 
+			resources.ApplyResources(this.chURL, "chURL");
+			// 
+			// pbThumbnail
+			// 
+			resources.ApplyResources(this.pbThumbnail, "pbThumbnail");
+			this.pbThumbnail.BackColor = System.Drawing.Color.White;
+			this.pbThumbnail.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+			this.pbThumbnail.DrawCheckeredBackground = true;
+			this.pbThumbnail.FullscreenOnClick = true;
+			this.pbThumbnail.Name = "pbThumbnail";
+			// 
+			// HistoryForm
+			// 
+			this.AcceptButton = this.btnApplyFilters;
+			resources.ApplyResources(this, "$this");
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this.lvHistory);
+			this.Controls.Add(this.pbThumbnail);
+			this.Controls.Add(this.gbFilters);
+			this.Controls.Add(this.ssMain);
+			this.KeyPreview = true;
+			this.Name = "HistoryForm";
+			this.Shown += new System.EventHandler(this.HistoryForm_Shown);
+			this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HistoryForm_KeyDown);
+			this.ssMain.ResumeLayout(false);
+			this.ssMain.PerformLayout();
+			this.gbFilters.ResumeLayout(false);
+			this.gbFilters.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 

--- a/ShareX.HistoryLib/HistoryForm.cs
+++ b/ShareX.HistoryLib/HistoryForm.cs
@@ -330,6 +330,11 @@ namespace ShareX.HistoryLib
             e.Handled = true;
         }
 
+		private void txtFilenameFilter_TextChanged(object sender, EventArgs e)
+		{
+			cbFilenameFilter.Checked = txtFilenameFilter.TextLength > 0;
+		}
+
         #endregion Form events
     }
 }

--- a/ShareX.HistoryLib/HistoryForm.resx
+++ b/ShareX.HistoryLib/HistoryForm.resx
@@ -407,12 +407,6 @@
   <metadata name="ssMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="tsslStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 17</value>
-  </data>
-  <data name="tsslStatus.Text" xml:space="preserve">
-    <value>Status</value>
-  </data>
   <data name="ssMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 665</value>
   </data>
@@ -433,6 +427,96 @@
   </data>
   <data name="&gt;&gt;ssMain.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="tsslStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 17</value>
+  </data>
+  <data name="tsslStatus.Text" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFilters.Name" xml:space="preserve">
+    <value>btnRemoveFilters</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFilters.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFilters.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtHostFilter.Name" xml:space="preserve">
+    <value>txtHostFilter</value>
+  </data>
+  <data name="&gt;&gt;txtHostFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHostFilter.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;txtHostFilter.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilterSelection.Name" xml:space="preserve">
+    <value>cbTypeFilterSelection</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilterSelection.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilterSelection.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilterSelection.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbHostFilter.Name" xml:space="preserve">
+    <value>cbHostFilter</value>
+  </data>
+  <data name="&gt;&gt;cbHostFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbHostFilter.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;cbHostFilter.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilter.Name" xml:space="preserve">
+    <value>cbTypeFilter</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilter.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;cbTypeFilter.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="gbFilters.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="gbFilters.Size" type="System.Drawing.Size, System.Drawing">
+    <value>312, 272</value>
+  </data>
+  <data name="gbFilters.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="gbFilters.Text" xml:space="preserve">
+    <value>Filters</value>
+  </data>
+  <data name="&gt;&gt;gbFilters.Name" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;gbFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFilters.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;gbFilters.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="btnRemoveFilters.Location" type="System.Drawing.Point, System.Drawing">
     <value>160, 232</value>
@@ -563,33 +647,30 @@
   <data name="&gt;&gt;cbTypeFilter.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="gbFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="gbFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>312, 272</value>
-  </data>
-  <data name="gbFilters.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="gbFilters.Text" xml:space="preserve">
-    <value>Filters</value>
-  </data>
-  <data name="&gt;&gt;gbFilters.Name" xml:space="preserve">
-    <value>gbFilters</value>
-  </data>
-  <data name="&gt;&gt;gbFilters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFilters.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;gbFilters.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lvHistory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="lvHistory.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 288</value>
+  </data>
+  <data name="lvHistory.Size" type="System.Drawing.Size, System.Drawing">
+    <value>904, 368</value>
+  </data>
+  <data name="lvHistory.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lvHistory.Name" xml:space="preserve">
+    <value>lvHistory</value>
+  </data>
+  <data name="&gt;&gt;lvHistory.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvHistory.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lvHistory.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="chDateTime.Text" xml:space="preserve">
     <value>Date &amp; time</value>
@@ -617,30 +698,9 @@
   </data>
   <data name="chURL.Text" xml:space="preserve">
     <value>URL</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="chURL.Width" type="System.Int32, mscorlib">
     <value>330</value>
-  </data>
-  <data name="lvHistory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 288</value>
-  </data>
-  <data name="lvHistory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>904, 368</value>
-  </data>
-  <data name="lvHistory.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lvHistory.Name" xml:space="preserve">
-    <value>lvHistory</value>
-  </data>
-  <data name="&gt;&gt;lvHistory.Type" xml:space="preserve">
-    <value>HelpersLib.MyListView, HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvHistory.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lvHistory.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="pbThumbnail.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -658,7 +718,7 @@
     <value>pbThumbnail</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.Type" xml:space="preserve">
-    <value>HelpersLib.MyPictureBox, HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.MyPictureBox, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.Parent" xml:space="preserve">
     <value>$this</value>


### PR DESCRIPTION
...' checkbox. 'Apply filters' button now default accept button.

Not sure why GitHub is showing it as wanting to change hundreds of lines in the Designer and resx files, when it's actually just a few lines here and there. Perhaps it's that I've got Visual Studio set to use tabs instead of spaces?