### PR TITLE
Save last drawing mode in Greenshot

### DIFF
--- a/Greenshot.ImageEditor/Configuration/EditorConfiguration.cs
+++ b/Greenshot.ImageEditor/Configuration/EditorConfiguration.cs
@@ -22,6 +22,7 @@
 using Greenshot.Core;
 using Greenshot.Drawing.Fields;
 using Greenshot.IniFile;
+using Greenshot.Plugin;
 using GreenshotPlugin.UnmanagedHelpers;
 using System;
 using System.Collections.Generic;
@@ -37,6 +38,13 @@ namespace Greenshot.Configuration
     {
         [IniProperty("RecentColors", Separator = "|", Description = "Last used colors")]
         public List<Color> RecentColors;
+
+        [IniProperty("DefaultDrawingMode", Separator = "|", Description = "Default drawing mode:None,Rect,Ellipse,Line,Arrow,Path,Text,SpeechBubble,StepLabel,Highlight,Obfuscate,Crop", DefaultValue = "Rect", FixedValue = true)]
+        public DrawingModes DefaultDrawingMode;
+        [IniProperty("RememberLastDrawingMode", Description = "Remember last drawing mode used and select it next time", DefaultValue = "False")]
+        public bool RememberLastDrawingMode;
+        [IniProperty("LastDrawingMode", Separator = "|", Description = "Last drawing mode used", DefaultValue = "Rect")]
+        public DrawingModes LastDrawingMode;
 
         [IniProperty("LastFieldValue", Separator = "|", Description = "Field values, make sure the last used settings are re-used")]
         public Dictionary<string, object> LastUsedFieldValues;

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
@@ -34,6 +34,7 @@
             this.cbSuppressSaveDialogAtClose = new System.Windows.Forms.CheckBox();
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
+            this.cbRememberLastDrawingMode = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.nudIconSize)).BeginInit();
             this.SuspendLayout();
             // 
@@ -97,6 +98,16 @@
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
+            // cbRememberLastDrawingMode
+            // 
+            this.cbRememberLastDrawingMode.AutoSize = true;
+            this.cbRememberLastDrawingMode.Location = new System.Drawing.Point(16, 87);
+            this.cbRememberLastDrawingMode.Name = "cbRememberLastDrawingMode";
+            this.cbRememberLastDrawingMode.Size = new System.Drawing.Size(226, 17);
+            this.cbRememberLastDrawingMode.TabIndex = 4;
+            this.cbRememberLastDrawingMode.Text = "Remember the last drawing mode selected";
+            this.cbRememberLastDrawingMode.UseVisualStyleBackColor = true;
+            // 
             // EditorSettingsForm
             // 
             this.AcceptButton = this.btnOK;
@@ -106,6 +117,7 @@
             this.ClientSize = new System.Drawing.Size(330, 186);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.cbRememberLastDrawingMode);
             this.Controls.Add(this.cbSuppressSaveDialogAtClose);
             this.Controls.Add(this.cbMatchSizeToCapture);
             this.Controls.Add(this.nudIconSize);
@@ -129,5 +141,6 @@
         private System.Windows.Forms.CheckBox cbSuppressSaveDialogAtClose;
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.CheckBox cbRememberLastDrawingMode;
     }
 }

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
@@ -24,6 +24,7 @@ namespace Greenshot
             nudIconSize.Value = (int)Math.Round(coreConfiguration.IconSize.Width / 16.0) * 16;
             cbMatchSizeToCapture.Checked = editorConfiguration.MatchSizeToCapture;
             cbSuppressSaveDialogAtClose.Checked = editorConfiguration.SuppressSaveDialogAtClose;
+            cbRememberLastDrawingMode.Checked = editorConfiguration.RememberLastDrawingMode;
         }
 
         private void SaveSettings()
@@ -31,6 +32,7 @@ namespace Greenshot
             coreConfiguration.IconSize = new Size((int)nudIconSize.Value, (int)nudIconSize.Value);
             editorConfiguration.MatchSizeToCapture = cbMatchSizeToCapture.Checked;
             editorConfiguration.SuppressSaveDialogAtClose = cbSuppressSaveDialogAtClose.Checked;
+            editorConfiguration.RememberLastDrawingMode = cbRememberLastDrawingMode.Checked;
         }
 
         private void btnOK_Click(object sender, EventArgs e)

--- a/Greenshot.ImageEditor/Forms/ImageEditorForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/ImageEditorForm.Designer.cs
@@ -286,9 +286,7 @@ namespace Greenshot {
             // 
             // btnRect
             // 
-            this.btnRect.Checked = true;
             this.btnRect.CheckOnClick = true;
-            this.btnRect.CheckState = System.Windows.Forms.CheckState.Checked;
             this.btnRect.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.btnRect.Image = ((System.Drawing.Image)(resources.GetObject("btnRect.Image")));
             this.btnRect.ImageTransparentColor = System.Drawing.Color.Magenta;

--- a/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
+++ b/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
@@ -192,7 +192,7 @@ namespace Greenshot
                 SurfaceSizeChanged(Surface, null);
 
                 BindFieldControls();
-                _surface.DrawingMode = DrawingModes.Rect;
+                _surface.DrawingMode = EditorConfiguration.RememberLastDrawingMode ? EditorConfiguration.LastDrawingMode : EditorConfiguration.DefaultDrawingMode;
                 RefreshEditorControls();
                 // Fix title
                 if (_surface != null && _surface.CaptureDetails != null && _surface.CaptureDetails.Title != null)
@@ -684,6 +684,8 @@ namespace Greenshot
 
             // persist our geometry string.
             EditorConfiguration.SetEditorPlacement(new WindowDetails(Handle).WindowPlacement);
+            // save last used drawing mode
+            EditorConfiguration.LastDrawingMode = _surface.DrawingMode;
             IniConfig.Save();
 
             // remove from the editor list
@@ -1011,7 +1013,8 @@ namespace Greenshot
             FieldAggregator props = _surface.FieldAggregator;
             // if a confirmable element is selected, we must disable most of the controls
             // since we demand confirmation or cancel for confirmable element
-            if (props.HasFieldValue(FieldType.FLAGS) && ((FieldType.Flag)props.GetFieldValue(FieldType.FLAGS) & FieldType.Flag.CONFIRMABLE) == FieldType.Flag.CONFIRMABLE)
+            if (props.HasFieldValue(FieldType.FLAGS) && ((FieldType.Flag)props.GetFieldValue(FieldType.FLAGS) & FieldType.Flag.CONFIRMABLE) == FieldType.Flag.CONFIRMABLE
+                && _surface.HasSelectedElements) // if nothing is selected, there is nothing to cancel, so don't disable controls
             {
                 // disable most controls
                 if (!_controlsDisabledDueToConfirmable)


### PR DESCRIPTION
Saves the last drawing mode used in Greenshot when editor is closed so
that it will be selected next time image editor is opened.
Closes #1609