### PR TITLE
Update ImageHelpers.cs

### DIFF
--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1112,7 +1112,7 @@ namespace ShareX.HelpersLib
             int w = unsafeBitmap.Width;
             int h = unsafeBitmap.Height;
             int halfRange = range / 2;
-            ColorBgra[] newColors = new ColorBgra[w];
+            ColorBgra[] newColors = new ColorBgra[h];
 
             for (int x = 0; x < w; x++)
             {


### PR DESCRIPTION
Index Out Of Range when using Blur filter on a portrait picture
y maximum is 'y < h' so newColors array should be sized from h, not w