### PR TITLE
[WIP] Refactoring uploaders using Inversion of Control

### DIFF
--- a/ShareX.HelpersLib/ServiceLocator.cs
+++ b/ShareX.HelpersLib/ServiceLocator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using SimpleInjector;
+
+namespace ShareX.HelpersLib
+{
+    public static class ServiceLocator
+    {
+        private static Container Container;
+
+        public static void SetContainer(Container container)
+        {
+            Container = container;
+        }
+
+        public static TService GetInstance<TService>() where TService : class
+        {
+            EnsureContainerIsSet();
+            return Container.GetInstance<TService>();
+        }
+
+        private static void EnsureContainerIsSet()
+        {
+            if (Container == null)
+                throw new InvalidOperationException(@"ServiceLocator used before a container was set");
+        }
+    }
+}

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -74,6 +74,10 @@
       <HintPath>..\packages\SevenZipSharp.0.64\lib\SevenZipSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
@@ -197,6 +201,7 @@
     <Compile Include="Controls\TabToTreeView.Designer.cs">
       <DependentUpon>TabToTreeView.cs</DependentUpon>
     </Compile>
+    <Compile Include="ServiceLocator.cs" />
     <Compile Include="TaskEx.cs" />
     <Compile Include="TextBoxTraceListener.cs" />
     <Compile Include="UITypeEditors\EnumDescriptionConverter.cs" />

--- a/ShareX.HelpersLib/packages.config
+++ b/ShareX.HelpersLib/packages.config
@@ -3,4 +3,5 @@
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
   <package id="QrCode.Net" version="0.4.0.0" targetFramework="net40" />
   <package id="SevenZipSharp" version="0.64" targetFramework="net40" />
+  <package id="SimpleInjector" version="3.1.2" targetFramework="net40" />
 </packages>

--- a/ShareX.UploadersLib/Controls/BaseConfigControl.Designer.cs
+++ b/ShareX.UploadersLib/Controls/BaseConfigControl.Designer.cs
@@ -1,0 +1,46 @@
+namespace ShareX.UploadersLib.Controls
+{
+    partial class BaseConfigControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.SuspendLayout();
+            // 
+            // BaseConfigControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.Name = "BaseConfigControl";
+            this.Size = new System.Drawing.Size(972, 493);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+    }
+}

--- a/ShareX.UploadersLib/Controls/BaseConfigControl.cs
+++ b/ShareX.UploadersLib/Controls/BaseConfigControl.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace ShareX.UploadersLib.Controls
+{
+    public partial class BaseConfigControl : UserControl
+    {
+        public BaseConfigControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ShareX.UploadersLib/Controls/BaseConfigControl.resx
+++ b/ShareX.UploadersLib/Controls/BaseConfigControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -77,7 +77,7 @@ namespace ShareX.UploadersLib
             AddControlsToTab(tcTextUploaders, servicesFactory.TextUpload);
         }
 
-        private void AddControlsToTab<TService, TEnum>(TabControl uploadTab, IServiceFactory<TService, TEnum> serviceFactory)
+        private void AddControlsToTab<TService, TEnum>(TabControl uploadTab, IUploadServiceFactory<TService, TEnum> serviceFactory)
             where TService : IUploadService<TEnum>
         {
             IEnumerable<TService> uploadServices = serviceFactory.GetAllServices();

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -36,6 +36,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using ShareX.UploadersLib.Controls;
 
 namespace ShareX.UploadersLib
 {
@@ -43,11 +44,13 @@ namespace ShareX.UploadersLib
     {
         public UploadersConfig Config { get; private set; }
 
+        private readonly IUploadServicesFactory servicesFactory;
         private ImageList uploadersImageList;
         private URLType urlType = URLType.URL;
 
         public UploadersConfigForm(UploadersConfig uploadersConfig)
         {
+            servicesFactory = ServiceLocator.GetInstance<IUploadServicesFactory>();
             Config = uploadersConfig;
             InitializeComponent();
             Icon = ShareXResources.Icon;
@@ -69,10 +72,58 @@ namespace ShareX.UploadersLib
             Refresh();
         }
 
+        private void AddControls()
+        {
+            AddControlsToTab(tcTextUploaders, servicesFactory.TextUpload);
+        }
+
+        private void AddControlsToTab<TService, TEnum>(TabControl uploadTab, IServiceFactory<TService, TEnum> serviceFactory)
+            where TService : IUploadService<TEnum>
+        {
+            IEnumerable<TService> uploadServices = serviceFactory.GetAllServices();
+
+            foreach (TService uploadService in uploadServices)
+            {
+                IUploadServiceConfig serviceConfig = uploadService.CreateConfig();
+                if (serviceConfig == null)
+                    continue;
+
+                Control configControl = serviceConfig.CreateConfigControl(Config);
+                configControl.BackColor = Color.Transparent;
+
+                var tabPage = new TabPage();
+                tabPage.Text = serviceConfig.TabText;
+                tabPage.Name = uploadService.ServiceId;
+                tabPage.BackColor = Color.Transparent;
+                tabPage.UseVisualStyleBackColor = true;
+                tabPage.Controls.Add(configControl);
+
+                object tabImage = serviceConfig.TabImage;
+                if (tabImage != null)
+                {
+                    var icon = tabImage as Icon;
+                    if (icon != null)
+                    {
+                        AddIconToTab(tabPage, icon);
+                    }
+
+                    var bitmap = tabImage as Bitmap;
+                    if (bitmap != null)
+                    {
+                        AddIconToTab(tabPage, bitmap);
+                    }
+                }
+
+                uploadTab.Controls.Add(tabPage);
+            }
+        }
+
         private void FormSettings()
         {
             uploadersImageList = new ImageList();
             uploadersImageList.ColorDepth = ColorDepth.Depth32Bit;
+
+            AddControls();
 
             AddIconToTab(tpAdFly, Resources.AdFly);
             AddIconToTab(tpAmazonS3, Resources.AmazonS3);

--- a/ShareX.UploadersLib/IURLShortener.cs
+++ b/ShareX.UploadersLib/IURLShortener.cs
@@ -1,6 +1,6 @@
 ﻿namespace ShareX.UploadersLib
 {
-    public interface IURLShortener
+    public interface IURLShortener : IUploader
     {
         UploadResult ShortenURL(string url);
     }

--- a/ShareX.UploadersLib/IURLShortener.cs
+++ b/ShareX.UploadersLib/IURLShortener.cs
@@ -1,0 +1,7 @@
+﻿namespace ShareX.UploadersLib
+{
+    public interface IURLShortener
+    {
+        UploadResult ShortenURL(string url);
+    }
+}

--- a/ShareX.UploadersLib/IURLShortenerService.cs
+++ b/ShareX.UploadersLib/IURLShortenerService.cs
@@ -33,7 +33,7 @@ namespace ShareX.UploadersLib
         ITextUploader CreateUploader(UploadersConfig config, string textFormat);
     }
 
-    public interface IServiceFactory<out TService, in TEnum>
+    public interface IUploadServiceFactory<out TService, in TEnum>
         where TService : IUploadService<TEnum>
     {
         TService GetServiceById(string serviceId);
@@ -43,11 +43,11 @@ namespace ShareX.UploadersLib
         IEnumerable<TService> GetAllServices();
     }
 
-    public interface IURLShortenerServiceFactory : IServiceFactory<IURLShortenerService, UrlShortenerType>
+    public interface IURLShortenerServiceFactory : IUploadServiceFactory<IURLShortenerService, UrlShortenerType>
     {
     }
 
-    internal abstract class UploadServiceFactory<TService, TEnum> : IServiceFactory<TService, TEnum>
+    internal abstract class UploadServiceFactory<TService, TEnum> : IUploadServiceFactory<TService, TEnum>
         where TService : IUploadService<TEnum>
     {
         private readonly IEnumerable<IUploadService<TEnum>> _services;
@@ -87,7 +87,7 @@ namespace ShareX.UploadersLib
         }
     }
 
-    public interface ITextUploadServiceFactory : IServiceFactory<ITextUploadService, TextDestination>
+    public interface ITextUploadServiceFactory : IUploadServiceFactory<ITextUploadService, TextDestination>
     {
     }
 

--- a/ShareX.UploadersLib/IURLShortenerService.cs
+++ b/ShareX.UploadersLib/IURLShortenerService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using ShareX.UploadersLib.Controls;
 
 namespace ShareX.UploadersLib
 {
@@ -10,6 +11,16 @@ namespace ShareX.UploadersLib
         string ServiceId { get; }
 
         TEnum EnumValue { get; }
+
+        IUploadServiceConfig CreateConfig();
+    }
+
+    public interface IUploadServiceConfig
+    {
+        string TabText { get; }
+        object TabImage { get; }
+
+        BaseConfigControl CreateConfigControl(UploadersConfig config);
     }
 
     public interface IURLShortenerService : IUploadService<UrlShortenerType>
@@ -28,6 +39,8 @@ namespace ShareX.UploadersLib
         TService GetServiceById(string serviceId);
 
         TService GetServiceByEnumValue(TEnum enumValue);
+
+        IEnumerable<TService> GetAllServices();
     }
 
     public interface IURLShortenerServiceFactory : IServiceFactory<IURLShortenerService, UrlShortenerType>
@@ -53,6 +66,8 @@ namespace ShareX.UploadersLib
         {
             return (TService)_services.FirstOrDefault(s => enumValue.Equals(s.EnumValue));
         }
+
+        public IEnumerable<TService> GetAllServices() => _services.Cast<TService>();
     }
 
     internal class URLShortenerServiceFactory : UploadServiceFactory<IURLShortenerService, UrlShortenerType>, IURLShortenerServiceFactory
@@ -63,7 +78,7 @@ namespace ShareX.UploadersLib
         }
     }
 
