### PR TITLE
Expand Folder Variables

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Localhost/LocalhostAccount.cs
+++ b/ShareX.UploadersLib/FileUploaders/Localhost/LocalhostAccount.cs
@@ -112,7 +112,7 @@ namespace ShareX.UploadersLib
 
         public string GetSubFolderPath()
         {
-            return NameParser.Parse(NameParserType.URL, SubFolderPath.Replace("%host", Helpers.GetVariableFolderPath(LocalhostRoot)));
+            return NameParser.Parse(NameParserType.URL, SubFolderPath.Replace("%host", Helpers.ExpandFolderVariables(LocalhostRoot)));
         }
 
         public string GetHttpHomePath()
@@ -126,7 +126,7 @@ namespace ShareX.UploadersLib
 
             HttpHomePath = URLHelpers.RemovePrefixes(HttpHomePath);
 
-            return NameParser.Parse(NameParserType.URL, HttpHomePath.Replace("%host", Helpers.GetVariableFolderPath(LocalhostRoot)));
+            return NameParser.Parse(NameParserType.URL, HttpHomePath.Replace("%host", Helpers.ExpandFolderVariables(LocalhostRoot)));
         }
 
         public string GetUriPath(string filename)
@@ -188,7 +188,7 @@ namespace ShareX.UploadersLib
             {
                 return string.Empty;
             }
-            return Path.Combine(Path.Combine(Helpers.GetVariableFolderPath(LocalhostRoot), GetSubFolderPath()), fileName);
+            return Path.Combine(Path.Combine(Helpers.ExpandFolderVariables(LocalhostRoot), GetSubFolderPath()), fileName);
         }
 
         public string GetLocalhostUri(string fileName)


### PR DESCRIPTION
Properly expand local folder variables (such as Desktop and My
Documents).
Corrects bug from 35cb75d055a7c250c4fdd8d19a42e1215fd1b6bc