### PR TITLE
Fixed line endings for Hastebin Text upload

### DIFF
--- a/ShareX.UploadersLib/TextUploaders/Hastebin.cs
+++ b/ShareX.UploadersLib/TextUploaders/Hastebin.cs
@@ -76,7 +76,7 @@ namespace ShareX.UploadersLib.TextUploaders
                     domain = "https://hastebin.com";
                 }
 
-                ur.Response = SendRequest(HttpMethod.POST, URLHelpers.CombineURL(domain, "documents"), text);
+                ur.Response = SendRequest(HttpMethod.POST, URLHelpers.CombineURL(domain, "documents"), text.Replace("\r\n", "\n"));
 
                 if (!string.IsNullOrEmpty(ur.Response))
                 {


### PR DESCRIPTION
I have a modified Hastebin installation that has some more features, and I use \n to extract the line counting from the source file. However, when I upload a text file through ShareX, it uses \r\n as a line ending. So this is easily fixed by doing `text.Replace("\r\n", "\n")`.
Everything will still work normally on a default installation of Hastebin.

Example:
Before: https://paste.projectdev.org/utuhijurir
After: https://paste.projectdev.org/sofugumufa