### PR TITLE
Changed Imgur generated links to SSL

### DIFF
--- a/ShareX.UploadersLib/ImageUploaders/Imgur.cs
+++ b/ShareX.UploadersLib/ImageUploaders/Imgur.cs
@@ -271,7 +271,7 @@ namespace ShareX.UploadersLib.ImageUploaders
                             }
                             else
                             {
-                                result.URL = "http://imgur.com/" + imageData.id;
+                                result.URL = "https://imgur.com/" + imageData.id;
                             }
 
                             string thumbnail = "";
@@ -298,8 +298,8 @@ namespace ShareX.UploadersLib.ImageUploaders
                                     break;
                             }
 
-                            result.ThumbnailURL = string.Format("http://i.imgur.com/{0}{1}.jpg", imageData.id, thumbnail); // Thumbnails always jpg
-                            result.DeletionURL = "http://imgur.com/delete/" + imageData.deletehash;
+                            result.ThumbnailURL = string.Format("https://i.imgur.com/{0}{1}.jpg", imageData.id, thumbnail); // Thumbnails always jpg
+                            result.DeletionURL = "https://imgur.com/delete/" + imageData.deletehash;
                         }
                     }
                     else


### PR DESCRIPTION
Seeing as Imgur does support SSL links, I strongly prefer the links to automatically be https links rather than http.

Small change, just a quick change in how image links are given to user