### PR TITLE
Do not url-encode file names for (S)FTP upload.

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/FTP.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP.cs
@@ -109,7 +109,6 @@ namespace ShareX.UploadersLib.FileUploaders
         {
             UploadResult result = new UploadResult();
 
-            fileName = Helpers.GetValidURL(fileName);
             string subFolderPath = Account.GetSubFolderPath(null, NameParserType.FolderPath);
             string path = subFolderPath.CombineURL(fileName);
             bool uploadResult;

--- a/ShareX.UploadersLib/FileUploaders/SFTP.cs
+++ b/ShareX.UploadersLib/FileUploaders/SFTP.cs
@@ -67,7 +67,6 @@ namespace ShareX.UploadersLib.FileUploaders
         {
             UploadResult result = new UploadResult();
 
-            fileName = Helpers.GetValidURL(fileName);
             string subFolderPath = Account.GetSubFolderPath();
             string path = subFolderPath.CombineURL(fileName);
             bool uploadResult;


### PR DESCRIPTION
Fix for Issue ShareX/ShareX#802
Do not url-encode file names for (S)FTP upload.

This is not necessary and a valid URL is created afterwards resulting in double-url-encoded URLs which is message and effectively destroys UTF8 based filenames e.g. Japanese.