### PR TITLE
Proper Single Instance Implementation

### DIFF
--- a/ShareX.HelpersLib/SingleInstanceApplication/InstanceProxy.cs
+++ b/ShareX.HelpersLib/SingleInstanceApplication/InstanceProxy.cs
@@ -32,26 +32,20 @@ namespace SingleInstanceApplication
     [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
     internal class InstanceProxy : MarshalByRefObject
     {
-        public static bool IsFirstInstance { get; internal set; }
-
         public static string[] CommandLineArgs { get; internal set; }
 
-        public void SetCommandLineArgs(bool isFirstInstance, string[] commandLineArgs)
+        public void SetCommandLineArgs(string[] commandLineArgs)
         {
-            IsFirstInstance = isFirstInstance;
             CommandLineArgs = commandLineArgs;
         }
     }
 
     public class InstanceCallbackEventArgs : EventArgs
     {
-        internal InstanceCallbackEventArgs(bool isFirstInstance, string[] commandLineArgs)
+        internal InstanceCallbackEventArgs(string[] commandLineArgs)
         {
-            IsFirstInstance = isFirstInstance;
             CommandLineArgs = commandLineArgs;
         }
-
-        public bool IsFirstInstance { get; private set; }
 
         public string[] CommandLineArgs { get; private set; }
     }


### PR DESCRIPTION
Reworked single instance code to better handle being launched with
context menu.

Previously:
- On launch, process would try to open an `EventWaitHandle`. If it
didn't exist, then process assumed it was first and created it
- Multiple processes launching at same time would all see the
`EventWaitHandle` did not exist before any process could create it
- This led to multiple instances of program running (as discussed at https://github.com/ShareX/ShareX/pull/1382#issuecomment-194561241)

Now a mutex is used for proper synchronization:
- Processes will all try to open the mutex. Only first one will succeed
- Process that opens the mutex will setup the `EventWaitHandle`
- Other processes won't get the mutex and will be directed to use the
`EventWaitHandle` to pass their command line args to the running
instance

Notes:
 - Currently, there is a 100ms wait for the mutex before it times out.
This works fine for my testing, but might need to be higher if there
are problems when invoking from context menu and ShareX isn't 
already running
 - Everything works fine in my testing, but this will need to be more 
widely tested. Any problems should only be seen when using context
menu to Upload or Send To or using `-multi` command line parameter