### PR TITLE
Don't parse null response string when Picasa upload fails

### DIFF
--- a/ShareX.UploadersLib/ImageUploaders/Picasa.cs
+++ b/ShareX.UploadersLib/ImageUploaders/Picasa.cs
@@ -206,6 +206,9 @@ namespace ShareX.UploadersLib.ImageUploaders
 
             ur.Response = SendRequestStream(url, stream, contentType, headers);
 
+            if (ur.Response == null)
+                return ur;
+
             XDocument xd = XDocument.Parse(ur.Response);
 
             XElement entry_element = xd.Element(AtomNS + "entry");


### PR DESCRIPTION
Skip trying to parse response if it is null. Errors will get reportedly
properly.
Fixes #1983