### PR TITLE
Issue #846: Unregister hotkeys when disabling them.

### DIFF
--- a/ShareX/Controls/HotkeySelectionControl.cs
+++ b/ShareX/Controls/HotkeySelectionControl.cs
@@ -91,7 +91,7 @@ namespace ShareX
             btnHotkey.Text = Setting.HotkeyInfo.ToString();
         }
 
-        private void UpdateHotkeyStatus()
+        public void UpdateHotkeyStatus()
         {
             switch (Setting.HotkeyInfo.Status)
             {

--- a/ShareX/Forms/HotkeySettingsForm.cs
+++ b/ShareX/Forms/HotkeySettingsForm.cs
@@ -51,6 +51,11 @@ namespace ShareX
         private void HotkeySettingsForm_FormClosed(object sender, FormClosedEventArgs e)
         {
             Program.HotkeyManager.IgnoreHotkeys = false;
+
+            if (manager != null)
+            {
+                manager.HotkeysToggledTrigger -= HandleHotkeysToggle;
+            }
         }
 
         public void PrepareHotkeys(HotkeyManager hotkeyManager)
@@ -58,6 +63,8 @@ namespace ShareX
             if (manager == null)
             {
                 manager = hotkeyManager;
+                manager.HotkeysToggledTrigger += HandleHotkeysToggle;
+
                 AddControls();
             }
         }
@@ -94,6 +101,14 @@ namespace ShareX
             foreach (Control control in flpHotkeys.Controls)
             {
                 ((HotkeySelectionControl)control).Selected = Selected == control;
+            }
+        }
+
+        private void UpdateHotkeyStatus()
+        {
+            foreach (Control control in flpHotkeys.Controls)
+            {
+                ((HotkeySelectionControl)control).UpdateHotkeyStatus();
             }
         }
 
@@ -134,6 +149,11 @@ namespace ShareX
             {
                 Edit(Selected);
             }
+        }
+
+        private void HandleHotkeysToggle(bool hotkeysEnabled)
+        {
+            UpdateHotkeyStatus();
         }
 
         private void flpHotkeys_Layout(object sender, LayoutEventArgs e)

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -1620,15 +1620,7 @@ namespace ShareX
 
             if (hotkeySetting.TaskSettings.Job != HotkeyType.None)
             {
-                if (hotkeySetting.TaskSettings.Job == HotkeyType.DisableHotkeys)
-                {
-                    TaskHelpers.ToggleHotkeys();
-                }
-
-                if (!Program.Settings.DisableHotkeys)
-                {
-                    ExecuteJob(hotkeySetting.TaskSettings);
-                }
+                ExecuteJob(hotkeySetting.TaskSettings);
             }
         }
 
@@ -1790,6 +1782,9 @@ namespace ShareX
                 // Other
                 case HotkeyType.OpenScreenshotsFolder:
                     TaskHelpers.OpenScreenshotsFolder();
+                    break;
+                case HotkeyType.DisableHotkeys:
+                    TaskHelpers.ToggleHotkeys();
                     break;
             }
         }

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -760,19 +760,20 @@ namespace ShareX
 
         public static bool ToggleHotkeys()
         {
-            bool result = !Program.Settings.DisableHotkeys;
-            Program.Settings.DisableHotkeys = result;
+            bool hotkeysDisabled = !Program.Settings.DisableHotkeys;
 
+            Program.Settings.DisableHotkeys = hotkeysDisabled;
+            Program.HotkeyManager.ToggleHotkeys(hotkeysDisabled);
             Program.MainForm.UpdateToggleHotkeyButton();
 
             if (Program.MainForm.niTray.Visible)
             {
                 Program.MainForm.niTray.Tag = null;
-                string balloonTipText = result ? Resources.TaskHelpers_ToggleHotkeys_Hotkeys_disabled_ : Resources.TaskHelpers_ToggleHotkeys_Hotkeys_enabled_;
+                string balloonTipText = hotkeysDisabled ? Resources.TaskHelpers_ToggleHotkeys_Hotkeys_disabled_ : Resources.TaskHelpers_ToggleHotkeys_Hotkeys_enabled_;
                 Program.MainForm.niTray.ShowBalloonTip(3000, "ShareX", balloonTipText, ToolTipIcon.Info);
             }
 
-            return result;
+            return hotkeysDisabled;
         }
 
         public static bool CheckFFmpeg(TaskSettings taskSettings)


### PR DESCRIPTION
Hotkeys are unregistered temporarily until the user enables them again. The hotkey form now also reacts to enabling and disabling hotkeys. When hotkeys are disabled, a new hotkey is saved but not registered. Resetting hotkeys to default also enables them again.