### PR TITLE
Reopen save as dialog on errors after capture

### DIFF
--- a/ShareX/ImageData.cs
+++ b/ShareX/ImageData.cs
@@ -24,8 +24,10 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
+using ShareX.Properties;
 using System;
 using System.IO;
+using System.Windows.Forms;
 
 namespace ShareX
 {
@@ -46,6 +48,9 @@ namespace ShareX
             catch (Exception e)
             {
                 DebugHelper.WriteException(e);
+                MessageBox.Show(new Form() { WindowState = FormWindowState.Maximized, TopMost = true },
+                    string.Format(Resources.ImageData_Write_Error + "\r\n\r\n" + e, filePath), "ShareX",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return string.Empty;

--- a/ShareX/Properties/Resources.Designer.cs
+++ b/ShareX/Properties/Resources.Designer.cs
@@ -1036,6 +1036,15 @@ namespace ShareX.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not write image to path {0}..
+        /// </summary>
+        public static string ImageData_Write_Error {
+            get {
+                return ResourceManager.GetString("ImageData_Write_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap images_stack {

--- a/ShareX/Properties/Resources.resx
+++ b/ShareX/Properties/Resources.resx
@@ -811,4 +811,7 @@ Would you like to restart ShareX?</value>
   <data name="vn" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\vn.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="ImageData_Write_Error" xml:space="preserve">
+    <value>Could not write image to path {0}.</value>
+  </data>
 </root>

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -590,7 +590,7 @@ namespace ShareX
                                 else
                                 {
                                     // User cancelled the dialog - stop image saving retries.
-                                    break;
+                                    return false;
                                 }
                             } while (!imageSaved);
                         }

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -561,24 +561,38 @@ namespace ShareX
                     {
                         using (SaveFileDialog sfd = new SaveFileDialog())
                         {
-                            if (string.IsNullOrEmpty(lastSaveAsFolder) || !Directory.Exists(lastSaveAsFolder))
-                            {
-                                lastSaveAsFolder = Info.TaskSettings.CaptureFolder;
-                            }
+                            bool imageSaved = false;
 
-                            sfd.InitialDirectory = lastSaveAsFolder;
-                            sfd.FileName = Info.FileName;
-                            sfd.DefaultExt = Path.GetExtension(Info.FileName).Substring(1);
-                            sfd.Filter = string.Format("*{0}|*{0}|All files (*.*)|*.*", Path.GetExtension(Info.FileName));
-                            sfd.Title = Resources.UploadTask_DoAfterCaptureJobs_Choose_a_folder_to_save + " " + Path.GetFileName(Info.FileName);
-
-                            if (sfd.ShowDialog() == DialogResult.OK && !string.IsNullOrEmpty(sfd.FileName))
+                            do
                             {
-                                Info.FilePath = sfd.FileName;
-                                lastSaveAsFolder = Path.GetDirectoryName(Info.FilePath);
-                                imageData.Write(Info.FilePath);
-                                DebugHelper.WriteLine("Image saved to file with dialog: " + Info.FilePath);
-                            }
+                                if (string.IsNullOrEmpty(lastSaveAsFolder) || !Directory.Exists(lastSaveAsFolder))
+                                {
+                                    lastSaveAsFolder = Info.TaskSettings.CaptureFolder;
+                                }
+
+                                sfd.InitialDirectory = lastSaveAsFolder;
+                                sfd.FileName = Info.FileName;
+                                sfd.DefaultExt = Path.GetExtension(Info.FileName).Substring(1);
+                                sfd.Filter = string.Format("*{0}|*{0}|All files (*.*)|*.*", Path.GetExtension(Info.FileName));
+                                sfd.Title = Resources.UploadTask_DoAfterCaptureJobs_Choose_a_folder_to_save + " " + Path.GetFileName(Info.FileName);
+
+                                if (sfd.ShowDialog() == DialogResult.OK && !string.IsNullOrEmpty(sfd.FileName))
+                                {
+                                    Info.FilePath = sfd.FileName;
+                                    lastSaveAsFolder = Path.GetDirectoryName(Info.FilePath);
+                                    imageSaved = imageData.Write(Info.FilePath) == Info.FilePath;
+
+                                    if (imageSaved)
+                                    {
+                                        DebugHelper.WriteLine("Image saved to file with dialog: " + Info.FilePath);
+                                    }   
+                                }
+                                else
+                                {
+                                    // User cancelled the dialog - stop image saving retries.
+                                    break;
+                                }
+                            } while (!imageSaved);
                         }
                     }
 


### PR DESCRIPTION
Reopens the save dialog after the exception window has been confirmed. This fix should prevent losing pictures on errors (see issue #1008).

An easy way to provoke an error on saving:

1. Create drive mapping to a folder: ``subst S: C:\Test``.
2. Activate post capture task ``Save image to file as...``.
3. Create breakpoint before the image is saved.
4. Capture a image and select the drive ``S:`` as location.
5. While the program is stopped, unmap the drive via ``subst S: /D``.
6. Remove breakpoint, continue execution. An exception is shown.
7. After the exception the file dialog is shown again.