### PR TITLE
Add "Use direct link" setting to Google Drive uploader

### DIFF
--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -4986,6 +4986,6 @@
         private System.Windows.Forms.TextBox txtEmailAutomaticSendTo;
         private System.Windows.Forms.CheckBox cbEmailAutomaticSend;
         private System.Windows.Forms.Button btnLithiioGetAPIKey;
-		private System.Windows.Forms.CheckBox cbGoogleDriveDirectLink;
-	}
+        private System.Windows.Forms.CheckBox cbGoogleDriveDirectLink;
+    }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -191,6 +191,7 @@
             this.cbOneDriveCreateShareableLink = new System.Windows.Forms.CheckBox();
             this.oAuth2OneDrive = new ShareX.UploadersLib.OAuthControl();
             this.tpGoogleDrive = new System.Windows.Forms.TabPage();
+            this.cbGoogleDriveDirectLink = new System.Windows.Forms.CheckBox();
             this.cbGoogleDriveUseFolder = new System.Windows.Forms.CheckBox();
             this.txtGoogleDriveFolderID = new System.Windows.Forms.TextBox();
             this.lblGoogleDriveFolderID = new System.Windows.Forms.Label();
@@ -1826,6 +1827,7 @@
             // 
             // tpGoogleDrive
             // 
+            this.tpGoogleDrive.Controls.Add(this.cbGoogleDriveDirectLink);
             this.tpGoogleDrive.Controls.Add(this.cbGoogleDriveUseFolder);
             this.tpGoogleDrive.Controls.Add(this.txtGoogleDriveFolderID);
             this.tpGoogleDrive.Controls.Add(this.lblGoogleDriveFolderID);
@@ -1836,6 +1838,13 @@
             resources.ApplyResources(this.tpGoogleDrive, "tpGoogleDrive");
             this.tpGoogleDrive.Name = "tpGoogleDrive";
             this.tpGoogleDrive.UseVisualStyleBackColor = true;
+            // 
+            // cbGoogleDriveDirectLink
+            // 
+            resources.ApplyResources(this.cbGoogleDriveDirectLink, "cbGoogleDriveDirectLink");
+            this.cbGoogleDriveDirectLink.Name = "cbGoogleDriveDirectLink";
+            this.cbGoogleDriveDirectLink.UseVisualStyleBackColor = true;
+            this.cbGoogleDriveDirectLink.CheckedChanged += new System.EventHandler(this.cbGoogleDriveDirectLink_CheckedChanged);
             // 
             // cbGoogleDriveUseFolder
             // 
@@ -4977,5 +4986,6 @@
         private System.Windows.Forms.TextBox txtEmailAutomaticSendTo;
         private System.Windows.Forms.CheckBox cbEmailAutomaticSend;
         private System.Windows.Forms.Button btnLithiioGetAPIKey;
-    }
+		private System.Windows.Forms.CheckBox cbGoogleDriveDirectLink;
+	}
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -370,6 +370,7 @@ namespace ShareX.UploadersLib
             }
 
             cbGoogleDriveIsPublic.Checked = Config.GoogleDriveIsPublic;
+            cbGoogleDriveDirectLink.Checked = Config.GoogleDriveDirectLink;
             cbGoogleDriveUseFolder.Checked = Config.GoogleDriveUseFolder;
             txtGoogleDriveFolderID.Enabled = Config.GoogleDriveUseFolder;
             txtGoogleDriveFolderID.Text = Config.GoogleDriveFolderID;
@@ -1364,6 +1365,11 @@ namespace ShareX.UploadersLib
         private void cbGoogleDriveIsPublic_CheckedChanged(object sender, EventArgs e)
         {
             Config.GoogleDriveIsPublic = cbGoogleDriveIsPublic.Checked;
+        }
+
+        private void cbGoogleDriveDirectLink_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.GoogleDriveDirectLink = cbGoogleDriveDirectLink.Checked;
         }
 
         private void cbGoogleDriveUseFolder_CheckedChanged(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -4203,6 +4203,36 @@ store.book[0].title</value>
   <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGoogleDriveDirectLink.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGoogleDriveDirectLink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGoogleDriveDirectLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 287</value>
+  </data>
+  <data name="cbGoogleDriveDirectLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 17</value>
+  </data>
+  <data name="cbGoogleDriveDirectLink.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="cbGoogleDriveDirectLink.Text" xml:space="preserve">
+    <value>Use direct link</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Name" xml:space="preserve">
+    <value>cbGoogleDriveDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbGoogleDriveUseFolder.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -152,6 +152,7 @@ namespace ShareX.UploadersLib
 
         public OAuth2Info GoogleDriveOAuth2Info = null;
         public bool GoogleDriveIsPublic = true;
+        public bool GoogleDriveDirectLink = false;
         public bool GoogleDriveUseFolder = false;
         public string GoogleDriveFolderID = "";
 


### PR DESCRIPTION
I was trying to find some way to get around the fact that Google Drive encodes videos after uploading them from ShareX, which can take quite a while. All I want is a direct link to the uploaded file.

One way to create a direct link is to just append the ID to a URL, as such:

`$"https://drive.google.com/uc?id={upload.id}"`.

... but I figured it would be better to leverage the response somehow, so instead I tried using the `webContentLink` entry from `result.Response`, which contains the above mentioned link.

But by default `webContentLink` is bundled with the query `?export=download`, which seems to add `Content-Disposition: attachment` to the HTTP headers, forcing the browser to download the file instead of just viewing it. Stripping away said query parameter seems to fix that, and the resulting link can be viewed in the browser just fine.

Let me know what your thoughts are.

Also, thanks for an awesome application.