### PR TITLE
P/Invoke fixes

### DIFF
--- a/ShareX.HelpersLib/Extensions/Extensions.cs
+++ b/ShareX.HelpersLib/Extensions/Extensions.cs
@@ -189,12 +189,12 @@ namespace ShareX.HelpersLib
 
         public static void BeginUpdate(this RichTextBox rtb)
         {
-            NativeMethods.SendMessage(rtb.Handle, (int)WindowsMessages.SETREDRAW, 0, 0);
+            NativeMethods.SendMessage(rtb.Handle, (int)WindowsMessages.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
         }
 
         public static void EndUpdate(this RichTextBox rtb)
         {
-            NativeMethods.SendMessage(rtb.Handle, (int)WindowsMessages.SETREDRAW, 1, 0);
+            NativeMethods.SendMessage(rtb.Handle, (int)WindowsMessages.SETREDRAW, (IntPtr)1, IntPtr.Zero);
             rtb.Invalidate();
         }
 
@@ -456,7 +456,7 @@ namespace ShareX.HelpersLib
         {
             if (textBox != null && textBox.IsHandleCreated && watermarkText != null)
             {
-                NativeMethods.SendMessage(textBox.Handle, (int)NativeMethods.EM_SETCUEBANNER, showCueWhenFocus ? 1 : 0, watermarkText);
+                NativeMethods.SendMessage(textBox.Handle, (int)NativeMethods.EM_SETCUEBANNER, showCueWhenFocus ? (IntPtr)1 : IntPtr.Zero, watermarkText);
             }
         }
 

--- a/ShareX.HelpersLib/Native/NativeMethods.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods.cs
@@ -150,8 +150,8 @@ namespace ShareX.HelpersLib
         [DllImport("user32.dll")]
         public static extern IntPtr GetWindowDC(IntPtr hWnd);
 
-        [DllImport("user32.dll")]
-        public static extern ulong GetWindowLong(IntPtr hWnd, int nIndex);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        public static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
 
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -203,17 +203,14 @@ namespace ShareX.HelpersLib
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
-
-        [DllImport("user32.dll")]
-        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam, SendMessageTimeoutFlags fuFlags, uint uTimeout, out UIntPtr lpdwResult);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, int wParam, int lParam, SendMessageTimeoutFlags fuFlags, uint uTimeout, out IntPtr lpdwResult);
+        public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam, SendMessageTimeoutFlags fuFlags, uint uTimeout, out IntPtr lpdwResult);
 
         [DllImport("user32.dll")]
         public static extern IntPtr SetActiveWindow(IntPtr hWnd);
