### PR TITLE
Sort destinations by name

### DIFF
--- a/ShareX.UploadersLib/Enums.cs
+++ b/ShareX.UploadersLib/Enums.cs
@@ -30,30 +30,30 @@ namespace ShareX.UploadersLib
     [Description("Image uploaders"), DefaultValue(Imgur)]
     public enum ImageDestination
     {
-        [Description("Imgur")]
-        Imgur,
-        [Description("ImageShack")]
-        ImageShack,
-        [Description("TinyPic")]
-        TinyPic,
-        [Description("Flickr")]
-        Flickr,
-        [Description("Photobucket")]
-        Photobucket,
-        [Description("Google Photos (Picasa)")]
-        Picasa,
-        [Description("Twitter")]
-        Twitter,
         [Description("Chevereto")]
         Chevereto,
-        [Description("vgy.me")]
-        Vgyme,
-        [Description("SomeImage")]
-        SomeImage,
+        [Description("Flickr")]
+        Flickr,
+        [Description("Google Photos (Picasa)")]
+        Picasa,
+        [Description("ImageShack")]
+        ImageShack,
         [Description("Imgland")]
         Imgland,
+        [Description("Imgur")]
+        Imgur,
+        [Description("Photobucket")]
+        Photobucket,
         [Description("SLiMG")]
         Slimg,
+        [Description("SomeImage")]
+        SomeImage,
+        [Description("TinyPic")]
+        TinyPic,
+        [Description("Twitter")]
+        Twitter,
+        [Description("vgy.me")]
+        Vgyme,
         CustomImageUploader, // Localized
         FileUploader // Localized
     }
@@ -61,24 +61,24 @@ namespace ShareX.UploadersLib
     [Description("Text uploaders"), DefaultValue(Pastebin)]
     public enum TextDestination
     {
-        [Description("Pastebin")]
-        Pastebin,
-        [Description("Paste2")]
-        Paste2,
-        [Description("Slexy")]
-        Slexy,
-        [Description("Pastee.org")]
-        Pastee,
-        [Description("Paste.ee")]
-        Paste_ee,
         [Description("GitHub Gist")]
         Gist,
-        [Description("uPaste")]
-        Upaste,
         [Description("Hastebin")]
         Hastebin,
         [Description("OneTimeSecret")]
         OneTimeSecret,
+        [Description("Paste.ee")]
+        Paste_ee,
+        [Description("Paste2")]
+        Paste2,
+        [Description("Pastebin")]
+        Pastebin,
+        [Description("Pastee.org")]
+        Pastee,
+        [Description("Slexy")]
+        Slexy,
+        [Description("uPaste")]
+        Upaste,
         CustomTextUploader, // Localized
         FileUploader // Localized
     }