-    internal class TextUploadServiceFactory : UploadServiceFactory<ITextUploadService, TextDestination>, ITextUploaderServiceFactory
+    internal class TextUploadServiceFactory : UploadServiceFactory<ITextUploadService, TextDestination>, ITextUploadServiceFactory
     {
 
         public TextUploadServiceFactory(IEnumerable<ITextUploadService> services)
@@ -72,7 +87,26 @@ namespace ShareX.UploadersLib
         }
     }
 
-    public interface ITextUploaderServiceFactory : IServiceFactory<ITextUploadService, TextDestination>
+    public interface ITextUploadServiceFactory : IServiceFactory<ITextUploadService, TextDestination>
     {
+    }
+
+    public interface IUploadServicesFactory
+    {
+        ITextUploadServiceFactory TextUpload { get; }
+
+        IURLShortenerServiceFactory URLShortener { get; }
+    }
+
+    internal class UploadServicesFactory : IUploadServicesFactory
+    {
+        public ITextUploadServiceFactory TextUpload { get; }
+        public IURLShortenerServiceFactory URLShortener { get; }
+
+        public UploadServicesFactory(ITextUploadServiceFactory textUpload, IURLShortenerServiceFactory urlShortener)
+        {
+            TextUpload = textUpload;
+            URLShortener = urlShortener;
+        }
     }
 }

--- a/ShareX.UploadersLib/IURLShortenerService.cs
+++ b/ShareX.UploadersLib/IURLShortenerService.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace ShareX.UploadersLib
+{
+    public interface IURLShortenerService
+    {
+        [Localizable(false)]
+        string ServiceId { get; }
+
+        UrlShortenerType EnumValue { get; }
+
+        IURLShortener CreateShortener(UploadersConfig config);
+    }
+
+    public interface IServiceFactory<out TService, in TEnum>
+    {
+        TService GetServiceById(string serviceId);
+
+        TService GetServiceByEnumValue(TEnum enumValue);
+    }
+
+    public interface IURLShortenerServiceFactory : IServiceFactory<IURLShortenerService, UrlShortenerType>
+    {
+    }
+
+    internal class URLShortenerServiceFactory : IURLShortenerServiceFactory
+    {
+        private readonly IEnumerable<IURLShortenerService> _services;
+
+        public URLShortenerServiceFactory(IEnumerable<IURLShortenerService> services)
+        {
+            _services = services;
+        }
+
+        public IURLShortenerService GetServiceById(string serviceId)
+        {
+            return _services.FirstOrDefault(s => s.ServiceId == serviceId);
+        }
+
+        public IURLShortenerService GetServiceByEnumValue(UrlShortenerType enumValue)
+        {
+            return _services.FirstOrDefault(s => s.EnumValue == enumValue);
+        }
+    }
+}

--- a/ShareX.UploadersLib/IoCRegistrant.cs
+++ b/ShareX.UploadersLib/IoCRegistrant.cs
@@ -38,7 +38,8 @@ namespace ShareX.UploadersLib
             container.RegisterCollection<ITextUploadService>(uploaderAssembly);
 
             container.RegisterSingleton<IURLShortenerServiceFactory, URLShortenerServiceFactory>();
