### PR TITLE
Fixed missing header for dev version of Nextcloud

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -139,7 +139,10 @@ namespace ShareX.UploadersLib.FileUploaders
 
             string url = URLHelpers.CombineURL(Host, "ocs/v1.php/apps/files_sharing/api/v1/shares?format=json");
             url = URLHelpers.FixPrefix(url);
+            
             NameValueCollection headers = CreateAuthenticationHeader(Username, Password);
+            headers["OCS-APIREQUEST"] = "true";
+            
             string response = SendRequestMultiPart(url, args, headers);
 
             if (!string.IsNullOrEmpty(response))


### PR DESCRIPTION
Overlooked this in my last commit since it worked fine without it at in the non dev version.