### PR TITLE
#404 - Use multipart/related for GDriveSDK uploads

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
+++ b/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
@@ -135,7 +135,7 @@ namespace ShareX.UploadersLib.FileUploaders
             return headers;
         }
 
-        private string GetMetadata(string title, string parentID = null)
+        private string GetMetadata(string title, string parentID)
         {
             object metadata;
 
@@ -219,7 +219,7 @@ namespace ShareX.UploadersLib.FileUploaders
         {
             if (!CheckAuthorization()) return null;
 
-            string metadata = GetMetadata(fileName);
+            string metadata = GetMetadata(fileName, FolderID);
 
             UploadResult result = UploadData(stream, "https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart", fileName, headers: GetAuthHeaders(), requestContentType: "multipart/related", metadata: metadata);
 

--- a/ShareX.UploadersLib/Uploader.cs
+++ b/ShareX.UploadersLib/Uploader.cs
@@ -302,28 +302,41 @@ namespace ShareX.UploadersLib
         }
 
         protected UploadResult UploadData(Stream dataStream, string url, string fileName, string fileFormName = "file", Dictionary<string, string> arguments = null,
-            NameValueCollection headers = null, CookieCollection cookies = null, ResponseType responseType = ResponseType.Text, HttpMethod method = HttpMethod.POST)
+            NameValueCollection headers = null, CookieCollection cookies = null, ResponseType responseType = ResponseType.Text, HttpMethod method = HttpMethod.POST,
+            string requestContentType = "multipart/form-data", string metadata = null)
         {
             UploadResult result = new UploadResult();
 
             IsUploading = true;
             StopUploadRequested = false;
-
             try
             {
                 string boundary = CreateBoundary();
 
                 byte[] bytesArguments = MakeInputContent(boundary, arguments, false);
-                byte[] bytesDataOpen = MakeFileInputContentOpen(boundary, fileFormName, fileName);
+                byte[] bytesDataOpen = { };
+                byte[] bytesDataDatafile = { };
+
+                if (metadata != null)
+                {
+                    bytesDataOpen = MakeFileInputContentOpen(boundary, fileFormName, fileName, metadata);
+                    bytesDataDatafile = MakeFileInputContentOpen(boundary, fileFormName, fileName, null);
+                }
+                else
+                {
+                    bytesDataOpen = MakeFileInputContentOpen(boundary, fileFormName, fileName);
+                }
+
                 byte[] bytesDataClose = MakeFileInputContentClose(boundary);
 
-                long contentLength = bytesArguments.Length + bytesDataOpen.Length + dataStream.Length + bytesDataClose.Length;
-                HttpWebRequest request = PrepareDataWebRequest(url, boundary, contentLength, "multipart/form-data", cookies, headers, method);
+                long contentLength = bytesArguments.Length + bytesDataOpen.Length + bytesDataDatafile.Length + dataStream.Length + bytesDataClose.Length;
+                HttpWebRequest request = PrepareDataWebRequest(url, boundary, contentLength, requestContentType, cookies, headers, method);
 
                 using (Stream requestStream = request.GetRequestStream())
                 {
                     requestStream.Write(bytesArguments, 0, bytesArguments.Length);
                     requestStream.Write(bytesDataOpen, 0, bytesDataOpen.Length);
+                    requestStream.Write(bytesDataDatafile, 0, bytesDataDatafile.Length);
                     if (!TransferData(dataStream, requestStream)) return null;
                     requestStream.Write(bytesDataClose, 0, bytesDataClose.Length);
                 }
@@ -468,6 +481,22 @@ namespace ShareX.UploadersLib
         {
             string format = string.Format("--{0}\r\nContent-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"\r\nContent-Type: {3}\r\n\r\n",
                 boundary, fileFormName, fileName, Helpers.GetMimeType(fileName));
+            return Encoding.UTF8.GetBytes(format);
+        }
+
+        private byte[] MakeFileInputContentOpen(string boundary, string fileFormName, string fileName, string metadata)
+        {
+            string format = "";
+
+            if (metadata != null)
+            {
+                format = string.Format("--{0}\r\nContent-Type: {1}; charset=UTF-8\r\n\r\n{2}\r\n\r\n", boundary, "application/json", metadata);
+            }
+            else
+            {
+                format = string.Format("--{0}\r\nContent-Type: {1}\r\n\r\n", boundary, Helpers.GetMimeType(fileName));
+            }
+
             return Encoding.UTF8.GetBytes(format);
         }
 


### PR DESCRIPTION
Updates GoogleDrive & Uploader to include the metadata in a multipart/related when sending to Google Drive. May also fix some cases where files uploaded to gdrive were broken.