### PR TITLE
PVS-Studio: fixed two errors

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/SendSpaceManager.cs
+++ b/ShareX.UploadersLib/FileUploaders/SendSpaceManager.cs
@@ -63,7 +63,7 @@ namespace ShareX.UploadersLib.FileUploaders
                         Token = sendSpace.AuthCreateToken();
                         if (string.IsNullOrEmpty(Token)) throw new Exception("Token is null or empty.");
                     }
-                    if (string.IsNullOrEmpty(SessionKey) || (DateTime.Now - LastSessionKey).Minutes > 30)
+                    if (string.IsNullOrEmpty(SessionKey) || (DateTime.Now - LastSessionKey).TotalMinutes > 30)
                     {
                         SessionKey = sendSpace.AuthLogin(Token, username, password).SessionKey;
                         if (string.IsNullOrEmpty(Token)) throw new Exception("SessionKey is null or empty.");


### PR DESCRIPTION
## We have found and fixed two errors using PVS-Studio tool.

PVS-Studio is a static code analyzer for C, C++ and C#.

### Fixes:

1. _[V3084](https://www.viva64.com/en/w/V3084/) Anonymous function is used to unsubscribe from 'PropertyChanged' event. No handlers will be unsubscribed, as a separate delegate instance is created for each anonymous function declaration. Greenshot.ImageEditor AbstractFieldHolder.cs 105_
> Before my fixes 'RemoveField' method not unsubscribed handler from 'field.PropertyChanged' event, because delegate on subscribing and delegate on unsubscribing it's different objects with same body. I added a dictionary with keys and handlers for storing it's after subscribing and correct unsubscribing.

2. _[V3118](https://www.viva64.com/en/w/V3118/) Minutes component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMinutes' value was intended instead. ShareX.UploadersLib SendSpaceManager.cs 66_
> Using 'Minutes' property of TimeSpan not represent full time interval, therefore I changed it to 'TotalMinutes'.