-            container.RegisterSingleton<ITextUploaderServiceFactory, TextUploadServiceFactory>();
+            container.RegisterSingleton<ITextUploadServiceFactory, TextUploadServiceFactory>();
+            container.RegisterSingleton<IUploadServicesFactory, UploadServicesFactory>();
         }
     }
 }

--- a/ShareX.UploadersLib/IoCRegistrant.cs
+++ b/ShareX.UploadersLib/IoCRegistrant.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using SimpleInjector;
+
+namespace ShareX.UploadersLib
+{
+    public static class IoCRegistrant
+    {
+        public static void Register(Container container)
+        {
+            Assembly[] uploaderAssembly = new[] { typeof(IoCRegistrant).Assembly };
+
+            container.RegisterCollection<IURLShortenerService>(uploaderAssembly);
+
+            container.RegisterSingleton<IURLShortenerServiceFactory, URLShortenerServiceFactory>();
+        }
+    }
+}

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -220,6 +220,10 @@
     <Compile Include="IURLShortenerService.cs" />
     <Compile Include="TextUploaders\Hastebin.cs" />
     <Compile Include="TextUploaders\OneTimeSecret.cs" />
+    <Compile Include="TextUploaders\Pastee\PasteeTextUploader.cs" />
+    <Compile Include="TextUploaders\Pastee\PasteeTextUploadService.cs" />
+    <Compile Include="TextUploaders\Paste_ee\Paste_eeTextUploader.cs" />
+    <Compile Include="TextUploaders\Paste_ee\Paste_eeTextUploadService.cs" />
     <Compile Include="TextUploaders\Upaste.cs" />
     <Compile Include="UploadersConfig.cs" />
     <Compile Include="Forms\UserPassBox.cs">
@@ -269,7 +273,6 @@
     <Compile Include="ImageUploaders\Picasa.cs" />
     <Compile Include="TextUploaders\CustomTextUploader.cs" />
     <Compile Include="TextUploaders\Gist.cs" />
-    <Compile Include="TextUploaders\Paste_ee.cs" />
     <Compile Include="UploadResult.cs" />
     <Compile Include="Forms\TwitterTweetForm.cs">
       <SubType>Form</SubType>
@@ -306,13 +309,15 @@
     <Compile Include="TextUploaders\Paste2.cs" />
     <Compile Include="TextUploaders\Pastebin_ca.cs" />
     <Compile Include="TextUploaders\Pastebin.cs" />
-    <Compile Include="TextUploaders\Pastee.cs" />
     <Compile Include="TextUploaders\Slexy.cs" />
     <Compile Include="Uploader.cs" />
     <Compile Include="URLShortener.cs" />
+    <Compile Include="URLShorteners\AdFly\AdFlyURLShortener.cs" />
+    <Compile Include="URLShorteners\AdFly\AdFlyURLShortenerService.cs" />
     <Compile Include="URLShorteners\PolrURLShortener.cs" />
+    <Compile Include="URLShorteners\TinyURL\TinyURLShortener.cs" />
+    <Compile Include="URLShorteners\TinyURL\TinyURLShortenerService.cs" />
     <Compile Include="URLShorteners\TwoGPURLShortener.cs" />
-    <Compile Include="URLShorteners\AdFlyURLShortener.cs" />
     <Compile Include="URLShorteners\BitlyURLShortener.cs" />
     <Compile Include="URLShorteners\CoinURLShortener.cs" />
     <Compile Include="URLShorteners\CustomURLShortener.cs" />
@@ -320,7 +325,6 @@
     <Compile Include="URLShorteners\IsgdURLShortener.cs" />
     <Compile Include="URLShorteners\NlcmURLShortener.cs" />
     <Compile Include="URLShorteners\QRnetURLShortener.cs" />
-    <Compile Include="URLShorteners\TinyURLShortener.cs" />
     <Compile Include="URLShorteners\TurlURLShortener.cs" />
     <Compile Include="FileUploaders\MediaCrushUploader.cs" />
     <Compile Include="URLShorteners\VgdURLShortener.cs" />
@@ -900,6 +904,7 @@
   <ItemGroup>
     <Analyzer Include="..\packages\AWSSDK.S3.3.1.4.0\analyzers\dotnet\cs\AWSSDK.S3.CodeAnalysis.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -101,6 +101,10 @@
     <Reference Include="Security.Cryptography">
       <HintPath>..\Lib\Security.Cryptography.dll</HintPath>
     </Reference>
+    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
@@ -211,6 +215,9 @@
     <Compile Include="ImageUploaders\ImglandUploader.cs" />
     <Compile Include="ImageUploaders\SomeImage.cs" />
     <Compile Include="ImageUploaders\VgymeUploader.cs" />
+    <Compile Include="IoCRegistrant.cs" />
+    <Compile Include="IURLShortener.cs" />
+    <Compile Include="IURLShortenerService.cs" />
     <Compile Include="TextUploaders\Hastebin.cs" />
     <Compile Include="TextUploaders\OneTimeSecret.cs" />
     <Compile Include="TextUploaders\Upaste.cs" />

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -106,6 +106,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.FtpClient, Version=1.0.5281.14359, Culture=neutral, PublicKeyToken=fa4be07daa57c2b7, processorArchitecture=MSIL">
@@ -124,6 +125,12 @@
   <ItemGroup>
     <Compile Include="APIKeys\APIKeys.cs" />
     <Compile Include="APIKeys\APIKeysLocal.cs" />
+    <Compile Include="Controls\BaseConfigControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\BaseConfigControl.Designer.cs">
+      <DependentUpon>BaseConfigControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="FileUploaders\AmazonS3Region.cs" />
     <Compile Include="FileUploaders\AmazonS3Settings.cs" />
     <Compile Include="FileUploaders\Box.cs" />
@@ -222,6 +229,12 @@
     <Compile Include="TextUploaders\OneTimeSecret.cs" />
     <Compile Include="TextUploaders\Pastee\PasteeTextUploader.cs" />
     <Compile Include="TextUploaders\Pastee\PasteeTextUploadService.cs" />
+    <Compile Include="TextUploaders\Paste_ee\Paste_eeConfigControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="TextUploaders\Paste_ee\Paste_eeConfigControl.Designer.cs">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="TextUploaders\Paste_ee\Paste_eeTextUploader.cs" />
     <Compile Include="TextUploaders\Paste_ee\Paste_eeTextUploadService.cs" />
     <Compile Include="TextUploaders\Upaste.cs" />
