### PR TITLE
add continuous integration support (appveyor and travis-ci)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: csharp
+solution: ShareX.sln
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start

--- a/Greenshot.ImageEditor/Greenshot.ImageEditor.csproj
+++ b/Greenshot.ImageEditor/Greenshot.ImageEditor.csproj
@@ -35,7 +35,6 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -456,7 +455,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>True</Optimize>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
-    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 </Project>

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -37,7 +37,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.HistoryLib/ShareX.HistoryLib.csproj
+++ b/ShareX.HistoryLib/ShareX.HistoryLib.csproj
@@ -30,7 +30,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.IRCLib/ShareX.IRCLib.csproj
+++ b/ShareX.IRCLib/ShareX.IRCLib.csproj
@@ -23,7 +23,6 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
+++ b/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
@@ -48,7 +48,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.IndexerLib/ShareX.IndexerLib.csproj
+++ b/ShareX.IndexerLib/ShareX.IndexerLib.csproj
@@ -25,7 +25,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.MediaLib/ShareX.MediaLib.csproj
+++ b/ShareX.MediaLib/ShareX.MediaLib.csproj
@@ -23,7 +23,6 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -30,7 +30,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.Setup/ShareX.Setup.csproj
+++ b/ShareX.Setup/ShareX.Setup.csproj
@@ -25,7 +25,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -57,7 +57,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -795,11 +794,9 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>cd $(ProjectDir)APIKeys\
-
-if not exist APIKeysLocal.cs (
-    type nul &gt; APIKeysLocal.cs
-)</PreBuildEvent>
+    <PreBuildEvent>cd $(ProjectDir)APIKeys
+echo=&gt;&gt; APIKeysLocal.cs
+exit 0</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -795,7 +795,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)APIKeys
-echo=&gt;&gt; APIKeysLocal.cs
+type APIKeysLocal.cs || cat APIKeysLocal.cs || echo=&gt;&gt;APIKeysLocal.cs
 exit 0</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -1036,7 +1036,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)
-git &amp;&amp; git rev-parse HEAD &gt; GitHash.txt || echo= &gt;&gt; GitHash.txt
+git &amp;&amp; git rev-parse HEAD &gt; GitHash.txt || type GitHash.txt || cat GitHash.txt || echo=&gt;&gt;GitHash.txt
 exit 0</PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -51,7 +51,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -1037,16 +1036,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)
-
-if $(ConfigurationName) == Release (
-    for %25%25x in (git.exe) do if not [%25%25~$PATH:x]==[] (
-        git rev-parse HEAD &gt; GitHash.txt
-    )
-)
-
-if not exist GitHash.txt (
-    type nul &gt; GitHash.txt
-)</PreBuildEvent>
+git &amp;&amp; git rev-parse HEAD &gt; GitHash.txt || echo= &gt;&gt; GitHash.txt
+exit 0</PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@
 #---------------------------------#
 
 # version format
-version: 1.0.2 Beta b{build}
+version: 1.0.2 Beta {branch}-{build}
 
 # branches to build
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,57 @@
+# Notes:
+#   - Minimal appveyor.yml file is an empty file. All sections are optional.
+#   - Indent each level of configuration with 2 spaces. Do not use tabs!
+#   - All section names are case-sensitive.
+#   - Section names should be unique on each level.
+
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 1.0.2 Beta b{build}
+
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+
+  # blacklist
+  except:
+    - gh-pages
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Operating system (build VM template)
+os: Visual Studio 2015
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform:
+  - Any CPU
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration:
+  - Debug
+  - Release
+
+build:
+  parallel: true                  # enable MSBuild parallel builds
+  project: ShareX.sln             # path to Visual Studio solution or project
+
+#---------------------------------#
+#         notifications           #
+#---------------------------------#
+  
+#notifications:
+#
+#  # Email
+#  - provider: Email
+#    to:
+#      - user@server.com


### PR DESCRIPTION
Add support for the Continuous Integration services
* [__Travis-CI__](https://travis-ci.org) (Unix Mono xBuild)
* [__AppVeyor__](https://ci.appveyor.com) (Windows Visual Studio 2015 MSBuild)

both services free for open source projects

Reason for Changes
* Added `.travis.yml` and `appveyor.yml` configuration files
* xBuild with Mono does not support the (default) none property for DebugType
* Updated BuildEvents to work on Windows (cmd) and Unix (shell) systems

Examples
* https://ci.appveyor.com/project/davidruhmann/sharex
* https://travis-ci.org/davidruhmann/ShareX/builds