### PR TITLE
add base form with default icon

### DIFF
--- a/ShareX.HelpersLib/Automate/AutomateForm.cs
+++ b/ShareX.HelpersLib/Automate/AutomateForm.cs
@@ -34,7 +34,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class AutomateForm : Form
+    public partial class AutomateForm : BaseForm
     {
         private static AutomateForm instance;
 
@@ -49,7 +49,6 @@ namespace ShareX.HelpersLib
         private AutomateForm(List<ScriptInfo> scripts)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             rtbInput.AddContextMenu();
             tokenizer.Keywords = FunctionManager.Functions.Select(x => x.Key).ToArray();
             cbFunctions.Items.AddRange(tokenizer.Keywords);

--- a/ShareX.HelpersLib/Colors/ColorPickerForm.cs
+++ b/ShareX.HelpersLib/Colors/ColorPickerForm.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class ColorPickerForm : Form
+    public partial class ColorPickerForm : BaseForm
     {
         public MyColor NewColor { get; protected set; }
         public MyColor OldColor { get; private set; }
@@ -66,7 +66,6 @@ namespace ShareX.HelpersLib
         private void Initialize(Color currentColor)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             if (currentColor.IsEmpty)
             {

--- a/ShareX.HelpersLib/Colors/GradientPickerForm.cs
+++ b/ShareX.HelpersLib/Colors/GradientPickerForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class GradientPickerForm : Form
+    public partial class GradientPickerForm : BaseForm
     {
         public GradientInfo Gradient { get; set; }
 
@@ -40,7 +40,6 @@ namespace ShareX.HelpersLib
         {
             Gradient = gradient;
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             cbGradientType.Items.AddRange(Helpers.GetEnumNamesProper<LinearGradientMode>());
             cbGradientType.SelectedIndex = (int)Gradient.Type;
             foreach (GradientStop gradientStop in Gradient.Colors)

--- a/ShareX.HelpersLib/DNS/DNSChangerForm.cs
+++ b/ShareX.HelpersLib/DNS/DNSChangerForm.cs
@@ -29,12 +29,11 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class DNSChangerForm : Form
+    public partial class DNSChangerForm : BaseForm
     {
         public DNSChangerForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             AddDNS(Resources.DNSChangerForm_DNSChangerForm_Manual);
             AddDNS("Google Public DNS", "8.8.8.8", "8.8.4.4"); // https://developers.google.com/speed/public-dns/

--- a/ShareX.HelpersLib/Forms/BaseForm.Designer.cs
+++ b/ShareX.HelpersLib/Forms/BaseForm.Designer.cs
@@ -1,0 +1,46 @@
+﻿namespace ShareX.HelpersLib
+{
+    partial class BaseForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // BaseForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(300, 300);
+            this.Name = "BaseForm";
+            this.Text = "ShareX";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+    }
+}

--- a/ShareX.HelpersLib/Forms/BaseForm.cs
+++ b/ShareX.HelpersLib/Forms/BaseForm.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows.Forms;
+
+namespace ShareX.HelpersLib
+{
+    public partial class BaseForm : Form
+    {
+        public BaseForm()
+        {
+            InitializeComponent();
+            Icon = ShareXResources.Icon;
+        }
+    }
+}

--- a/ShareX.HelpersLib/Forms/BaseForm.resx
+++ b/ShareX.HelpersLib/Forms/BaseForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ShareX.HelpersLib/Forms/ClipboardContentViewer.cs
+++ b/ShareX.HelpersLib/Forms/ClipboardContentViewer.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class ClipboardContentViewer : Form
+    public partial class ClipboardContentViewer : BaseForm
     {
         public bool IsClipboardEmpty { get; private set; }
 
@@ -40,7 +40,6 @@ namespace ShareX.HelpersLib
         public ClipboardContentViewer(bool showCheckBox = false)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             cbDontShowThisWindow.Visible = showCheckBox;
         }
 

--- a/ShareX.HelpersLib/Forms/DebugForm.cs
+++ b/ShareX.HelpersLib/Forms/DebugForm.cs
@@ -31,14 +31,13 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class DebugForm : Form
+    public partial class DebugForm : BaseForm
     {
         private Logger logger;
 
         public DebugForm(Logger logger)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             this.logger = logger;
 
             rtbDebug.Text = logger.ToString();

--- a/ShareX.HelpersLib/Forms/ErrorForm.cs
+++ b/ShareX.HelpersLib/Forms/ErrorForm.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class ErrorForm : Form
+    public partial class ErrorForm : BaseForm
     {
         public string LogPath { get; private set; }
         public string BugReportPath { get; private set; }
@@ -42,7 +42,6 @@ namespace ShareX.HelpersLib
         public ErrorForm(string errorTitle, string errorMessage, string logPath, string bugReportPath)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             LogPath = logPath;
             BugReportPath = bugReportPath;
 

--- a/ShareX.HelpersLib/Forms/HashCheckForm.cs
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.cs
@@ -30,14 +30,13 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class HashCheckForm : Form
+    public partial class HashCheckForm : BaseForm
     {
         private HashCheck hashCheck;
 
         public HashCheckForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             cbHashType.Items.AddRange(Helpers.GetEnumDescriptions<HashType>());
             cbHashType.SelectedIndex = (int)HashType.SHA1;

--- a/ShareX.HelpersLib/Forms/ImageViewer.cs
+++ b/ShareX.HelpersLib/Forms/ImageViewer.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public class ImageViewer : Form
+    public class ImageViewer : BaseForm
     {
         private Image screenshot;
 

--- a/ShareX.HelpersLib/Forms/InputBox.cs
+++ b/ShareX.HelpersLib/Forms/InputBox.cs
@@ -28,7 +28,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public class InputBox : Form
+    public class InputBox : BaseForm
     {
         public string Title { get; set; }
         public string InputText { get; set; }
@@ -36,7 +36,6 @@ namespace ShareX.HelpersLib
         public InputBox(string title = null, string inputText = null)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             Title = title;
             InputText = inputText;

--- a/ShareX.HelpersLib/Forms/MonitorTestForm.cs
+++ b/ShareX.HelpersLib/Forms/MonitorTestForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class MonitorTestForm : Form
+    public partial class MonitorTestForm : BaseForm
     {
         public MonitorTestForm()
         {

--- a/ShareX.HelpersLib/Forms/MyMessageBox.cs
+++ b/ShareX.HelpersLib/Forms/MyMessageBox.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public class MyMessageBox : Form
+    public class MyMessageBox : BaseForm
     {
         private const int LabelHorizontalPadding = 15;
         private const int LabelVerticalPadding = 20;

--- a/ShareX.HelpersLib/Forms/OutputBox.cs
+++ b/ShareX.HelpersLib/Forms/OutputBox.cs
@@ -28,12 +28,11 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class OutputBox : Form
+    public partial class OutputBox : BaseForm
     {
         public OutputBox(string text, string title)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Text = "ShareX - " + title;
             txtText.Text = text;
         }

--- a/ShareX.HelpersLib/Forms/QRCodeForm.cs
+++ b/ShareX.HelpersLib/Forms/QRCodeForm.cs
@@ -33,14 +33,13 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class QRCodeForm : Form
+    public partial class QRCodeForm : BaseForm
     {
         public bool EditMode { get; set; }
 
         public QRCodeForm(string text = null)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             ClientSize = new Size(400, 400);
 
             if (!string.IsNullOrEmpty(text))

--- a/ShareX.HelpersLib/Forms/TrayForm.cs
+++ b/ShareX.HelpersLib/Forms/TrayForm.cs
@@ -28,7 +28,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public class TrayForm : Form
+    public class TrayForm : BaseForm
     {
         protected NotifyIcon TrayIcon = null;
 

--- a/ShareX.HelpersLib/Native/LayeredForm.cs
+++ b/ShareX.HelpersLib/Native/LayeredForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public class LayeredForm : Form
+    public class LayeredForm : BaseForm
     {
         public LayeredForm()
         {

--- a/ShareX.HelpersLib/Printer/PrintForm.cs
+++ b/ShareX.HelpersLib/Printer/PrintForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class PrintForm : Form
+    public partial class PrintForm : BaseForm
     {
         private PrintHelper printHelper;
         private PrintSettings printSettings;

--- a/ShareX.HelpersLib/Printer/PrintTextForm.cs
+++ b/ShareX.HelpersLib/Printer/PrintTextForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class PrintTextForm : Form
+    public partial class PrintTextForm : BaseForm
     {
         private PrintHelper printHelper;
         private PrintSettings printSettings;

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -130,6 +130,12 @@
     <Compile Include="Extensions\NumberExtensions.cs" />
     <Compile Include="FFmpegDownloader.cs" />
     <Compile Include="FontSafe.cs" />
+    <Compile Include="Forms\BaseForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\BaseForm.Designer.cs">
+      <DependentUpon>BaseForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\OutputBox.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -560,6 +566,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="DNS\DNSChangerForm.zh-CN.resx">
       <DependentUpon>DNSChangerForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\BaseForm.resx">
+      <DependentUpon>BaseForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\ClipboardContentViewer.de.resx">
       <DependentUpon>ClipboardContentViewer.cs</DependentUpon>

--- a/ShareX.HelpersLib/UpdateChecker/DownloaderForm.cs
+++ b/ShareX.HelpersLib/UpdateChecker/DownloaderForm.cs
@@ -36,7 +36,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class DownloaderForm : Form
+    public partial class DownloaderForm : BaseForm
     {
         public delegate void DownloaderInstallEventHandler(string filePath);
         public event DownloaderInstallEventHandler InstallRequested;
@@ -60,7 +60,6 @@ namespace ShareX.HelpersLib
         private DownloaderForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             fillRect = new Rectangle(0, 0, ClientSize.Width, ClientSize.Height);
 

--- a/ShareX.HelpersLib/UpdateChecker/UpdateMessageBox.cs
+++ b/ShareX.HelpersLib/UpdateChecker/UpdateMessageBox.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
-    public partial class UpdateMessageBox : Form
+    public partial class UpdateMessageBox : BaseForm
     {
         public static bool IsOpen { get; private set; }
         public static bool DontShow { get; private set; }
@@ -43,7 +43,6 @@ namespace ShareX.HelpersLib
         {
             InitializeComponent();
 
-            Icon = ShareXResources.Icon;
             Text = Resources.UpdateMessageBox_UpdateMessageBox_update_is_available;
             lblText.Text = string.Format(Resources.UpdateMessageBox_UpdateMessageBox_, Application.ProductName);
 

--- a/ShareX.HistoryLib/HistoryForm.cs
+++ b/ShareX.HistoryLib/HistoryForm.cs
@@ -34,7 +34,7 @@ using System.Windows.Forms;
 
 namespace ShareX.HistoryLib
 {
-    public partial class HistoryForm : Form
+    public partial class HistoryForm : BaseForm
     {
         public string HistoryPath { get; private set; }
         public int MaxItemCount { get; set; }
@@ -46,7 +46,6 @@ namespace ShareX.HistoryLib
         public HistoryForm(string historyPath, int maxItemCount = -1)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Text = "ShareX - " + string.Format(Resources.HistoryForm_HistoryForm_History_, historyPath);
 
             HistoryPath = historyPath;

--- a/ShareX.HistoryLib/HistoryItemInfoForm.cs
+++ b/ShareX.HistoryLib/HistoryItemInfoForm.cs
@@ -23,11 +23,12 @@
 
 #endregion License Information (GPL v3)
 
+using ShareX.HelpersLib;
 using System.Windows.Forms;
 
 namespace ShareX.HistoryLib
 {
-    public partial class HistoryItemInfoForm : Form
+    public partial class HistoryItemInfoForm : BaseForm
     {
         public HistoryItemInfoForm(object hi)
         {

--- a/ShareX.HistoryLib/ImageHistoryForm.cs
+++ b/ShareX.HistoryLib/ImageHistoryForm.cs
@@ -35,7 +35,7 @@ using View = Manina.Windows.Forms.View;
 
 namespace ShareX.HistoryLib
 {
-    public partial class ImageHistoryForm : Form
+    public partial class ImageHistoryForm : BaseForm
     {
         public string HistoryPath { get; private set; }
         public int MaxItemCount { get; set; }
@@ -74,7 +74,6 @@ namespace ShareX.HistoryLib
         public ImageHistoryForm(string historyPath, int viewMode, Size thumbnailSize, int maxItemCount = -1)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Text = "ShareX - " + string.Format("Image history: {0}", historyPath);
 
             HistoryPath = historyPath;

--- a/ShareX.IRCLib/IRCClient/IRCClientForm.cs
+++ b/ShareX.IRCLib/IRCClient/IRCClientForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX.IRCLib
 {
-    public partial class IRCClientForm : Form
+    public partial class IRCClientForm : BaseForm
     {
         public IRCInfo Info { get; private set; }
         public IRC IRC { get; private set; }
@@ -45,7 +45,6 @@ namespace ShareX.IRCLib
         public IRCClientForm(IRCInfo info)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             ((ToolStripDropDownMenu)tsmiColors.DropDown).ShowImageMargin = false;
 
             tabManager = new TabManager(tcMessages);

--- a/ShareX.ImageEffectsLib/ImageEffectsForm.cs
+++ b/ShareX.ImageEffectsLib/ImageEffectsForm.cs
@@ -34,7 +34,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ImageEffectsLib
 {
-    public partial class ImageEffectsForm : Form
+    public partial class ImageEffectsForm : BaseForm
     {
         public Image DefaultImage { get; private set; }
 
@@ -43,7 +43,6 @@ namespace ShareX.ImageEffectsLib
         public ImageEffectsForm(Image img, List<ImageEffect> effects = null)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             DefaultImage = img;
             eiImageEffects.ObjectType = typeof(List<ImageEffect>);
             AddAllEffectsToContextMenu();

--- a/ShareX.ImageEffectsLib/WatermarkForm.cs
+++ b/ShareX.ImageEffectsLib/WatermarkForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ImageEffectsLib
 {
-    public partial class WatermarkForm : Form
+    public partial class WatermarkForm : BaseForm
     {
         private WatermarkConfig config;
         private bool IsGuiReady;

--- a/ShareX.MediaLib/Forms/VideoThumbnailerForm.cs
+++ b/ShareX.MediaLib/Forms/VideoThumbnailerForm.cs
@@ -33,7 +33,7 @@ using System.Windows.Forms;
 
 namespace ShareX.MediaLib
 {
-    public partial class VideoThumbnailerForm : Form
+    public partial class VideoThumbnailerForm : BaseForm
     {
         public event Action<List<VideoThumbnailInfo>> ThumbnailsTaken;
 
@@ -45,7 +45,6 @@ namespace ShareX.MediaLib
             FFmpegPath = ffmpegPath;
             Options = options;
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             txtMediaPath.Text = Options.LastVideoPath ?? string.Empty;
             pgOptions.SelectedObject = Options;
         }

--- a/ShareX.ScreenCaptureLib/Forms/RectangleAnnotate.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RectangleAnnotate.cs
@@ -35,7 +35,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    public class RectangleAnnotate : Form
+    public class RectangleAnnotate : BaseForm
     {
         public static Rectangle LastSelectionRectangle0Based { get; private set; }
 

--- a/ShareX.ScreenCaptureLib/Forms/RectangleLight.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RectangleLight.cs
@@ -34,7 +34,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    public class RectangleLight : Form
+    public class RectangleLight : BaseForm
     {
         public static Rectangle LastSelectionRectangle0Based { get; private set; }
 

--- a/ShareX.ScreenCaptureLib/Forms/Surface.cs
+++ b/ShareX.ScreenCaptureLib/Forms/Surface.cs
@@ -37,7 +37,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    public class Surface : Form
+    public class Surface : BaseForm
     {
         public Image SurfaceImage { get; set; }
         public SurfaceOptions Config { get; set; }

--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegOptionsForm.cs
@@ -33,7 +33,7 @@ using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    public partial class FFmpegOptionsForm : Form
+    public partial class FFmpegOptionsForm : BaseForm
     {
         public ScreencastOptions Options { get; private set; }
         public string DefaultToolsPath { get; set; }
@@ -43,7 +43,6 @@ namespace ShareX.ScreenCaptureLib
         public FFmpegOptionsForm(ScreencastOptions options)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Options = options;
 
             eiFFmpeg.ObjectType = typeof(FFmpegOptions);

--- a/ShareX.UploadersLib/FTPClient/FTPClientForm.Designer.cs
+++ b/ShareX.UploadersLib/FTPClient/FTPClientForm.Designer.cs
@@ -33,7 +33,7 @@
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
-            this.lvFTPList = new UploadersLib.ListViewEx();
+            this.lvFTPList = new ShareX.UploadersLib.ListViewEx();
             this.chFilename = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chFilesize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chFiletype = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));

--- a/ShareX.UploadersLib/FTPClient/FTPClientForm.cs
+++ b/ShareX.UploadersLib/FTPClient/FTPClientForm.cs
@@ -36,7 +36,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib
 {
-    public partial class FTPClientForm : Form
+    public partial class FTPClientForm : BaseForm
     {
         private const string Root = "/";
 
@@ -49,7 +49,6 @@ namespace ShareX.UploadersLib
         public FTPClientForm(FTPAccount account)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             lblStatus.Text = string.Empty;
             lvFTPList.SubItemEndEditing += lvFTPList_SubItemEndEditing;

--- a/ShareX.UploadersLib/FTPClient/FTPClientForm.resx
+++ b/ShareX.UploadersLib/FTPClient/FTPClientForm.resx
@@ -280,7 +280,7 @@
     <value>lvFTPList</value>
   </data>
   <data name="&gt;&gt;lvFTPList.Type" xml:space="preserve">
-    <value>UploadersLib.ListViewEx, UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.UploadersLib.ListViewEx, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lvFTPList.Parent" xml:space="preserve">
     <value>toolStripContainer1.ContentPanel</value>
@@ -919,6 +919,6 @@
     <value>FTPClientForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>ShareX.HelpersLib.BaseForm, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/DropboxFilesForm.cs
+++ b/ShareX.UploadersLib/Forms/DropboxFilesForm.cs
@@ -35,7 +35,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.Forms
 {
-    public partial class DropboxFilesForm : Form
+    public partial class DropboxFilesForm : BaseForm
     {
         public string CurrentFolderPath { get; private set; }
 

--- a/ShareX.UploadersLib/Forms/EmailForm.cs
+++ b/ShareX.UploadersLib/Forms/EmailForm.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.GUI
 {
-    public partial class EmailForm : Form
+    public partial class EmailForm : BaseForm
     {
         public string ToEmail { get; private set; }
         public string Subject { get; private set; }
@@ -38,7 +38,6 @@ namespace ShareX.UploadersLib.GUI
         public EmailForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
         }
 
         public EmailForm(string toEmail, string subject, string body)

--- a/ShareX.UploadersLib/Forms/JiraUpload.cs
+++ b/ShareX.UploadersLib/Forms/JiraUpload.cs
@@ -31,9 +31,10 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.GUI
 {
+    using ShareX.HelpersLib;
     using System.Threading.Tasks;
 
-    public partial class JiraUpload : Form
+    public partial class JiraUpload : BaseForm
     {
         public delegate string GetSummaryHandler(string issueId);
 

--- a/ShareX.UploadersLib/Forms/OAuthWebForm.cs
+++ b/ShareX.UploadersLib/Forms/OAuthWebForm.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.GUI
 {
-    public partial class OAuthWebForm : Form
+    public partial class OAuthWebForm : BaseForm
     {
         public string AuthorizeURL { get; set; }
         public string CallbackURL { get; set; }
@@ -40,7 +40,6 @@ namespace ShareX.UploadersLib.GUI
         public OAuthWebForm(string authorizeURL, string callbackURL)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             AuthorizeURL = authorizeURL;
             CallbackURL = callbackURL;
             tstbURL.Text = authorizeURL;

--- a/ShareX.UploadersLib/Forms/ResponseForm.cs
+++ b/ShareX.UploadersLib/Forms/ResponseForm.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib
 {
-    public partial class ResponseForm : Form
+    public partial class ResponseForm : BaseForm
     {
         public string Response { get; private set; }
 
@@ -38,7 +38,6 @@ namespace ShareX.UploadersLib
         public ResponseForm(string response)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Response = response;
             txtSource.Text = Response;
         }

--- a/ShareX.UploadersLib/Forms/TwitterTweetForm.cs
+++ b/ShareX.UploadersLib/Forms/TwitterTweetForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib
 {
-    public partial class TwitterTweetForm : Form
+    public partial class TwitterTweetForm : BaseForm
     {
         public string Message
         {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -39,7 +39,7 @@ using System.Windows.Forms;
 
 namespace ShareX.UploadersLib
 {
-    public partial class UploadersConfigForm : Form
+    public partial class UploadersConfigForm : BaseForm
     {
         public UploadersConfig Config { get; private set; }
 
@@ -54,8 +54,6 @@ namespace ShareX.UploadersLib
             {
                 Text += " - " + Config.FilePath;
             }
-
-            Icon = ShareXResources.Icon;
         }
 
         private void UploadersConfigForm_Shown(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UserPassBox.cs
+++ b/ShareX.UploadersLib/Forms/UserPassBox.cs
@@ -23,12 +23,13 @@
 
 #endregion License Information (GPL v3)
 
+using ShareX.HelpersLib;
 using System;
 using System.Windows.Forms;
 
 namespace ShareX.UploadersLib
 {
-    public partial class UserPassBox : Form
+    public partial class UserPassBox : BaseForm
     {
         public string FullName { get; private set; }
         public string UserName { get; private set; }

--- a/ShareX/Forms/AboutForm.cs
+++ b/ShareX/Forms/AboutForm.cs
@@ -32,12 +32,11 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class AboutForm : Form
+    public partial class AboutForm : BaseForm
     {
         public AboutForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             lblProductName.Text = Program.Title;
 
             rtbShareXInfo.AddContextMenu();

--- a/ShareX/Forms/ActionsForm.cs
+++ b/ShareX/Forms/ActionsForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class ActionsForm : Form
+    public partial class ActionsForm : BaseForm
     {
         public ExternalProgram FileAction { get; private set; }
 
@@ -42,7 +42,6 @@ namespace ShareX
         public ActionsForm(ExternalProgram fileAction)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             FileAction = fileAction;
             txtName.Text = fileAction.Name ?? "";
             txtPath.Text = fileAction.Path ?? "";

--- a/ShareX/Forms/AfterCaptureForm.cs
+++ b/ShareX/Forms/AfterCaptureForm.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class AfterCaptureForm : Form
+    public partial class AfterCaptureForm : BaseForm
     {
         public AfterCaptureTasks AfterCaptureTasks { get; private set; }
         public AfterCaptureFormResult Result { get; private set; }
@@ -39,7 +39,6 @@ namespace ShareX
         public AfterCaptureForm(Image img, TaskSettings taskSettings)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             ImageList imageList = new ImageList { ColorDepth = ColorDepth.Depth32Bit };
             imageList.Images.Add(Resources.checkbox_uncheck);

--- a/ShareX/Forms/AfterUploadForm.cs
+++ b/ShareX/Forms/AfterUploadForm.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class AfterUploadForm : Form
+    public partial class AfterUploadForm : BaseForm
     {
         public TaskInfo Info { get; private set; }
 
@@ -46,7 +46,6 @@ namespace ShareX
         public AfterUploadForm(TaskInfo info)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             Info = info;
             if (Info.TaskSettings.AdvancedSettings.AutoCloseAfterUploadForm) tmrClose.Start();
 

--- a/ShareX/Forms/ApplicationSettingsForm.cs
+++ b/ShareX/Forms/ApplicationSettingsForm.cs
@@ -34,7 +34,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class ApplicationSettingsForm : Form
+    public partial class ApplicationSettingsForm : BaseForm
     {
         private bool loaded;
         private const int MaxBufferSizePower = 14;
@@ -48,8 +48,6 @@ namespace ShareX
 
         private void LoadSettings()
         {
-            Icon = ShareXResources.Icon;
-
             // General
 
             foreach (SupportedLanguage language in Helpers.GetEnums<SupportedLanguage>())

--- a/ShareX/Forms/AutoCaptureForm.cs
+++ b/ShareX/Forms/AutoCaptureForm.cs
@@ -33,7 +33,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class AutoCaptureForm : Form
+    public partial class AutoCaptureForm : BaseForm
     {
         private static AutoCaptureForm instance;
 
@@ -63,7 +63,6 @@ namespace ShareX
         private AutoCaptureForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             niTray.Icon = Resources.clock.ToIcon();
 
             screenshotTimer = new System.Timers.Timer();

--- a/ShareX/Forms/BeforeUploadForm.cs
+++ b/ShareX/Forms/BeforeUploadForm.cs
@@ -30,12 +30,11 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class BeforeUploadForm : Form
+    public partial class BeforeUploadForm : BaseForm
     {
         public BeforeUploadForm(TaskInfo info)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             DialogResult = DialogResult.OK;
 
             ucBeforeUpload.InitCompleted += currentDestination =>

--- a/ShareX/Forms/ChromeForm.cs
+++ b/ShareX/Forms/ChromeForm.cs
@@ -38,12 +38,11 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class ChromeForm : Form
+    public partial class ChromeForm : BaseForm
     {
         public ChromeForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
         }
 
         private void CreateChromeHostManifest(string filepath)

--- a/ShareX/Forms/ClipboardFormatForm.cs
+++ b/ShareX/Forms/ClipboardFormatForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class ClipboardFormatForm : Form
+    public partial class ClipboardFormatForm : BaseForm
     {
         public ClipboardFormat ClipboardFormat { get; private set; }
 

--- a/ShareX/Forms/EncoderProgramForm.cs
+++ b/ShareX/Forms/EncoderProgramForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class EncoderProgramForm : Form
+    public partial class EncoderProgramForm : BaseForm
     {
         public VideoEncoder encoder { get; private set; }
 
@@ -41,7 +41,6 @@ namespace ShareX
 
         public EncoderProgramForm(VideoEncoder encoder)
         {
-            Icon = ShareXResources.Icon;
             this.encoder = encoder;
             InitializeComponent();
             txtName.Text = encoder.Name ?? "";

--- a/ShareX/Forms/FileExistForm.cs
+++ b/ShareX/Forms/FileExistForm.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class FileExistForm : Form
+    public partial class FileExistForm : BaseForm
     {
         public string Filepath { get; private set; }
 
@@ -41,7 +41,6 @@ namespace ShareX
         public FileExistForm(string filepath)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             Filepath = filepath;
             filename = Path.GetFileNameWithoutExtension(Filepath);

--- a/ShareX/Forms/HotkeyForm.cs
+++ b/ShareX/Forms/HotkeyForm.cs
@@ -29,7 +29,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public class HotkeyForm : Form
+    public class HotkeyForm : BaseForm
     {
         public int HotkeyRepeatLimit { get; set; }
 

--- a/ShareX/Forms/HotkeySettingsForm.cs
+++ b/ShareX/Forms/HotkeySettingsForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class HotkeySettingsForm : Form
+    public partial class HotkeySettingsForm : BaseForm
     {
         public HotkeySelectionControl Selected { get; private set; }
 
@@ -41,7 +41,6 @@ namespace ShareX
         public HotkeySettingsForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
 
             if (Program.HotkeyManager != null)
             {

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -84,7 +84,6 @@ namespace ShareX
             InitializeComponent();
 
             Text = Program.Title;
-            Icon = ShareXResources.Icon;
 
             ((ToolStripDropDownMenu)tsddbWorkflows.DropDown).ShowImageMargin = ((ToolStripDropDownMenu)tsmiTrayWorkflows.DropDown).ShowImageMargin =
                 ((ToolStripDropDownMenu)tsmiMonitor.DropDown).ShowImageMargin = ((ToolStripDropDownMenu)tsmiTrayMonitor.DropDown).ShowImageMargin =

--- a/ShareX/Forms/NotificationForm.cs
+++ b/ShareX/Forms/NotificationForm.cs
@@ -31,7 +31,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public class NotificationForm : Form
+    public class NotificationForm : BaseForm
     {
         public NotificationFormConfig ToastConfig { get; private set; }
 

--- a/ShareX/Forms/ScreenRegionForm.cs
+++ b/ShareX/Forms/ScreenRegionForm.cs
@@ -33,7 +33,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class ScreenRegionForm : Form
+    public partial class ScreenRegionForm : BaseForm
     {
         public event Action StopRequested;
 

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -37,7 +37,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class TaskSettingsForm : Form
+    public partial class TaskSettingsForm : BaseForm
     {
         public TaskSettings TaskSettings { get; private set; }
         public bool IsDefault { get; private set; }
@@ -48,7 +48,6 @@ namespace ShareX
         public TaskSettingsForm(TaskSettings hotkeySetting, bool isDefault = false)
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             TaskSettings = hotkeySetting;
             IsDefault = isDefault;
 

--- a/ShareX/Forms/VideoEncodersForm.cs
+++ b/ShareX/Forms/VideoEncodersForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class VideoEncodersForm : Form
+    public partial class VideoEncodersForm : BaseForm
     {
         public VideoEncodersForm()
         {

--- a/ShareX/Forms/WatchFolderForm.cs
+++ b/ShareX/Forms/WatchFolderForm.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class WatchFolderForm : Form
+    public partial class WatchFolderForm : BaseForm
     {
         public WatchFolderSettings WatchFolder { get; private set; }
 

--- a/ShareX/Forms/WebpageCaptureForm.cs
+++ b/ShareX/Forms/WebpageCaptureForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace ShareX
 {
-    public partial class WebpageCaptureForm : Form
+    public partial class WebpageCaptureForm : BaseForm
     {
         public event Action<Image> OnImageUploadRequested;
         public event Action<Image> OnImageCopyRequested;
@@ -45,7 +45,6 @@ namespace ShareX
         public WebpageCaptureForm()
         {
             InitializeComponent();
-            Icon = ShareXResources.Icon;
             LoadSettings();
             webpageCapture = new WebpageCapture();
             webpageCapture.CaptureCompleted += webpageCapture_CaptureCompleted;

--- a/ShareX/UploadInfoManager.cs
+++ b/ShareX/UploadInfoManager.cs
@@ -340,7 +340,6 @@ namespace ShareX
             {
                 using (ResponseForm form = new ResponseForm(SelectedItem.Info.Result.Response))
                 {
-                    form.Icon = ShareXResources.Icon;
                     form.ShowDialog();
                 }
             }

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -1007,8 +1007,6 @@ namespace ShareX
                     using (EmailForm emailForm = new EmailForm(Program.UploadersConfig.EmailRememberLastTo ? Program.UploadersConfig.EmailLastTo : string.Empty,
                         Program.UploadersConfig.EmailDefaultSubject, Program.UploadersConfig.EmailDefaultBody))
                     {
-                        emailForm.Icon = ShareXResources.Icon;
-
                         if (emailForm.ShowDialog() == DialogResult.OK)
                         {
                             if (Program.UploadersConfig.EmailRememberLastTo)


### PR DESCRIPTION
Added the default ShareX icon to a new BaseForm which other forms derive from to inherit the icon.  IMHO, the BaseForm helps with maintainability and provides a single location where form defaults can be specified without having to modify every form.

resolves #958