### PR TITLE
Make rect default selection in Greenshot

### DIFF
--- a/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
+++ b/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
@@ -192,6 +192,7 @@ namespace Greenshot
                 SurfaceSizeChanged(Surface, null);
 
                 BindFieldControls();
+                _surface.DrawingMode = DrawingModes.Rect;
                 RefreshEditorControls();
                 // Fix title
                 if (_surface != null && _surface.CaptureDetails != null && _surface.CaptureDetails.Title != null)


### PR DESCRIPTION
Fixes error introduced in last Greenshot merge