@@ -290,13 +287,13 @@ namespace ShareX.HelpersLib
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         public static extern ushort GlobalDeleteAtom(ushort nAtom);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         public static extern uint GetClassLong(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr GetClassLongPtr(IntPtr hWnd, int nIndex);
 
-        [DllImport("kernel32.dll")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr GetModuleHandle(string lpModuleName);
 
         [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi)]
@@ -316,7 +313,7 @@ namespace ShareX.HelpersLib
         [DllImport("gdi32.dll")]
         public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
 
-        [DllImport("gdi32.dll")]
+        [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr CreateDC(string lpszDriver, string lpszDevice, string lpszOutput, IntPtr lpInitData);
 
         [DllImport("gdi32.dll")]

--- a/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
@@ -122,11 +122,11 @@ namespace ShareX.HelpersLib
         {
             IntPtr iconHandle;
 
-            SendMessageTimeout(handle, (int)WindowsMessages.GETICON, ICON_SMALL2, 0, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
+            SendMessageTimeout(handle, (int)WindowsMessages.GETICON, (IntPtr)ICON_SMALL2, IntPtr.Zero, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
 
             if (iconHandle == IntPtr.Zero)
             {
-                SendMessageTimeout(handle, (int)WindowsMessages.GETICON, ICON_SMALL, 0, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
+                SendMessageTimeout(handle, (int)WindowsMessages.GETICON, (IntPtr)ICON_SMALL, IntPtr.Zero, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
 
                 if (iconHandle == IntPtr.Zero)
                 {
@@ -134,7 +134,7 @@ namespace ShareX.HelpersLib
 
                     if (iconHandle == IntPtr.Zero)
                     {
-                        SendMessageTimeout(handle, (int)WindowsMessages.QUERYDRAGICON, 0, 0, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
+                        SendMessageTimeout(handle, (int)WindowsMessages.QUERYDRAGICON, IntPtr.Zero, IntPtr.Zero, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
                     }
                 }
             }
@@ -151,7 +151,7 @@ namespace ShareX.HelpersLib
         {
             IntPtr iconHandle;
 
-            SendMessageTimeout(handle, (int)WindowsMessages.GETICON, ICON_BIG, 0, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
+            SendMessageTimeout(handle, (int)WindowsMessages.GETICON, (IntPtr)ICON_BIG, IntPtr.Zero, SendMessageTimeoutFlags.SMTO_ABORTIFHUNG, 1000, out iconHandle);
 
             if (iconHandle == IntPtr.Zero)
             {

--- a/ShareX.ScreenCaptureLib/Forms/ScrollingCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/ScrollingCaptureForm.cs
@@ -326,7 +326,7 @@ namespace ShareX.ScreenCaptureLib
 
                 if (Options.ScrollTopMethodBeforeCapture == ScrollingCaptureScrollTopMethod.All || Options.ScrollTopMethodBeforeCapture == ScrollingCaptureScrollTopMethod.SendMessageTop)
                 {
-                    NativeMethods.SendMessage(selectedWindow.Handle, (int)WindowsMessages.VSCROLL, (int)ScrollBarCommands.SB_TOP, 0);
+                    NativeMethods.SendMessage(selectedWindow.Handle, (int)WindowsMessages.VSCROLL, (IntPtr)ScrollBarCommands.SB_TOP, IntPtr.Zero);
                 }
 
                 if (Options.ScrollTopMethodBeforeCapture != ScrollingCaptureScrollTopMethod.None)
@@ -371,7 +371,7 @@ namespace ShareX.ScreenCaptureLib
             {
                 case ScrollingCaptureScrollMethod.Automatic:
                 case ScrollingCaptureScrollMethod.SendMessageScroll:
-                    NativeMethods.SendMessage(selectedWindow.Handle, (int)WindowsMessages.VSCROLL, (int)ScrollBarCommands.SB_PAGEDOWN, 0);
+                    NativeMethods.SendMessage(selectedWindow.Handle, (int)WindowsMessages.VSCROLL, (IntPtr)ScrollBarCommands.SB_PAGEDOWN, IntPtr.Zero);
                     break;
                 case ScrollingCaptureScrollMethod.KeyPressPageDown:
                     InputHelpers.SendKeyPress(VirtualKeyCode.NEXT);

--- a/ShareX.UploadersLib/FTPClient/IconHelper.cs
+++ b/ShareX.UploadersLib/FTPClient/IconHelper.cs
@@ -195,7 +195,7 @@ namespace ShareX.UploadersLib
         public const uint BIF_BROWSEINCLUDEFILES = 0x4000;
         public const uint BIF_SHAREABLE = 0x8000;
 
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public struct SHFILEINFO
         {
             public IntPtr hIcon;
@@ -229,7 +229,7 @@ namespace ShareX.UploadersLib
         public const uint FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
         public const uint FILE_ATTRIBUTE_NORMAL = 0x00000080;
 
-        [DllImport("shell32.dll")]
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
         public static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes, ref SHFILEINFO psfi, uint cbFileInfo, uint uFlags);
     }
 }

--- a/ShareX.UploadersLib/FTPClient/ListViewEx.cs
+++ b/ShareX.UploadersLib/FTPClient/ListViewEx.cs
@@ -49,11 +49,11 @@ namespace ShareX.UploadersLib
             public Int32 code;
         }
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wPar, IntPtr lPar);
 
-        [DllImport("user32.dll", CharSet = CharSet.Ansi)]
-        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, int len, ref int[] order);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr len, ref int[] order);
 
         // ListView messages
         private const int LVM_FIRST = 0x1000;


### PR DESCRIPTION
This patch does four things:
1. Add CharSet.Unicode to DllImports that lack it - CharSet.Ansi is the [default](https://blogs.msdn.microsoft.com/oldnewthing/20140812-00/?p=263).
2. Fixes the [SendMessage](http://www.pinvoke.net/default.aspx/user32.sendmessage) and [SendMessageTimeout](http://www.pinvoke.net/default.aspx/user32.SendMessageTimeout) P/Invokes for 64bit and adds the needed casts to callers.
3. Fixes the return type of [GetWindowLong](http://www.pinvoke.net/default.aspx/user32/GetWindowLong.html). This function returns a uint but was declared as returning a ulong.
4. Add CharSet.Unicode to a struct.