### PR TITLE
Changed Ctrl to Control

### DIFF
--- a/ShareX/Forms/QRCodeForm.resx
+++ b/ShareX/Forms/QRCodeForm.resx
@@ -125,7 +125,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="tsmiCopy.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+C</value>
+    <value>Control+C</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="tsmiCopy.Size" type="System.Drawing.Size, System.Drawing">
@@ -135,7 +135,7 @@
     <value>Copy to clipboard</value>
   </data>
   <data name="tsmiSaveAs.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+S</value>
+    <value>Control+S</value>
   </data>
   <data name="tsmiSaveAs.Size" type="System.Drawing.Size, System.Drawing">
     <value>191, 22</value>


### PR DESCRIPTION
Changed 'Ctrl' to 'Control' for a multi-language keyboard support.
According to this issue: https://social.msdn.microsoft.com/Forums/vstudio/en-US/9ab50ba0-9be1-49e8-b4f6-7cfd97eccf10/msbuild-cannot-process-resource-files?forum=msbuild