### PR TITLE
Change Pomf Default to more reliable host

### DIFF
--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -264,7 +264,7 @@ namespace ShareX.UploadersLib
 
         // Pomf
 
-        public PomfUploader PomfUploader = new PomfUploader("https://pomf.cat/upload.php", "https://a.pomf.cat");
+        public PomfUploader PomfUploader = new PomfUploader("https://mixtape.moe/upload.php");
 
         // s-ul
 


### PR DESCRIPTION
To fix issue #1720 (https://github.com/ShareX/ShareX/issues/1720).

Pomf.cat's uptime according to http://pomfstatus.sapph.io/ is abysmal and shouldn't be enabled as the default Pomf uploader host destination.