### PR TITLE
fixes issue with hash in filename when uploading to owncloud

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -67,8 +67,12 @@ namespace ShareX.UploadersLib.FileUploaders
                 Path = "/";
             }
 
+            // Original, unencoded path. Necessary for shared files
             string path = URLHelpers.CombineURL(Path, fileName);
-            string url = URLHelpers.CombineURL(Host, "remote.php/webdav", path);
+            // Encoded path (# replaced by %23), necessary when sent in the URL
+            string encodedPath = URLHelpers.CombineURL(Path, fileName.Replace("#", "%23"));
+
+            string url = URLHelpers.CombineURL(Host, "remote.php/webdav", encodedPath);
             url = URLHelpers.FixPrefix(url);
             NameValueCollection headers = CreateAuthenticationHeader(Username, Password);
 

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -69,8 +69,8 @@ namespace ShareX.UploadersLib.FileUploaders
 
             // Original, unencoded path. Necessary for shared files
             string path = URLHelpers.CombineURL(Path, fileName);
-            // Encoded path (# replaced by %23), necessary when sent in the URL
-            string encodedPath = URLHelpers.CombineURL(Path, fileName.Replace("#", "%23"));
+            // Encoded path, necessary when sent in the URL
+            string encodedPath = URLHelpers.CombineURL(Path, URLHelpers.URLEncode(fileName));
 
             string url = URLHelpers.CombineURL(Host, "remote.php/webdav", encodedPath);
             url = URLHelpers.FixPrefix(url);


### PR DESCRIPTION
This fixes an issue where a file in a hash would cause the uploaded
file to be truncated after the hash, causing the share function to
fail subsequentially because the file was not found. Only the PUT
request to upload the file requires the hash to be encoded, as it's
part of the URL, while the POST request for the share has the path in
the POST parameters.

closes #1148.

Illustration:

Currently:

![2015-11-28_02-06-37](https://cloud.githubusercontent.com/assets/7365586/11449494/229ad0d2-9578-11e5-96c3-e58107d73d54.png)

After fix:

![2015-11-28_01-56-34](https://cloud.githubusercontent.com/assets/7365586/11449495/3059893e-9578-11e5-871d-a953fe180e16.png)