### PR TITLE
ResizeIfSmaller Option for Resizing

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -167,4 +167,14 @@ namespace ShareX.HelpersLib
         Failed,
         NotConfigured
     }
+
+	public enum ResizeMode
+	{
+		[Description("Resizes all images to the specified size.")]
+		ResizeAll,
+		[Description("Only resize image if it is bigger than specified size.")]
+		ResizeIfBigger,
+		[Description("Only resize image if it is smaller than specified size.")]
+		ResizeIfSmaller
+	}
 }

--- a/ShareX.ImageEffectsLib/Manipulations/Resize.cs
+++ b/ShareX.ImageEffectsLib/Manipulations/Resize.cs
@@ -37,8 +37,8 @@ namespace ShareX.ImageEffectsLib
         [DefaultValue(0), Description("Use height as 0 to automatically adjust height to maintain aspect ratio.")]
         public int Height { get; set; }
 
-        [DefaultValue(false), Description("Only resize image if it is bigger than specified size.")]
-        public bool ResizeIfBigger { get; set; }
+		[DefaultValue(ResizeMode.ResizeAll)]
+		public ResizeMode Mode { get; set; }
 
         public Resize()
         {
@@ -52,10 +52,8 @@ namespace ShareX.ImageEffectsLib
             int width = Width <= 0 ? (int)((float)Height / img.Height * img.Width) : Width;
             int height = Height <= 0 ? (int)((float)Width / img.Width * img.Height) : Height;
 
-            if (ResizeIfBigger && img.Width <= width && img.Height <= height)
-            {
-                return img;
-            }
+			if (Mode == ResizeMode.ResizeIfBigger && img.Width <= width && img.Height <= height)  return img;
+			if (Mode == ResizeMode.ResizeIfSmaller && img.Width >= width && img.Height >= height)  return img;
 
             return ImageHelpers.ResizeImage(img, width, height);
         }


### PR DESCRIPTION
My main issue with the resizing image effect is there should be an option for those (like myself) who would like to only resize if the image is smaller! Currently you either get big images resized or you get all images resized, but not small images resized while big images are left alone. I propose we use three modes to choose from for resizing options. The modes would be the following: resizing all images, resizing only bigger images, and resizing only smaller images . The default being to resize all images.