@@ -398,6 +411,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\AccountTypeControl.zh-CN.resx">
       <DependentUpon>AccountTypeControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Controls\BaseConfigControl.resx">
+      <DependentUpon>BaseConfigControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\OAuthControl.de.resx">
       <DependentUpon>OAuthControl.cs</DependentUpon>
@@ -786,6 +802,9 @@
     <EmbeddedResource Include="Properties\Resources.tr.resx" />
     <EmbeddedResource Include="Properties\Resources.vi-VN.resx" />
     <EmbeddedResource Include="Properties\Resources.zh-CN.resx" />
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -802,7 +802,40 @@
     <EmbeddedResource Include="Properties\Resources.tr.resx" />
     <EmbeddedResource Include="Properties\Resources.vi-VN.resx" />
     <EmbeddedResource Include="Properties\Resources.zh-CN.resx" />
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.de.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.es.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.fr.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.hu.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.ko-KR.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.nl-NL.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.pt-BR.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.ru.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.tr.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.vi-VN.resx">
+      <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="TextUploaders\Paste_ee\Paste_eeConfigControl.zh-CN.resx">
       <DependentUpon>Paste_eeConfigControl.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>

--- a/ShareX.UploadersLib/TextUploader.cs
+++ b/ShareX.UploadersLib/TextUploader.cs
@@ -28,7 +28,13 @@ using System.Text;
 
 namespace ShareX.UploadersLib
 {
-    public abstract class TextUploader : Uploader
+    public interface ITextUploader : IUploader
+    {
+        UploadResult UploadText(string text, string fileName);
+        UploadResult UploadText(Stream stream, string fileName);
+    }
+
+    public abstract class TextUploader : Uploader, ITextUploader
     {
         public abstract UploadResult UploadText(string text, string fileName);
 

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.Designer.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.Designer.cs
@@ -28,32 +28,26 @@
         /// </summary>
         private void InitializeComponent()
         {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Paste_eeConfigControl));
             this.lblPaste_eeUserAPIKey = new System.Windows.Forms.Label();
             this.txtPaste_eeUserAPIKey = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
             // 
             // lblPaste_eeUserAPIKey
             // 
-            this.lblPaste_eeUserAPIKey.AutoSize = true;
-            this.lblPaste_eeUserAPIKey.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblPaste_eeUserAPIKey.Location = new System.Drawing.Point(17, 16);
+            resources.ApplyResources(this.lblPaste_eeUserAPIKey, "lblPaste_eeUserAPIKey");
             this.lblPaste_eeUserAPIKey.Name = "lblPaste_eeUserAPIKey";
-            this.lblPaste_eeUserAPIKey.Size = new System.Drawing.Size(72, 13);
-            this.lblPaste_eeUserAPIKey.TabIndex = 2;
-            this.lblPaste_eeUserAPIKey.Text = "User API key:";
             // 
             // txtPaste_eeUserAPIKey
             // 
-            this.txtPaste_eeUserAPIKey.Location = new System.Drawing.Point(20, 32);
+            resources.ApplyResources(this.txtPaste_eeUserAPIKey, "txtPaste_eeUserAPIKey");
             this.txtPaste_eeUserAPIKey.Name = "txtPaste_eeUserAPIKey";
-            this.txtPaste_eeUserAPIKey.Size = new System.Drawing.Size(296, 20);
-            this.txtPaste_eeUserAPIKey.TabIndex = 3;
             this.txtPaste_eeUserAPIKey.UseSystemPasswordChar = true;
             this.txtPaste_eeUserAPIKey.TextChanged += new System.EventHandler(this.txtPaste_eeUserAPIKey_TextChanged);
             // 
             // Paste_eeConfigControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            resources.ApplyResources(this, "$this");
             this.Controls.Add(this.lblPaste_eeUserAPIKey);
             this.Controls.Add(this.txtPaste_eeUserAPIKey);
             this.Name = "Paste_eeConfigControl";

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.Designer.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.Designer.cs
@@ -1,0 +1,70 @@
+﻿namespace ShareX.UploadersLib.TextUploaders.Paste_ee
+{
+    partial class Paste_eeConfigControl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblPaste_eeUserAPIKey = new System.Windows.Forms.Label();
+            this.txtPaste_eeUserAPIKey = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // lblPaste_eeUserAPIKey
+            // 
+            this.lblPaste_eeUserAPIKey.AutoSize = true;
+            this.lblPaste_eeUserAPIKey.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.lblPaste_eeUserAPIKey.Location = new System.Drawing.Point(17, 16);
+            this.lblPaste_eeUserAPIKey.Name = "lblPaste_eeUserAPIKey";
+            this.lblPaste_eeUserAPIKey.Size = new System.Drawing.Size(72, 13);
+            this.lblPaste_eeUserAPIKey.TabIndex = 2;
+            this.lblPaste_eeUserAPIKey.Text = "User API key:";
+            // 
+            // txtPaste_eeUserAPIKey
+            // 
+            this.txtPaste_eeUserAPIKey.Location = new System.Drawing.Point(20, 32);
+            this.txtPaste_eeUserAPIKey.Name = "txtPaste_eeUserAPIKey";
+            this.txtPaste_eeUserAPIKey.Size = new System.Drawing.Size(296, 20);
+            this.txtPaste_eeUserAPIKey.TabIndex = 3;
+            this.txtPaste_eeUserAPIKey.UseSystemPasswordChar = true;
+            this.txtPaste_eeUserAPIKey.TextChanged += new System.EventHandler(this.txtPaste_eeUserAPIKey_TextChanged);
+            // 
+            // Paste_eeConfigControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.Controls.Add(this.lblPaste_eeUserAPIKey);
+            this.Controls.Add(this.txtPaste_eeUserAPIKey);
+            this.Name = "Paste_eeConfigControl";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblPaste_eeUserAPIKey;
+        private System.Windows.Forms.TextBox txtPaste_eeUserAPIKey;
+    }
+}

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using ShareX.UploadersLib.Controls;
+
+namespace ShareX.UploadersLib.TextUploaders.Paste_ee
+{
+    public partial class Paste_eeConfigControl : BaseConfigControl
+    {
+        private readonly UploadersConfig config;
+
+        public Paste_eeConfigControl(UploadersConfig config)
+        {
+            this.config = config;
+
+            InitializeComponent();
+
+            txtPaste_eeUserAPIKey.Text = config.Paste_eeUserAPIKey;
+        }
+
+        private void txtPaste_eeUserAPIKey_TextChanged(object sender, EventArgs e)
+        {
+            config.Paste_eeUserAPIKey = txtPaste_eeUserAPIKey.Text;
+        }
+    }
+}

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.de.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.de.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Benutzer API Schlüssel:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.es.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.es.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Clave de API de usuario:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.fr.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.fr.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Clé API de l'utilisateur:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.hu.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.hu.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Felhasználói API kulcs:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.ko-KR.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.ko-KR.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>사용자 API 키:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.nl-NL.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.nl-NL.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Gebruikers API sleutel:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.pt-BR.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.pt-BR.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Chave de API do usuário:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.ru.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.ru.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>API ключ пользователя:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.tr.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.tr.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Kullanıcı API anahtarı:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.vi-VN.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.vi-VN.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>API key người dùng:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.zh-CN.resx
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeConfigControl.zh-CN.resx
@@ -117,70 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblPaste_eeUserAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="lblPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
-  </data>
-  <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="lblPaste_eeUserAPIKey.Text" xml:space="preserve">
-    <value>User API key:</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
-  </data>
-  <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>Paste_eeConfigControl</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.Controls.BaseConfigControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>用户API密钥:</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploadService.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploadService.cs
@@ -23,22 +23,16 @@
 
 #endregion License Information (GPL v3)
 
