### PR TITLE
resolve right click cancel to insert state

### DIFF
--- a/ShareX.ScreenCaptureLib/RegionHelpers/AreaManager.cs
+++ b/ShareX.ScreenCaptureLib/RegionHelpers/AreaManager.cs
@@ -374,6 +374,7 @@ namespace ShareX.ScreenCaptureLib
             else if (e.Button == MouseButtons.Right)
             {
                 CancelRegionSelection();
+                EndRegionSelection();
             }
         }
 

--- a/ShareX.ScreenCaptureLib/RegionHelpers/AreaManager.cs
+++ b/ShareX.ScreenCaptureLib/RegionHelpers/AreaManager.cs
@@ -369,12 +369,18 @@ namespace ShareX.ScreenCaptureLib
         {
             if (e.Button == MouseButtons.Left)
             {
-                EndRegionSelection();
+                if (IsMoving || IsCreating)
+                {
+                    EndRegionSelection();
+                }
             }
             else if (e.Button == MouseButtons.Right)
             {
                 CancelRegionSelection();
-                EndRegionSelection();
+                if (IsCreating)
+                {
+                    EndRegionSelection();
+                }
             }
         }
 


### PR DESCRIPTION
related #936 

The cancel operation does not reset the state back to be ready for a new region.  The end operation is needed to reset the state.

fixes issue:
<kbd>Insert</kbd> to start.
<kbd>Right click</kbd> to cancel it.
<kbd>Left hold</kbd> or <kbd>Insert</kbd> not starts region selection.
But If I cancel it with <kbd>Delete</kbd> then it works fine.