### PR TITLE
Lock Greenshot icon sizes to multiples of 8

### DIFF
--- a/Greenshot.ImageEditor/Configuration/CoreConfiguration.cs
+++ b/Greenshot.ImageEditor/Configuration/CoreConfiguration.cs
@@ -291,7 +291,7 @@ namespace GreenshotPlugin.Core
                     {
                         newSize.Width = 256;
                     }
-                    newSize.Width = (newSize.Width / 16) * 16;
+                    newSize.Width = (newSize.Width / 8) * 8;
                     if (newSize.Height < 16)
                     {
                         newSize.Height = 16;
@@ -300,7 +300,7 @@ namespace GreenshotPlugin.Core
                     {
                         newSize.Height = 256;
                     }
-                    newSize.Height = (newSize.Height / 16) * 16;
+                    newSize.Height = (newSize.Height / 8) * 8;
                 }
                 if (_iconSize != newSize)
                 {

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
@@ -49,11 +49,32 @@
             // 
             // nudIconSize
             // 
+            this.nudIconSize.Increment = new decimal(new int[] {
+            8,
+            0,
+            0,
+            0});
             this.nudIconSize.Location = new System.Drawing.Point(72, 12);
+            this.nudIconSize.Maximum = new decimal(new int[] {
+            256,
+            0,
+            0,
+            0});
+            this.nudIconSize.Minimum = new decimal(new int[] {
+            16,
+            0,
+            0,
+            0});
             this.nudIconSize.Name = "nudIconSize";
+            this.nudIconSize.ReadOnly = true;
             this.nudIconSize.Size = new System.Drawing.Size(48, 20);
             this.nudIconSize.TabIndex = 1;
             this.nudIconSize.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.nudIconSize.Value = new decimal(new int[] {
+            16,
+            0,
+            0,
+            0});
             // 
             // cbMatchSizeToCapture
             // 


### PR DESCRIPTION
Change to allow any icon size that is a multiple of 8 and don't let user
choose an invalid size.

Closes #1651 