-using System.Reflection;
-using SimpleInjector;
-
-namespace ShareX.UploadersLib
+namespace ShareX.UploadersLib.TextUploaders.Paste_ee
 {
-    public static class IoCRegistrant
+    internal sealed class Paste_eeTextUploadService : ITextUploadService
     {
-        public static void Register(Container container)
+        public string ServiceId { get; } = "Paste_ee";
+        public TextDestination EnumValue { get; } = TextDestination.Paste_ee;
+
+        public ITextUploader CreateUploader(UploadersConfig config, string textFormat)
         {
-            Assembly[] uploaderAssembly = new[] { typeof(IoCRegistrant).Assembly };
-
-            container.RegisterCollection<IURLShortenerService>(uploaderAssembly);
-            container.RegisterCollection<ITextUploadService>(uploaderAssembly);
-
-            container.RegisterSingleton<IURLShortenerServiceFactory, URLShortenerServiceFactory>();
-            container.RegisterSingleton<ITextUploaderServiceFactory, TextUploadServiceFactory>();
+            return new Paste_eeTextUploader(config.Paste_eeUserAPIKey);
         }
     }
 }

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploadService.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploadService.cs
@@ -23,6 +23,9 @@
 
 #endregion License Information (GPL v3)
 
+using ShareX.UploadersLib.Controls;
+using ShareX.UploadersLib.Properties;
+
 namespace ShareX.UploadersLib.TextUploaders.Paste_ee
 {
     internal sealed class Paste_eeTextUploadService : ITextUploadService
@@ -30,9 +33,25 @@ namespace ShareX.UploadersLib.TextUploaders.Paste_ee
         public string ServiceId { get; } = "Paste_ee";
         public TextDestination EnumValue { get; } = TextDestination.Paste_ee;
 
+        public IUploadServiceConfig CreateConfig()
+        {
+            return new Paste_eeUploadServiceConfig();
+        }
+
         public ITextUploader CreateUploader(UploadersConfig config, string textFormat)
         {
             return new Paste_eeTextUploader(config.Paste_eeUserAPIKey);
+        }
+    }
+
+    internal sealed class Paste_eeUploadServiceConfig : IUploadServiceConfig
+    {
+        public string TabText { get; } = "Paste.ee";
+        public object TabImage { get; } = Resources.page_white_text;
+
+        public BaseConfigControl CreateConfigControl(UploadersConfig config)
+        {
+            return new Paste_eeConfigControl(config);
         }
     }
 }

--- a/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploader.cs
+++ b/ShareX.UploadersLib/TextUploaders/Paste_ee/Paste_eeTextUploader.cs
@@ -1,42 +1,17 @@
-﻿#region License Information (GPL v3)
+﻿using System.Collections.Generic;
 
