### PR TITLE
Add NVENC support to FFmpeg options.

### DIFF
--- a/ShareX.ScreenCaptureLib/Enums.cs
+++ b/ShareX.ScreenCaptureLib/Enums.cs
@@ -89,6 +89,8 @@ namespace ShareX.ScreenCaptureLib
     {
         [Description("x264 (mp4)")]
         libx264,
+        [Description("x264-nvenc (mp4)")]
+        h264_nvenc,
         [Description("VP8 (webm)")]
         libvpx,
         [Description("Xvid (avi)")]

--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
@@ -44,6 +44,7 @@ namespace ShareX.ScreenCaptureLib
 
         // Video
         public FFmpegPreset x264_Preset { get; set; }
+        public string x264nvenc_Preset { get; set; }
         public int x264_CRF { get; set; }
         public int VPx_bitrate { get; set; }  // kbit/s
         public int XviD_qscale { get; set; }
@@ -91,6 +92,7 @@ namespace ShareX.ScreenCaptureLib
                     switch (VideoCodec)
                     {
                         case FFmpegVideoCodec.libx264:
+                        case FFmpegVideoCodec.h264_nvenc:
                         case FFmpegVideoCodec.libx265:
                         case FFmpegVideoCodec.gif:
                             return "mp4";
@@ -156,6 +158,7 @@ namespace ShareX.ScreenCaptureLib
             // Video
             x264_CRF = 28;
             x264_Preset = FFmpegPreset.ultrafast;
+            x264nvenc_Preset = "default";
             VPx_bitrate = 3000;
             XviD_qscale = 10;
             GIFStatsMode = FFmpegPaletteGenStatsMode.full;

--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegOptionsForm.cs
@@ -293,6 +293,7 @@ namespace ShareX.ScreenCaptureLib
                 {
                     default:
                     case FFmpegVideoCodec.libx264:
+                    case FFmpegVideoCodec.h264_nvenc:
                     case FFmpegVideoCodec.libx265:
                         tcFFmpegVideoCodecs.SelectedIndex = 0;
                         break;

--- a/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
@@ -171,6 +171,10 @@ namespace ShareX.ScreenCaptureLib
                         args.AppendFormat("-crf {0} ", FFmpeg.x264_CRF);
                         args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // -pix_fmt yuv420p required otherwise can't stream in Chrome
                         break;
+                    case FFmpegVideoCodec.h264_nvenc:
+                        args.AppendFormat("-preset {0} ", FFmpeg.x264nvenc_Preset); // TODO: make this configurable.
+                        args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // otherwise you will get a No NVENC capable devices found.
+                        break;
                     case FFmpegVideoCodec.libvpx: // https://trac.ffmpeg.org/wiki/Encode/VP8
                         args.AppendFormat("-deadline {0} ", "realtime");
                         args.AppendFormat("-b:v {0}k ", FFmpeg.VPx_bitrate);


### PR DESCRIPTION
This makes it easier for those who own NVIDIA cards to use NVENC encoder that FFmpeg provides.