### PR TITLE
CLI for Edit Image

### DIFF
--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -61,7 +61,7 @@ namespace ShareX
 
             DebugHelper.WriteLine("Startup time: {0} ms", Program.StartTimer.ElapsedMilliseconds);
 
-            UseCommandLineArgs(Program.CLI.Commands); //TODO: AA
+            UseCommandLineArgs(Program.CLI.Commands);
         }
 
         private void InitializeControls()

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -61,7 +61,7 @@ namespace ShareX
 
             DebugHelper.WriteLine("Startup time: {0} ms", Program.StartTimer.ElapsedMilliseconds);
 
-            UseCommandLineArgs(Program.CLI.Commands);
+            UseCommandLineArgs(Program.CLI.Commands); //TODO: AA
         }
 
         private void InitializeControls()
@@ -721,7 +721,7 @@ namespace ShareX
             {
                 if (command.CheckCommand(job.ToString()))
                 {
-                    ExecuteJob(job);
+                    ExecuteJob(TaskSettings.GetDefaultTaskSettings(), job, command);
                     return true;
                 }
             }
@@ -1754,7 +1754,7 @@ namespace ShareX
             ExecuteJob(taskSettings, taskSettings.Job);
         }
 
-        private void ExecuteJob(TaskSettings taskSettings, HotkeyType job)
+        private void ExecuteJob(TaskSettings taskSettings, HotkeyType job, CLICommand command = null)
         {
             DebugHelper.WriteLine("Executing: " + job.GetLocalizedDescription());
 
@@ -1860,7 +1860,11 @@ namespace ShareX
                     TaskHelpers.OpenScreenColorPicker(safeTaskSettings);
                     break;
                 case HotkeyType.ImageEditor:
-                    TaskHelpers.AnnotateImage();
+                    if (command != null)
+                        if (!string.IsNullOrEmpty(command.Parameter))
+                            TaskHelpers.AnnotateImage(command.Parameter);
+                    else
+                        TaskHelpers.AnnotateImage(taskSettings);
                     break;
                 case HotkeyType.ImageEffects:
                     TaskHelpers.OpenImageEffects();

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -605,7 +605,7 @@ namespace ShareX
 
         public static void AnnotateImage(string filePath, TaskSettings taskSettings = null)
         {
-            if (!string.IsNullOrEmpty(filePath))
+            if (!string.IsNullOrEmpty(filePath) && File.Exists(filePath))
             {
                 if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
@@ -617,6 +617,10 @@ namespace ShareX
                 {
                     AnnotateImageUsingGreenshot(null, filePath);
                 }
+            }
+            else
+            {
+                AnnotateImage(taskSettings);
             }
         }
 


### PR DESCRIPTION
Added capability to pass a file path as a parameter to the ImageEditor
CLICommand so it doesn't prompt an open file dialog if a valid image path
has been given in the CLI already and fixes #1990.