### PR TITLE
fixes Newtonsoft.Json.JsonSerializationException with OwnCloud upload

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using ShareX.HelpersLib;
 using System;
 using System.Collections.Generic;
@@ -133,7 +134,8 @@ namespace ShareX.UploadersLib.FileUploaders
                 {
                     if (result.ocs.data != null && result.ocs.meta.statuscode == 100)
                     {
-                        string link = result.ocs.data.url;
+                        OwnCloudShareResponseData data = ((JObject)result.ocs.data).ToObject<OwnCloudShareResponseData>();
+                        string link = data.url;
                         if (DirectLink) link += (IsCompatibility81 ? "/download" : "&download");
                         return link;
                     }
@@ -155,7 +157,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public class OwnCloudShareResponseOcs
         {
             public OwnCloudShareResponseMeta meta { get; set; }
-            public OwnCloudShareResponseData data { get; set; }
+            public object data { get; set; }
         }
 
         public class OwnCloudShareResponseMeta


### PR DESCRIPTION
Currently, when a file is uploaded, and an error is generated, a JSON
serialization error is thrown because of the unexpected JSON output.
This commit fixes that.

To illustrate the problem:

Current error:

![2015-11-28_02-21-14](https://cloud.githubusercontent.com/assets/7365586/11449490/02d1ffe6-9578-11e5-8bef-a0ae9cf38422.png)

Error after this fix:

![2015-11-28_02-29-40](https://cloud.githubusercontent.com/assets/7365586/11449491/0930c17e-9578-11e5-95f0-cbe863509007.png)