### PR TITLE
Actions toolbar can now be placed on other monitors.

### DIFF
--- a/ShareX/Forms/ActionsToolbarForm.cs
+++ b/ShareX/Forms/ActionsToolbarForm.cs
@@ -199,7 +199,7 @@ namespace ShareX
         private void CheckToolbarPosition()
         {
             Rectangle rectToolbar = Bounds;
-            Rectangle rectScreen = CaptureHelpers.GetScreenWorkingArea();
+            Rectangle rectScreen = SystemInformation.VirtualScreen;
             Point pos = rectToolbar.Location;
 
             if (rectToolbar.Width < rectScreen.Width)


### PR DESCRIPTION
I used answers in this thread as a solution http://stackoverflow.com/questions/1317235/c-get-complete-desktop-size

Fixes #2354 