### PR TITLE
Fix a null check for newParent at SwitchParent

### DIFF
--- a/Greenshot.ImageEditor/Drawing/DrawableContainer.cs
+++ b/Greenshot.ImageEditor/Drawing/DrawableContainer.cs
@@ -843,7 +843,7 @@ namespace Greenshot.Drawing
                 _parent.Controls.Add(_targetGripper);
             }
             // Normal grippers
-            if (_grippers != null)
+            if (_parent != null && _grippers != null)
             {
                 _parent.Controls.AddRange(_grippers);
             }


### PR DESCRIPTION
It was checked before the first dereference and was not checked before the
second one