### PR TITLE
Made Amazon S3 uploader more robust, additional error handling. Moved classes to their own files.

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AmazonS3Region.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3Region.cs
@@ -1,0 +1,32 @@
+﻿using Amazon;
+
+namespace ShareX.UploadersLib.FileUploaders
+{
+    public class AmazonS3Region
+    {
+        public AmazonS3Region(string name)
+        {
+            Name = name;
+        }
+
+        public AmazonS3Region(string name, string identifier, string hostname)
+        {
+            Name = name;
+            Identifier = identifier;
+            Hostname = hostname;
+        }
+
+        public AmazonS3Region(RegionEndpoint region)
+        {
+            Name = region.DisplayName;
+            Identifier = region.SystemName;
+            AmazonRegion = region;
+            Hostname = region.GetEndpointForService("s3").Hostname;
+        }
+
+        public string Name { get; private set; }
+        public string Identifier { get; private set; }
+        public RegionEndpoint AmazonRegion { get; private set; }
+        public string Hostname { get; private set; }
+    }
+}

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3Settings.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3Settings.cs
@@ -1,0 +1,14 @@
+﻿namespace ShareX.UploadersLib.FileUploaders
+{
+    public class AmazonS3Settings
+    {
+        public string AccessKeyID { get; set; }
+        public string SecretAccessKey { get; set; }
+        public string Endpoint { get; set; }
+        public string Bucket { get; set; }
+        public string ObjectPrefix { get; set; }
+        public bool UseCustomCNAME { get; set; }
+        public string CustomDomain { get; set; }
+        public bool UseReducedRedundancyStorage { get; set; }
+    }
+}

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -103,6 +103,8 @@
   <ItemGroup>
     <Compile Include="APIKeys\APIKeys.cs" />
     <Compile Include="APIKeys\APIKeysLocal.cs" />
+    <Compile Include="FileUploaders\AmazonS3Region.cs" />
+    <Compile Include="FileUploaders\AmazonS3Settings.cs" />
     <Compile Include="FileUploaders\Box.cs" />
     <Compile Include="FileUploaders\Lambda.cs" />
     <Compile Include="FileUploaders\Copy.cs" />

--- a/ShareX.UploadersLib/Uploader.cs
+++ b/ShareX.UploadersLib/Uploader.cs
@@ -258,7 +258,12 @@ namespace ShareX.UploadersLib
         {
             using (HttpWebResponse response = GetResponse(url, stream, null, contentType, headers, cookies, method))
             {
-                return response.Headers;
+                if (response != null)
+                {
+                    return response.Headers;
+                }
+
+                return new NameValueCollection();
             }
         }
 


### PR DESCRIPTION
There is no functional change here, it's just clearer why an upload fails now. Uses the `Errors` collection of `UploadResult` instead of throwing exceptions.