### PR TITLE
Fix possible null dereference at ChangeText

### DIFF
--- a/Greenshot.ImageEditor/Drawing/TextContainer.cs
+++ b/Greenshot.ImageEditor/Drawing/TextContainer.cs
@@ -77,7 +77,7 @@ namespace Greenshot.Drawing
 
         internal void ChangeText(string newText, bool allowUndoable)
         {
-            if ((text == null && newText != null) || !text.Equals(newText))
+            if ((text == null && newText != null) || (text != null && !text.Equals(newText)))
             {
                 if (makeUndoable && allowUndoable)
                 {


### PR DESCRIPTION
text == null and newText == null leads to "null.Equals(null)" check