### PR TITLE
Fixes the error message in debug screen when pressing loaded assemblies button, by not trying to include dynamic assemblies.

### DIFF
--- a/ShareX.HelpersLib/Forms/DebugForm.cs
+++ b/ShareX.HelpersLib/Forms/DebugForm.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
@@ -88,7 +89,7 @@ namespace ShareX.HelpersLib
         {
             StringBuilder sb = new StringBuilder();
             string directoryPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(x => x.IsDynamic == false))
             {
                 if (assembly.Location.StartsWith(directoryPath, StringComparison.InvariantCultureIgnoreCase))
                 {


### PR DESCRIPTION
Fixes the error message in debug screen when pressing loaded assemblies button, by not trying to include dynamic assemblies as these assemblies don't have a location.
Alternative way to fix this is referenced here: [https://github.com/dphoebus/Zbu.ModelsBuilder/commit/1cfb31f24ee6cf58c316519c8554384e1f22a0ec](https://github.com/dphoebus/Zbu.ModelsBuilder/commit/1cfb31f24ee6cf58c316519c8554384e1f22a0ec)
Fixes [706](https://github.com/ShareX/ShareX/issues/706) and [1860](https://github.com/ShareX/ShareX/issues/1860).