### PR TITLE
disable minimize for color picker

### DIFF
--- a/ShareX.HelpersLib/Colors/ColorPickerForm.Designer.cs
+++ b/ShareX.HelpersLib/Colors/ColorPickerForm.Designer.cs
@@ -444,6 +444,7 @@
             this.Controls.Add(this.rbHue);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "ColorPickerForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.TopMost = true;


### PR DESCRIPTION
The color picker if minimized can become stuck behind region annotate window.  I did not see a reason that minimizing is needed for this window.

When stuck you can escape by
* <kbd>Alt</kbd> + <kbd>Tab</kbd> to make color picker visible again
* <kbd>Esc</kbd> to close capture
* <kbd>Alt</kbd> + <kbd>F4</kbd> to close color picker
* <kbd>Win</kbd> then open back up the color picker from the task bar

Though, I would say that none of these are intuitive enough for an average user since there are no mouse only resolution.