### PR TITLE
Size and position Greenshot editor window to be on screen

### DIFF
--- a/Greenshot.ImageEditor/Configuration/EditorConfiguration.cs
+++ b/Greenshot.ImageEditor/Configuration/EditorConfiguration.cs
@@ -51,6 +51,8 @@ namespace Greenshot.Configuration
 
         [IniProperty("MatchSizeToCapture", Description = "Match the editor window size to the capture", DefaultValue = "True")]
         public bool MatchSizeToCapture;
+        [IniProperty("MaximizeWhenLargeImage", Description = "Maximize the editor window when image is larger than the working area", DefaultValue = "False")]
+        public bool MaximizeWhenLargeImage;
         [IniProperty("WindowPlacementFlags", Description = "Placement flags", DefaultValue = "0")]
         public WindowPlacementFlags WindowPlacementFlags;
         [IniProperty("WindowShowCommand", Description = "Show command", DefaultValue = "Normal")]

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
@@ -35,6 +35,7 @@
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.cbRememberLastDrawingMode = new System.Windows.Forms.CheckBox();
+            this.cbMaximizeWhenLargeImage = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.nudIconSize)).BeginInit();
             this.SuspendLayout();
             // 
@@ -89,7 +90,7 @@
             // cbSuppressSaveDialogAtClose
             // 
             this.cbSuppressSaveDialogAtClose.AutoSize = true;
-            this.cbSuppressSaveDialogAtClose.Location = new System.Drawing.Point(16, 64);
+            this.cbSuppressSaveDialogAtClose.Location = new System.Drawing.Point(16, 88);
             this.cbSuppressSaveDialogAtClose.Name = "cbSuppressSaveDialogAtClose";
             this.cbSuppressSaveDialogAtClose.Size = new System.Drawing.Size(257, 17);
             this.cbSuppressSaveDialogAtClose.TabIndex = 3;
@@ -122,12 +123,22 @@
             // cbRememberLastDrawingMode
             // 
             this.cbRememberLastDrawingMode.AutoSize = true;
-            this.cbRememberLastDrawingMode.Location = new System.Drawing.Point(16, 87);
+            this.cbRememberLastDrawingMode.Location = new System.Drawing.Point(16, 111);
             this.cbRememberLastDrawingMode.Name = "cbRememberLastDrawingMode";
             this.cbRememberLastDrawingMode.Size = new System.Drawing.Size(226, 17);
             this.cbRememberLastDrawingMode.TabIndex = 4;
             this.cbRememberLastDrawingMode.Text = "Remember the last drawing mode selected";
             this.cbRememberLastDrawingMode.UseVisualStyleBackColor = true;
+            // 
+            // cbMaximizeWhenLargeImage
+            // 
+            this.cbMaximizeWhenLargeImage.AutoSize = true;
+            this.cbMaximizeWhenLargeImage.Location = new System.Drawing.Point(36, 63);
+            this.cbMaximizeWhenLargeImage.Name = "cbMaximizeWhenLargeImage";
+            this.cbMaximizeWhenLargeImage.Size = new System.Drawing.Size(280, 17);
+            this.cbMaximizeWhenLargeImage.TabIndex = 6;
+            this.cbMaximizeWhenLargeImage.Text = "Maximize window when image larger than display area";
+            this.cbMaximizeWhenLargeImage.UseVisualStyleBackColor = true;
             // 
             // EditorSettingsForm
             // 
@@ -136,6 +147,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(330, 186);
+            this.Controls.Add(this.cbMaximizeWhenLargeImage);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.cbRememberLastDrawingMode);
@@ -163,5 +175,6 @@
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.CheckBox cbRememberLastDrawingMode;
+        private System.Windows.Forms.CheckBox cbMaximizeWhenLargeImage;
     }
 }

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
@@ -23,6 +23,7 @@ namespace Greenshot
         {
             nudIconSize.Value = (int)Math.Round(coreConfiguration.IconSize.Width / 16.0) * 16;
             cbMatchSizeToCapture.Checked = editorConfiguration.MatchSizeToCapture;
+            cbMaximizeWhenLargeImage.Checked = editorConfiguration.MaximizeWhenLargeImage;
             cbSuppressSaveDialogAtClose.Checked = editorConfiguration.SuppressSaveDialogAtClose;
             cbRememberLastDrawingMode.Checked = editorConfiguration.RememberLastDrawingMode;
         }
