### PR TITLE
Handle multiple context menu selections - Move semaphore release

### DIFF
--- a/ShareX.HelpersLib/SingleInstanceApplication/ApplicationInstanceManager.cs
+++ b/ShareX.HelpersLib/SingleInstanceApplication/ApplicationInstanceManager.cs
@@ -54,8 +54,6 @@ namespace SingleInstanceApplication
                     UpdateRemoteObject(name);
 
                     if (eventWaitHandle != null) eventWaitHandle.Set();
-
-                    semaphore.Release();
                 }
 
                 Environment.Exit(0);
@@ -125,6 +123,8 @@ namespace SingleInstanceApplication
             if (callback == null) return;
 
             callback(state, new InstanceCallbackEventArgs(InstanceProxy.IsFirstInstance, InstanceProxy.CommandLineArgs));
+
+            semaphore.Release();
         }
     }
 }


### PR DESCRIPTION
Current process is as follows:
1. Invoked .exe gets the semaphore
2. Invoked .exe sets `InstanceProxy` values in running exe
3. Invoked .exe causes thread to spawn in running exe
4. New thread in running .exe reads values from `InstanceProxy`
5. Invoked .exe releases the semaphore

The problem is that there is no guarantee on how fast new threads in
running .exe will spawn and read values from `InstanceProxy`. This PR
addresses that by moving the semaphore release from the invoked .exe to
the thread spawned in running .exe.

This means that an invoked .exe can't change `InstanceProxy` until 
running .exe has processed the previous call.