@@ -86,62 +86,62 @@ namespace ShareX.UploadersLib
     [Description("File uploaders"), DefaultValue(Dropbox)]
     public enum FileDestination
     {
-        [Description("Dropbox")]
-        Dropbox,
-        [Description("FTP")]
-        FTP,
-        [Description("OneDrive")]
-        OneDrive,
-        [Description("Google Drive")]
-        GoogleDrive,
-        [Description("puush")]
-        Puush,
-        [Description("Box")]
-        Box,
-        [Description("MEGA")]
-        Mega,
         [Description("Amazon S3")]
         AmazonS3,
-        [Description("ownCloud")]
-        OwnCloud,
-        [Description("MediaFire")]
-        MediaFire,
-        [Description("Gfycat")]
-        Gfycat,
-        [Description("Pushbullet")]
-        Pushbullet,
-        [Description("SendSpace")]
-        SendSpace,
-        [Description("Minus")]
-        Minus,
+        [Description("Box")]
+        Box,
+        [Description("Dropbox")]
+        Dropbox,
+        [Description("Dropfile")]
+        Dropfile,
+        [Description("FTP")]
+        FTP,
         [Description("Ge.tt")]
         Ge_tt,
+        [Description("Gfycat")]
+        Gfycat,
+        [Description("Google Drive")]
+        GoogleDrive,
         [Description("Hostr")]
         Localhostr,
         [Description("JIRA")]
         Jira,
         [Description("Lambda")]
         Lambda,
-        [Description("VideoBin")]
-        VideoBin,
-        [Description("Pomf")]
-        Pomf,
-        [Description("Uguu")]
-        Uguu,
-        [Description("Dropfile")]
-        Dropfile,
-        [Description("Up1")]
-        Up1,
-        [Description("Seafile")]
-        Seafile,
-        [Description("Streamable")]
-        Streamable,
-        [Description("s-ul")]
-        Sul,
         [Description("Lithiio")]
         Lithiio,
+        [Description("MediaFire")]
+        MediaFire,
+        [Description("MEGA")]
+        Mega,
+        [Description("Minus")]
+        Minus,
+        [Description("OneDrive")]
+        OneDrive,
+        [Description("ownCloud")]
+        OwnCloud,
+        [Description("Pomf")]
+        Pomf,
+        [Description("Pushbullet")]
+        Pushbullet,
+        [Description("puush")]
+        Puush,
+        [Description("s-ul")]
+        Sul,
+        [Description("Seafile")]
+        Seafile,
+        [Description("SendSpace")]
+        SendSpace,
+        [Description("Streamable")]
+        Streamable,
         [Description("transfer.sh")]
         Transfersh,
+        [Description("Uguu")]
+        Uguu,
+        [Description("Up1")]
+        Up1,
+        [Description("VideoBin")]
+        VideoBin,
         SharedFolder, // Localized
         Email, // Localized
         CustomFileUploader // Localized
@@ -150,32 +150,32 @@ namespace ShareX.UploadersLib
     [Description("URL shorteners"), DefaultValue(BITLY)]
     public enum UrlShortenerType
     {
+        [Description("2.gp")]
+        TwoGP,
+        [Description("adf.ly")]
+        AdFly,
         [Description("bit.ly")]
         BITLY,
+        [Description("coinurl.com")]
+        CoinURL,
         [Description("goo.gl")]
         Google,
         [Description("is.gd")]
         ISGD,
-        [Description("v.gd")]
-        VGD,
+        [Description("Polr")]
+        Polr,
+        [Description("qr.net")]
+        QRnet,
         [Description("tinyurl.com")]
         TINYURL,
         [Description("turl.ca")]
         TURL,
-        [Description("yourls.org")]
-        YOURLS,
-        [Description("adf.ly")]
-        AdFly,
-        [Description("coinurl.com")]
-        CoinURL,
-        [Description("qr.net")]
-        QRnet,
+        [Description("v.gd")]
+        VGD,
         [Description("vurl.com")]
         VURL,
-        [Description("2.gp")]
-        TwoGP,
-        [Description("Polr")]
-        Polr,
+        [Description("yourls.org")]
+        YOURLS,
         CustomURLShortener // Localized
     }
 
@@ -183,28 +183,28 @@ namespace ShareX.UploadersLib
     public enum URLSharingServices
     {
         Email, // Localized
-        [Description("Twitter")]
-        Twitter,
+        [Description("Delicious")]
+        Delicious,
         [Description("Facebook")]
         Facebook,
         [Description("Google+")]
         GooglePlus,
-        [Description("Reddit")]
-        Reddit,
-        [Description("Pinterest")]
-        Pinterest,
-        [Description("Tumblr")]
-        Tumblr,
         [Description("LinkedIn")]
         LinkedIn,
-        [Description("StumbleUpon")]
-        StumbleUpon,
-        [Description("Delicious")]
-        Delicious,
-        [Description("VK")]
-        VK,
+        [Description("Pinterest")]
+        Pinterest,
         [Description("Pushbullet")]
         Pushbullet
+        [Description("Reddit")]
+        Reddit,
+        [Description("StumbleUpon")]
+        StumbleUpon,
+        [Description("Tumblr")]
+        Tumblr,
+        [Description("Twitter")]
+        Twitter,
+        [Description("VK")]
+        VK,
     }
 
     public enum HttpMethod


### PR DESCRIPTION
I'm not entirely sure if this will work or not--I haven't actually tried compiling (because I don't want to download the nuget dependencies), but I'm hoping that this will sort the destinations as listed in the context menu (and in the main program as well).

I was recently told that puush was added, and couldn't find it because I was looking under pomf, which I use. It seems that maybe some of the services are currently sorted by popularity (twitter/imgur/pastebin at the tops of their lists), but there's simply too many services for that now, especially for the file uploader.

It would be even nicer to have an option to hide each service from the list, or to automatically hide unconfigured services that don't allow anonymous login.