### PR TITLE
Add extra flag to help with silent installations

### DIFF
--- a/InnoSetup/ShareX setup.iss
+++ b/InnoSetup/ShareX setup.iss
@@ -84,7 +84,7 @@ Name: "{sendto}\{#MyAppName}"; Filename: "{app}\{#MyAppFile}"; WorkingDir: "{app
 Name: "{userstartup}\{#MyAppName}"; Filename: "{app}\{#MyAppFile}"; WorkingDir: "{app}"; Parameters: "-silent"; Tasks: CreateStartupIcon and not PortableMode
 
 [Run]
-Filename: "{app}\{#MyAppFile}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall
+Filename: "{app}\{#MyAppFile}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent
 
 [UninstallRun]
 Filename: regsvr32; WorkingDir: {app}; Parameters: "/s /u screen-capture-recorder.dll"; Check: not IsWin64


### PR DESCRIPTION
When network administrators are deploying software en-mass they deploy using silent installations and the fact that ShareX opens a window when it has finished installing would be breaking that process.
