### PR TITLE
Hide background UWP apps from window capture options

### DIFF
--- a/ShareX.HelpersLib/Native/NativeEnums.cs
+++ b/ShareX.HelpersLib/Native/NativeEnums.cs
@@ -207,6 +207,9 @@ namespace ShareX.HelpersLib
         HasIconicBitmap,
         DisallowPeek,
         ExcludedFromPeek,
+        Cloak,
+        Cloaked,
+        FreezeRepresentation,
         Last
     }
 

--- a/ShareX.HelpersLib/Native/NativeMethods.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods.cs
@@ -393,6 +393,9 @@ namespace ShareX.HelpersLib
         public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out bool pvAttribute, int cbAttribute);
 
         [DllImport("dwmapi.dll")]
+        public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
+        [DllImport("dwmapi.dll")]
         public static extern void DwmEnableBlurBehindWindow(IntPtr hwnd, ref DWM_BLURBEHIND blurBehind);
 
         [DllImport("dwmapi.dll", PreserveSig = false)]

--- a/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
@@ -351,6 +351,9 @@ namespace ShareX.HelpersLib
 
         public static bool IsWindowCloaked(IntPtr handle)
         {
+            if (!IsDWMEnabled())
+                return false;
+
             int cloaked;
             int result = DwmGetWindowAttribute(handle, (int)DwmWindowAttribute.Cloaked, out cloaked, sizeof(int));
             return result == 0 && cloaked != 0;

--- a/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
@@ -349,6 +349,13 @@ namespace ShareX.HelpersLib
             return wp.showCmd == WindowShowStyle.Maximize;
         }
 
+        public static bool IsWindowCloaked(IntPtr handle)
+        {
+            int cloaked;
+            int result = DwmGetWindowAttribute(handle, (int)DwmWindowAttribute.Cloaked, out cloaked, sizeof(int));
+            return result == 0 && cloaked != 0;
+        }
+
         public static IntPtr SetHook(int hookType, HookProc hookProc)
         {
             using (Process currentProcess = Process.GetCurrentProcess())

--- a/ShareX.HelpersLib/Native/WindowInfo.cs
+++ b/ShareX.HelpersLib/Native/WindowInfo.cs
@@ -54,7 +54,9 @@ namespace ShareX.ScreenCaptureLib
 
         public bool IsMinimized => NativeMethods.IsIconic(Handle);
 
-        public bool IsVisible => NativeMethods.IsWindowVisible(Handle);
+        public bool IsVisible => NativeMethods.IsWindowVisible(Handle) && !IsCloaked;
+
+        public bool IsCloaked => NativeMethods.IsWindowCloaked(Handle);
 
         public bool IsActive => NativeMethods.GetForegroundWindow() == Handle;
 


### PR DESCRIPTION
UWP apps that aren't shown are 'cloaked'
Fixes #1960 