### PR TITLE
Updated imgfly.me to HTTPS

### DIFF
--- a/ShareX.UploadersLib/ImageUploaders/Chevereto.cs
+++ b/ShareX.UploadersLib/ImageUploaders/Chevereto.cs
@@ -73,7 +73,7 @@ namespace ShareX.UploadersLib.ImageUploaders
             new CheveretoUploader("https://pixr.co/api/1/upload", "8fff10a8b0d2852c4167db53aa590e94"),
             new CheveretoUploader("https://sexr.co/api/1/upload", "46b9aa05ec994098c4b6f18b5eed5e36"),
             new CheveretoUploader("http://lightpics.net/api/1/upload", "7c6238e8f24c19454315d5dc812d4b93"),
-            new CheveretoUploader("http://imgfly.me/api/1/upload", "c6133147592983996b65dda51ba70255"),
+            new CheveretoUploader("https://imgfly.me/api/1/upload", "c6133147592983996b65dda51ba70255"),
             new CheveretoUploader("http://imgpinas.com/api/1/upload", "7153eeee787ccbb4b01bea44ec0e699e"),
             new CheveretoUploader("http://imu.gr/api/1/upload", "a8e5fcfb79df9be675a6aa0a1541a89e"),
             new CheveretoUploader("http://www.upsieutoc.com/api/1/upload", "c692ca0925f8da5990e8c795602bf942"),


### PR DESCRIPTION
Imgfly.me is now serving with HTTPS and it's needed to update the link for properly access the API.