### PR TITLE
Update AmazonS3.cs

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -66,7 +66,7 @@ namespace ShareX.UploadersLib.FileUploaders
     public sealed class AmazonS3 : FileUploader
     {
         public static readonly AmazonS3Region UnknownEndpoint = new AmazonS3Region("Unknown Endpoint");
-        public static readonly AmazonS3Region DreamObjectsEndpoint = new AmazonS3Region("DreamObjects", "dreamobjects", "objects.dreamhost.com");
+        public static readonly AmazonS3Region DreamObjectsEndpoint = new AmazonS3Region("DreamObjects", "dreamobjects", "'objects-us-west-1.dream.io");
 
         private static IList<AmazonS3Region> regionEndpoints = new List<AmazonS3Region>();
 


### PR DESCRIPTION
DreamObjects hostname changes in September. This line needs to be changed so functionality doesn't break.