### PR TITLE
Redraws blue information icon after column resize. Partially fixes #1831.

### DIFF
--- a/ShareX/Forms/MainForm.Designer.cs
+++ b/ShareX/Forms/MainForm.Designer.cs
@@ -318,6 +318,7 @@
             this.lvUploads.ShowItemToolTips = true;
             this.lvUploads.UseCompatibleStateImageBehavior = false;
             this.lvUploads.View = System.Windows.Forms.View.Details;
+            this.lvUploads.ColumnWidthChanged += new System.Windows.Forms.ColumnWidthChangedEventHandler(this.lvUploads_ColumnWidthChanged);
             this.lvUploads.ItemDrag += new System.Windows.Forms.ItemDragEventHandler(this.lvUploads_ItemDrag);
             this.lvUploads.SelectedIndexChanged += new System.EventHandler(this.lvUploads_SelectedIndexChanged);
             this.lvUploads.QueryContinueDrag += new System.Windows.Forms.QueryContinueDragEventHandler(this.lvUploads_QueryContinueDrag);

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -2482,6 +2482,11 @@ namespace ShareX
             CaptureRectangleLight(null, false);
         }
 
+        private void lvUploads_ColumnWidthChanged(object sender, ColumnWidthChangedEventArgs e)
+        {
+            lvUploads.Invalidate(pbTips.Region);
+        }
+
         private void pbPatreonOpen_Click(object sender, EventArgs e)
         {
             URLHelpers.OpenURL(Links.URL_PATREON);


### PR DESCRIPTION
It's still not drawing the icon **while** resizing.