-/*
-    ShareX - A program that allows you to take screenshots and share any file type
-    Copyright (c) 2007-2016 ShareX Team
-
-    This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License
-    as published by the Free Software Foundation; either version 2
-    of the License, or (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
-*/
-
-#endregion License Information (GPL v3)
-
-using System.Collections.Generic;
-
-namespace ShareX.UploadersLib.TextUploaders
+namespace ShareX.UploadersLib.TextUploaders.Paste_ee
 {
-    public sealed class Paste_ee : TextUploader
+    internal sealed class Paste_eeTextUploader : TextUploader
     {
         public string APIKey { get; private set; }
 
-        public Paste_ee()
+        public Paste_eeTextUploader()
         {
             APIKey = "public";
         }
 
-        public Paste_ee(string apiKey)
+        public Paste_eeTextUploader(string apiKey)
         {
             APIKey = apiKey;
         }

--- a/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploadService.cs
+++ b/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploadService.cs
@@ -29,6 +29,10 @@ namespace ShareX.UploadersLib.TextUploaders.Pastee
     {
         public string ServiceId { get; } = "Pastee";
         public TextDestination EnumValue { get; } = TextDestination.Pastee;
+        public IUploadServiceConfig CreateConfig()
+        {
+            return null;
+        }
 
         public ITextUploader CreateUploader(UploadersConfig config, string textFormat)
         {

--- a/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploadService.cs
+++ b/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploadService.cs
@@ -23,22 +23,19 @@
 
 #endregion License Information (GPL v3)
 
-using System.Reflection;
-using SimpleInjector;
-
-namespace ShareX.UploadersLib
+namespace ShareX.UploadersLib.TextUploaders.Pastee
 {
-    public static class IoCRegistrant
+    internal class PasteeTextUploadService : ITextUploadService
     {
-        public static void Register(Container container)
+        public string ServiceId { get; } = "Pastee";
+        public TextDestination EnumValue { get; } = TextDestination.Pastee;
+
+        public ITextUploader CreateUploader(UploadersConfig config, string textFormat)
         {
-            Assembly[] uploaderAssembly = new[] { typeof(IoCRegistrant).Assembly };
-
-            container.RegisterCollection<IURLShortenerService>(uploaderAssembly);
-            container.RegisterCollection<ITextUploadService>(uploaderAssembly);
-
-            container.RegisterSingleton<IURLShortenerServiceFactory, URLShortenerServiceFactory>();
-            container.RegisterSingleton<ITextUploaderServiceFactory, TextUploadServiceFactory>();
+            return new PasteeTextUploader
+            {
+                Lexer = textFormat
+            };
         }
     }
 }

--- a/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploader.cs
+++ b/ShareX.UploadersLib/TextUploaders/Pastee/PasteeTextUploader.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -25,15 +25,15 @@
 
 using System.Collections.Generic;
 
-namespace ShareX.UploadersLib.TextUploaders
+namespace ShareX.UploadersLib.TextUploaders.Pastee
 {
-    public sealed class Pastee : TextUploader
+    public sealed class PasteeTextUploader : TextUploader
     {
         public string Lexer { get; set; }
         public int TimeToLive { get; set; } // Days
         public string Key { get; set; }
 
-        public Pastee()
+        public PasteeTextUploader()
         {
             Lexer = "text";
             TimeToLive = 30;

--- a/ShareX.UploadersLib/URLShortener.cs
+++ b/ShareX.UploadersLib/URLShortener.cs
@@ -25,7 +25,7 @@
 
 namespace ShareX.UploadersLib
 {
-    public abstract class URLShortener : Uploader
+    public abstract class URLShortener : Uploader, IURLShortener
     {
         public abstract UploadResult ShortenURL(string url);
     }

--- a/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortener.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace ShareX.UploadersLib.URLShorteners.AdFly
+{
+    public class AdFlyURLShortener : URLShortener
+    {
+        public string APIKEY { get; set; }
+        public string APIUID { get; set; }
+
+        public override UploadResult ShortenURL(string url)
+        {
+            UploadResult result = new UploadResult { URL = url };
+
+            Dictionary<string, string> args = new Dictionary<string, string>();
+            args.Add("key", APIKEY);
+            args.Add("uid", APIUID);
+            args.Add("advert_type", "int");
+            args.Add("domain", "adf.ly");
+            args.Add("url", url);
+
+            string response = SendRequest(HttpMethod.GET, "http://api.adf.ly/api.php", args);
+
+            if (!string.IsNullOrEmpty(response) && response != "error")
+            {
+                result.ShortenedURL = response;
+            }
+
+            return result;
+        }
+    }
+}

--- a/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortenerService.cs
+++ b/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortenerService.cs
@@ -31,6 +31,10 @@ namespace ShareX.UploadersLib.URLShorteners.AdFly
     {
         public string ServiceId { get; } = "AdFly";
         public UrlShortenerType EnumValue { get; } = UrlShortenerType.AdFly;
+        public IUploadServiceConfig CreateConfig()
+        {
+            return null;
+        }
 
         public IURLShortener CreateShortener(UploadersConfig config)
         {

--- a/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortenerService.cs
+++ b/ShareX.UploadersLib/URLShorteners/AdFly/AdFlyURLShortenerService.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -25,37 +25,8 @@
 
 // Credits: https://github.com/LRNAB
 
-using System.Collections.Generic;
-
-namespace ShareX.UploadersLib.URLShorteners
+namespace ShareX.UploadersLib.URLShorteners.AdFly
 {
-    public class AdFlyURLShortener : URLShortener
-    {
-        public string APIKEY { get; set; }
-        public string APIUID { get; set; }
-
-        public override UploadResult ShortenURL(string url)
-        {
-            UploadResult result = new UploadResult { URL = url };
-
-            Dictionary<string, string> args = new Dictionary<string, string>();
-            args.Add("key", APIKEY);
-            args.Add("uid", APIUID);
-            args.Add("advert_type", "int");
-            args.Add("domain", "adf.ly");
-            args.Add("url", url);
-
-            string response = SendRequest(HttpMethod.GET, "http://api.adf.ly/api.php", args);
-
-            if (!string.IsNullOrEmpty(response) && response != "error")
-            {
-                result.ShortenedURL = response;
-            }
-
-            return result;
-        }
-    }
-
     public class AdFlyURLShortenerService : IURLShortenerService
     {
         public string ServiceId { get; } = "AdFly";

--- a/ShareX.UploadersLib/URLShorteners/AdFlyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/AdFlyURLShortener.cs
@@ -55,4 +55,19 @@ namespace ShareX.UploadersLib.URLShorteners
             return result;
         }
     }
+
+    public class AdFlyURLShortenerService : IURLShortenerService
+    {
+        public string ServiceId { get; } = "AdFly";
+        public UrlShortenerType EnumValue { get; } = UrlShortenerType.AdFly;
+
+        public IURLShortener CreateShortener(UploadersConfig config)
+        {
+            return new AdFlyURLShortener
+            {
+                APIKEY = config.AdFlyAPIKEY,
+                APIUID = config.AdFlyAPIUID
+            };
+        }
+    }
 }

--- a/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortener.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace ShareX.UploadersLib.URLShorteners.TinyURL
+{
+    public sealed class TinyURLShortener : URLShortener
+    {
+        public override UploadResult ShortenURL(string url)
+        {
+            UploadResult result = new UploadResult { URL = url };
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                Dictionary<string, string> arguments = new Dictionary<string, string>();
+                arguments.Add("url", url);
+
+                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "http://tinyurl.com/api-create.php", arguments);
+            }
+
+            return result;
+        }
+    }
+}

--- a/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortenerService.cs
+++ b/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortenerService.cs
@@ -29,6 +29,11 @@ namespace ShareX.UploadersLib.URLShorteners.TinyURL
     {
         public string ServiceId { get; } = "TinyURL";
         public UrlShortenerType EnumValue { get; } = UrlShortenerType.TINYURL;
+        public IUploadServiceConfig CreateConfig()
+        {
+            return null;
+        }
+
         public IURLShortener CreateShortener(UploadersConfig config)
         {
             return new TinyURLShortener();

--- a/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortenerService.cs
+++ b/ShareX.UploadersLib/URLShorteners/TinyURL/TinyURLShortenerService.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -23,28 +23,8 @@
 
 #endregion License Information (GPL v3)
 
-using System.Collections.Generic;
-
-namespace ShareX.UploadersLib.URLShorteners
+namespace ShareX.UploadersLib.URLShorteners.TinyURL
 {
-    public sealed class TinyURLShortener : URLShortener
-    {
-        public override UploadResult ShortenURL(string url)
-        {
-            UploadResult result = new UploadResult { URL = url };
-
-            if (!string.IsNullOrEmpty(url))
-            {
-                Dictionary<string, string> arguments = new Dictionary<string, string>();
-                arguments.Add("url", url);
-
-                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "http://tinyurl.com/api-create.php", arguments);
-            }
-
-            return result;
-        }
-    }
-
     public class TinyURLShortenerService : IURLShortenerService
     {
         public string ServiceId { get; } = "TinyURL";

--- a/ShareX.UploadersLib/URLShorteners/TinyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/TinyURLShortener.cs
@@ -44,4 +44,14 @@ namespace ShareX.UploadersLib.URLShorteners
             return result;
         }
     }
+
+    public class TinyURLShortenerService : IURLShortenerService
+    {
+        public string ServiceId { get; } = "TinyURL";
+        public UrlShortenerType EnumValue { get; } = UrlShortenerType.TINYURL;
+        public IURLShortener CreateShortener(UploadersConfig config)
+        {
+            return new TinyURLShortener();
+        }
+    }
 }

--- a/ShareX.UploadersLib/Uploader.cs
+++ b/ShareX.UploadersLib/Uploader.cs
@@ -37,7 +37,23 @@ using System.Web;
 
 namespace ShareX.UploadersLib
 {
-    public class Uploader
+    public interface IUploader
+    {
+        event Uploader.ProgressEventHandler ProgressChanged;
+        event Action<string> EarlyURLCopyRequested;
+        List<string> Errors { get; }
+        bool IsUploading { get; }
+        int BufferSize { get; set; }
+        bool AllowReportProgress { get; set; }
+        bool WebExceptionReturnResponse { get; set; }
+        bool WebExceptionThrow { get; set; }
+        bool IsError { get; }
+        bool StopUploadRequested { get; }
+        string ToErrorString();
+        void StopUpload();
+    }
+
+    public class Uploader : IUploader
     {
         private static readonly string UserAgent = "ShareX";
 

--- a/ShareX.UploadersLib/packages.config
+++ b/ShareX.UploadersLib/packages.config
@@ -4,6 +4,7 @@
   <package id="AWSSDK.S3" version="3.1.4.0" targetFramework="net40" />
   <package id="MegaApiClient" version="1.2.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
+  <package id="SimpleInjector" version="3.1.2" targetFramework="net40" />
   <package id="SSH.NET" version="2014.4.6-beta2" targetFramework="net40" />
   <package id="System.Net.FtpClient" version="1.0.5281.14359" targetFramework="net40" />
 </packages>

--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -32,6 +32,8 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using ShareX.UploadersLib.URLShorteners;
+using SimpleInjector;
 
 namespace ShareX
 {
@@ -283,6 +285,9 @@ namespace ShareX
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+            Container container = BuildContainer();
+            ServiceLocator.SetContainer(container);
+
             IsSilentRun = CLI.IsCommandExist("silent", "s");
 
 #if STEAM
@@ -305,7 +310,7 @@ namespace ShareX
             LanguageHelper.ChangeLanguage(Settings.Language);
 
             DebugHelper.WriteLine("MainForm init started");
-            MainForm = new MainForm();
+            MainForm = container.GetInstance<MainForm>();
             DebugHelper.WriteLine("MainForm init finished");
 
             Application.Run(MainForm);
@@ -316,6 +321,23 @@ namespace ShareX
 
             DebugHelper.Logger.Async = false;
             DebugHelper.WriteLine("ShareX closing");
+        }
+
+        private static Container BuildContainer()
+        {
+            var container = new Container();
+
+            // Register uploader services
+            ShareX.UploadersLib.IoCRegistrant.Register(container);
+            
+
+            container.RegisterSingleton<MainForm>();
+
+#if DEBUG
+            container.Verify();
+#endif
+
+            return container;
         }
 
         public static void Restart()

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -89,6 +89,10 @@
       <HintPath>..\packages\SevenZipSharp.0.64\lib\SevenZipSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -909,7 +909,7 @@ namespace ShareX
             ITextUploader textUploader = null;
 
             // Temporary Factory Transition
-            var factory = ServiceLocator.GetInstance<ITextUploaderServiceFactory>();
+            var factory = ServiceLocator.GetInstance<ITextUploadServiceFactory>();
             ITextUploadService urlShortenerService = factory.GetServiceByEnumValue(Info.TaskSettings.TextDestination);
             if (urlShortenerService != null)
             {

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -1205,82 +1205,93 @@ namespace ShareX
 
         public UploadResult ShortenURL(string url)
         {
-            URLShortener urlShortener = null;
+            IURLShortener urlShortener = null;
 
-            switch (Info.TaskSettings.URLShortenerDestination)
+            // Temporary Factory Transition
+            var factory = ServiceLocator.GetInstance<IURLShortenerServiceFactory>();
+            IURLShortenerService urlShortenerService = factory.GetServiceByEnumValue(Info.TaskSettings.URLShortenerDestination);
+            if (urlShortenerService != null)
             {
-                case UrlShortenerType.BITLY:
-                    if (Program.UploadersConfig.BitlyOAuth2Info == null)
-                    {
-                        Program.UploadersConfig.BitlyOAuth2Info = new OAuth2Info(APIKeys.BitlyClientID, APIKeys.BitlyClientSecret);
-                    }
+                urlShortener = urlShortenerService.CreateShortener(Program.UploadersConfig);
+            }
 
-                    urlShortener = new BitlyURLShortener(Program.UploadersConfig.BitlyOAuth2Info)
-                    {
-                        Domain = Program.UploadersConfig.BitlyDomain
-                    };
-                    break;
-                case UrlShortenerType.Google:
-                    urlShortener = new GoogleURLShortener(Program.UploadersConfig.GoogleURLShortenerAccountType, APIKeys.GoogleAPIKey,
-                        Program.UploadersConfig.GoogleURLShortenerOAuth2Info);
-                    break;
-                case UrlShortenerType.ISGD:
-                    urlShortener = new IsgdURLShortener();
-                    break;
-                case UrlShortenerType.VGD:
-                    urlShortener = new VgdURLShortener();
-                    break;
-                case UrlShortenerType.TINYURL:
-                    urlShortener = new TinyURLShortener();
-                    break;
-                case UrlShortenerType.TURL:
-                    urlShortener = new TurlURLShortener();
-                    break;
-                case UrlShortenerType.YOURLS:
-                    urlShortener = new YourlsURLShortener
-                    {
-                        APIURL = Program.UploadersConfig.YourlsAPIURL,
-                        Signature = Program.UploadersConfig.YourlsSignature,
-                        Username = Program.UploadersConfig.YourlsUsername,
-                        Password = Program.UploadersConfig.YourlsPassword
-                    };
-                    break;
-                case UrlShortenerType.AdFly:
-                    urlShortener = new AdFlyURLShortener
-                    {
-                        APIKEY = Program.UploadersConfig.AdFlyAPIKEY,
-                        APIUID = Program.UploadersConfig.AdFlyAPIUID
-                    };
-                    break;
-                case UrlShortenerType.CoinURL:
-                    urlShortener = new CoinURLShortener
-                    {
-                        UUID = Program.UploadersConfig.CoinURLUUID
-                    };
-                    break;
-                case UrlShortenerType.QRnet:
-                    urlShortener = new QRnetURLShortener();
-                    break;
-                case UrlShortenerType.VURL:
-                    urlShortener = new VURLShortener();
-                    break;
-                case UrlShortenerType.TwoGP:
-                    urlShortener = new TwoGPURLShortener();
-                    break;
-                case UrlShortenerType.Polr:
-                    urlShortener = new PolrURLShortener
-                    {
-                        API_HOST = Program.UploadersConfig.PolrAPIHostname,
-                        API_KEY = Program.UploadersConfig.PolrAPIKey
-                    };
-                    break;
-                case UrlShortenerType.CustomURLShortener:
-                    CustomUploaderItem customUploader = GetCustomUploader(Program.UploadersConfig.CustomURLShortenerSelected);
-                    if (customUploader != null)
-                    {
-                        urlShortener = new CustomURLShortener(customUploader);
-                    }
-                    break;
+            if (urlShortener == null)
+            {
+                switch (Info.TaskSettings.URLShortenerDestination)
+                {
+                    case UrlShortenerType.BITLY:
+                        if (Program.UploadersConfig.BitlyOAuth2Info == null)
+                        {
+                            Program.UploadersConfig.BitlyOAuth2Info = new OAuth2Info(APIKeys.BitlyClientID, APIKeys.BitlyClientSecret);
+                        }
+
+                        urlShortener = new BitlyURLShortener(Program.UploadersConfig.BitlyOAuth2Info)
+                        {
+                            Domain = Program.UploadersConfig.BitlyDomain
+                        };
+                        break;
+                    case UrlShortenerType.Google:
+                        urlShortener = new GoogleURLShortener(Program.UploadersConfig.GoogleURLShortenerAccountType, APIKeys.GoogleAPIKey,
+                            Program.UploadersConfig.GoogleURLShortenerOAuth2Info);
+                        break;
+                    case UrlShortenerType.ISGD:
+                        urlShortener = new IsgdURLShortener();
+                        break;
+                    case UrlShortenerType.VGD:
+                        urlShortener = new VgdURLShortener();
+                        break;
+                    case UrlShortenerType.TINYURL:
+                        urlShortener = new TinyURLShortener();
+                        break;
+                    case UrlShortenerType.TURL:
+                        urlShortener = new TurlURLShortener();
+                        break;
+                    case UrlShortenerType.YOURLS:
+                        urlShortener = new YourlsURLShortener
+                        {
+                            APIURL = Program.UploadersConfig.YourlsAPIURL,
+                            Signature = Program.UploadersConfig.YourlsSignature,
+                            Username = Program.UploadersConfig.YourlsUsername,
+                            Password = Program.UploadersConfig.YourlsPassword
+                        };
+                        break;
+                    case UrlShortenerType.AdFly:
+                        urlShortener = new AdFlyURLShortener
+                        {
+                            APIKEY = Program.UploadersConfig.AdFlyAPIKEY,
+                            APIUID = Program.UploadersConfig.AdFlyAPIUID
+                        };
+                        break;
+                    case UrlShortenerType.CoinURL:
+                        urlShortener = new CoinURLShortener
+                        {
+                            UUID = Program.UploadersConfig.CoinURLUUID
+                        };
+                        break;
+                    case UrlShortenerType.QRnet:
+                        urlShortener = new QRnetURLShortener();
+                        break;
+                    case UrlShortenerType.VURL:
+                        urlShortener = new VURLShortener();
+                        break;
+                    case UrlShortenerType.TwoGP:
+                        urlShortener = new TwoGPURLShortener();
+                        break;
+                    case UrlShortenerType.Polr:
+                        urlShortener = new PolrURLShortener
+                        {
+                            API_HOST = Program.UploadersConfig.PolrAPIHostname,
+                            API_KEY = Program.UploadersConfig.PolrAPIKey
+                        };
+                        break;
+                    case UrlShortenerType.CustomURLShortener:
+                        CustomUploaderItem customUploader = GetCustomUploader(Program.UploadersConfig.CustomURLShortenerSelected);
+                        if (customUploader != null)
+                        {
+                            urlShortener = new CustomURLShortener(customUploader);
+                        }
+                        break;
+                }
             }
 
             if (urlShortener != null)

--- a/ShareX/packages.config
+++ b/ShareX/packages.config
@@ -3,4 +3,5 @@
   <package id="MegaApiClient" version="1.2.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net40" />
   <package id="SevenZipSharp" version="0.64" targetFramework="net40" />
+  <package id="SimpleInjector" version="3.1.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This is an early, work in progress, refactor of something that's always bugged me about ShareX's codebase. Right now to add an additional image uploader, it requires edits to for different locations within the codebase. This also results in tight coupling, and makes automated testing difficult. I'm submitting this PR to gather feedback on the design and overall concept (the code is sloppy and will be fixed in due time).

I've refactored a few uploaders in a way that allows for inversion of control, and introduced a service locator in the `WorkerTask` for retreiving these new implementations, rather than the existing switch statement. I've also added Simple Injector as a dependency injection framework.

## New Concepts
### `IUploadService`
Represents an upload service such as pastebin or Dropbox. The interface provides metadata about the service, and can creates `IUploader`s and `IUploadServiceConfig`. Upload-type descendents exist such as `IURLShortenerService` and `ITextUploadService`

### `IUploader`
Mentioned above, the `IUploader` implementation actually handles the task of uploading things to the service.

### `IUploadServiceFactory`
Code that needs to locate an instance of an `IUploadService` will make use of the factory to find an `IUploadService` by ID or enum value

### `IUploadServiceConfig`
**Naming sucks, I need to change it**

Handles UI concerns of displaying the upload target in the `UploadersConfigForm`. Rather than having all of the code for each uploader UI defined in the config form, the `IUploadServiceConfig` would provide an icon and UserComponent for that uploader.


## Wrap-up
It's 3AM here, so I'll answer any questions tomorrow morning, and continue to update this PR.