@@ -31,6 +32,7 @@ namespace Greenshot
         {
             coreConfiguration.IconSize = new Size((int)nudIconSize.Value, (int)nudIconSize.Value);
             editorConfiguration.MatchSizeToCapture = cbMatchSizeToCapture.Checked;
+            editorConfiguration.MaximizeWhenLargeImage = cbMaximizeWhenLargeImage.Checked;
             editorConfiguration.SuppressSaveDialogAtClose = cbSuppressSaveDialogAtClose.Checked;
             editorConfiguration.RememberLastDrawingMode = cbRememberLastDrawingMode.Checked;
         }

--- a/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
+++ b/Greenshot.ImageEditor/Forms/ImageEditorForm.cs
@@ -121,9 +121,56 @@ namespace Greenshot
             if (EditorConfiguration.MatchSizeToCapture)
             {
                 RECT lastPosition = EditorConfiguration.GetEditorPlacement().NormalPosition;
+
+                WindowPlacement wp = new WindowDetails(Handle).WindowPlacement;
+                wp.NormalPosition.Top = lastPosition.Top ;
+                wp.NormalPosition.Left = lastPosition.Left;
+                // don't actually show window now (it is done later)
+                wp.ShowCmd = ShowWindowCommand.Hide;
+
                 this.StartPosition = FormStartPosition.Manual;
-                this.Location = new Point(lastPosition.Left, lastPosition.Top);
-            }
+
+                WindowDetails thisForm = new WindowDetails(Handle)
+                {
+                        WindowPlacement = wp
+                };
+
+                // Once image is loaded into window, size and position window
+                Load += delegate
+                {
+                    Rectangle workingArea = Screen.FromControl(this).WorkingArea;
+                    WindowPlacement windowPlacement = new WindowDetails(Handle).WindowPlacement;
+
+                    if (EditorConfiguration.MaximizeWhenLargeImage)
+                    {
+                        if ((windowPlacement.NormalPosition.Width > workingArea.Width) || (windowPlacement.NormalPosition.Height > workingArea.Height))
+                        {
+                            windowPlacement.ShowCmd = ShowWindowCommand.Maximize;
+                        }
+                    }
+
+                    if (windowPlacement.NormalPosition.Right > workingArea.Right)
+                    {
+                        int toMoveLeft = windowPlacement.NormalPosition.Right - workingArea.Right;
+                        if (windowPlacement.NormalPosition.Left - toMoveLeft < 0)
+                            toMoveLeft = windowPlacement.NormalPosition.Left;
+
+                        windowPlacement.NormalPosition.Left -= toMoveLeft;
+                        windowPlacement.NormalPosition.Right -= toMoveLeft;
+                    }
+                    if (windowPlacement.NormalPosition.Bottom > workingArea.Bottom)
+                    {
+                        int toMoveUp = windowPlacement.NormalPosition.Bottom - workingArea.Bottom;
+                        if (windowPlacement.NormalPosition.Top - toMoveUp < 0)
+                            toMoveUp = windowPlacement.NormalPosition.Top;
+
+                        windowPlacement.NormalPosition.Top -= toMoveUp;
+                        windowPlacement.NormalPosition.Bottom -= toMoveUp;
+                    }
+                    WindowDetails thisForm1 = new WindowDetails(Handle) { WindowPlacement = windowPlacement };
+                };
+
+                }
             else
             {
                 Load += delegate


### PR DESCRIPTION
When Automatically resize window is set:
1. Fixes #1640 which was caused by mixing screen and working area
coordinates
2. Moves window up and left to try and fit it in the working area
3. Adds option to maximize the editor window when it is larger than
working area (such as when capturing full desktop or multi-monitor).