### PR TITLE
Fix Greenshot editor icon size restraint

### DIFF
--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.cs
@@ -21,7 +21,7 @@ namespace Greenshot
 
         private void LoadSettings()
         {
-            nudIconSize.Value = (int)Math.Round(coreConfiguration.IconSize.Width / 16.0) * 16;
+            nudIconSize.Value = (int)Math.Round(coreConfiguration.IconSize.Width / 8.0) * 8;
             cbMatchSizeToCapture.Checked = editorConfiguration.MatchSizeToCapture;
             cbSuppressSaveDialogAtClose.Checked = editorConfiguration.SuppressSaveDialogAtClose;
             cbRememberLastDrawingMode.Checked = editorConfiguration.RememberLastDrawingMode;


### PR DESCRIPTION
Size allowed to be multiple of 8 not 16