### PR TITLE
Added post capture task to show in explorer #1265

### DIFF
--- a/ShareX.HelpersLib/Properties/Resources.Designer.cs
+++ b/ShareX.HelpersLib/Properties/Resources.Designer.cs
@@ -197,6 +197,15 @@ namespace ShareX.HelpersLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show file in explorer.
+        /// </summary>
+        internal static string AfterCaptureTasks_ShowInExplorer {
+            get {
+                return ResourceManager.GetString("AfterCaptureTasks_ShowInExplorer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Upload image to host.
         /// </summary>
         internal static string AfterCaptureTasks_UploadImageToHost {

--- a/ShareX.HelpersLib/Properties/Resources.resx
+++ b/ShareX.HelpersLib/Properties/Resources.resx
@@ -540,6 +540,9 @@ File size: {2:n0} / {3:n0} KB</value>
   <data name="AfterCaptureTasks_SaveImageToFileWithDialog" xml:space="preserve">
     <value>Save image to file as...</value>
   </data>
+  <data name="AfterCaptureTasks_ShowInExplorer" xml:space="preserve">
+    <value>Show file in explorer</value>
+  </data>
   <data name="AfterCaptureTasks_SaveThumbnailImageToFile" xml:space="preserve">
     <value>Save thumbnail image to file</value>
   </data>

--- a/ShareX/Enums.cs
+++ b/ShareX/Enums.cs
@@ -101,10 +101,10 @@ namespace ShareX
         PerformActions = 1 << 8,
         CopyFileToClipboard = 1 << 9,
         CopyFilePathToClipboard = 1 << 10,
-        ShowBeforeUploadWindow = 1 << 11,
-        UploadImageToHost = 1 << 12,
-        DeleteFile = 1 << 13,
-        ShowInExplorer = 1 << 14
+        ShowInExplorer = 1 << 11,
+        ShowBeforeUploadWindow = 1 << 12,
+        UploadImageToHost = 1 << 13,
+        DeleteFile = 1 << 14
     }
 
     [Flags]

--- a/ShareX/Enums.cs
+++ b/ShareX/Enums.cs
@@ -103,7 +103,8 @@ namespace ShareX
         CopyFilePathToClipboard = 1 << 10,
         ShowBeforeUploadWindow = 1 << 11,
         UploadImageToHost = 1 << 12,
-        DeleteFile = 1 << 13
+        DeleteFile = 1 << 13,
+        ShowInExplorer = 1 << 14
     }
 
     [Flags]

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -857,17 +857,5 @@ namespace ShareX
                 Helpers.PlaySoundAsync(Resources.ErrorSound);
             }
         }
-
-        public static void ShowFileInWindowsExplorer(string filePath)
-        {
-            using (Process p = new Process())
-            {
-                if (!string.IsNullOrEmpty(filePath) && File.Exists(filePath))
-                {
-                    p.StartInfo = new ProcessStartInfo("explorer.exe", string.Format(@"/select, ""{0}""", filePath));
-                    p.Start();
-                }
-            }
-        }
     }
 }

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -857,5 +857,17 @@ namespace ShareX
                 Helpers.PlaySoundAsync(Resources.ErrorSound);
             }
         }
+
+        public static void ShowFileInWindowsExplorer(string filePath)
+        {
+            using (Process p = new Process())
+            {
+                if (!string.IsNullOrEmpty(filePath) && File.Exists(filePath))
+                {
+                    p.StartInfo = new ProcessStartInfo("explorer.exe", string.Format(@"/select, ""{0}""", filePath));
+                    p.Start();
+                }
+            }
+        }
     }
 }

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -655,6 +655,11 @@ namespace ShareX
                 {
                     ClipboardHelpers.CopyText(Info.FilePath);
                 }
+
+                if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.ShowInExplorer))
+                {
+                    TaskHelpers.ShowFileInWindowsExplorer(Info.FilePath);
+                }
             }
         }
 

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -658,7 +658,7 @@ namespace ShareX
 
                 if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.ShowInExplorer))
                 {
-                    TaskHelpers.ShowFileInWindowsExplorer(Info.FilePath);
+                    Helpers.OpenFolderWithFile(Info.FilePath);
                 }
             }
         }


### PR DESCRIPTION
I've implemented the functionality discussed in #1265. This has been added as an After Capture task that can be enabled. If enabled it shows windows explorer after capture with the new screenshot highlighted. See screenshots below.
![2016-01-19_23-08-48](https://cloud.githubusercontent.com/assets/838529/12435007/6ec0dc6e-bf02-11e5-9a04-dbd685370293.png)
![explorer_2016-01-19_23-10-10](https://cloud.githubusercontent.com/assets/838529/12435006/6ebcb35a-bf02-11e5-83b1-a588f879c227.png)

I've added the localized translation for English for 'Show file in explorer'. I wasn't sure how you do the translations for the other resource files?

Please let me know if there are any issues.
Thanks

