### PR TITLE
Updated gfycat to use newer oauth2 api

### DIFF
--- a/ShareX.UploadersLib/APIKeys/APIKeys.cs
+++ b/ShareX.UploadersLib/APIKeys/APIKeys.cs
@@ -61,6 +61,8 @@ namespace ShareX.UploadersLib
         public static string MediaFireApiKey = "";
         public static string OneDriveClientID = "";
         public static string OneDriveClientSecret = "";
+        public static string GfycatClientID = "";
+        public static string GfycatClientSecret = "";
 
         // Text Uploaders
         public static string PastebinKey = "";

--- a/ShareX.UploadersLib/FileUploaders/GfycatUploader.cs
+++ b/ShareX.UploadersLib/FileUploaders/GfycatUploader.cs
@@ -28,8 +28,10 @@
 using Newtonsoft.Json;
 using ShareX.HelpersLib;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.FileUploaders
 {
@@ -37,103 +39,264 @@ namespace ShareX.UploadersLib.FileUploaders
     {
         public override FileDestination EnumValue { get; } = FileDestination.Gfycat;
 
-        public override bool CheckConfig(UploadersConfig config) => true;
+        public override bool CheckConfig(UploadersConfig config)
+        {
+            return config.GfycatAccountType == AccountType.Anonymous || OAuth2Info.CheckOAuth(config.GfycatOAuth2Info);
+        }
 
         public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
         {
-            return new GfycatUploader();
+            if (config.GfycatOAuth2Info == null)
+            {
+                config.GfycatOAuth2Info = new OAuth2Info(APIKeys.GfycatClientID, APIKeys.GfycatClientSecret);
+            }
+            return new GfycatUploader(config.GfycatOAuth2Info)
+            {
+                UploadMethod = config.GfycatAccountType,
+                Private = !config.GfycatIsPublic,
+            };
         }
+
+        public override TabPage GetUploadersConfigTabPage(UploadersConfigForm form) => form.tpImgur;
     }
 
-    public class GfycatUploader : FileUploader
+    public class GfycatUploader : FileUploader, IOAuth2
     {
         public bool NoResize { get; set; }
         public bool IgnoreExisting { get; set; }
+        public bool Private { get; set; }
+        public OAuth2Info AuthInfo { get; set; }
+        public AccountType UploadMethod { get; set; }
+        public OAuth2Token AnonymousToken { get; set; }
 
-        public GfycatUploader()
+        private const string URL_AUTHORIZE = "https://gfycat.com/oauth/authorize";
+        private const string URL_UPLOAD = "https://filedrop.gfycat.com";
+        private const string URL_API = "https://api.gfycat.com/v1";
+        private const string URL_API_TOKEN = URL_API + "/oauth/token";
+        private const string URL_API_CREATE_GFY = URL_API + "/gfycats";
+        private const string URL_API_STATUS = URL_API + "/gfycats/fetch/status/";
+
+        public GfycatUploader(OAuth2Info oauth)
         {
+            AuthInfo = oauth;
             NoResize = true;
             IgnoreExisting = false;
         }
 
+        public string GetAuthorizationURL()
+        {
+            Dictionary<string, string> args = new Dictionary<string, string>();
+            args.Add("client_id", AuthInfo.Client_ID);
+            args.Add("scope", "all");
+            args.Add("state", "sharex");
+            args.Add("response_type", "code");
+            args.Add("redirect_uri", Links.URL_CALLBACK);
+
+            return CreateQuery(URL_AUTHORIZE, args);
+        }
+
+        public bool GetAccessToken(string code)
+        {
+            string request = JsonConvert.SerializeObject(new
+            {
+                client_id = AuthInfo.Client_ID,
+                client_secret = AuthInfo.Client_Secret,
+                grant_type = "authorization_code",
+                redirect_uri = Links.URL_CALLBACK,
+                code = code,
+            });
+
+            string response = SendRequest(HttpMethod.POST, URL_API_TOKEN, request, ContentTypeJSON);
+
+            if (!string.IsNullOrEmpty(response))
+            {
+                OAuth2Token token = JsonConvert.DeserializeObject<OAuth2Token>(response);
+
+                if (token != null && !string.IsNullOrEmpty(token.access_token))
+                {
+                    token.UpdateExpireDate();
+                    AuthInfo.Token = token;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool RefreshAccessToken()
+        {
+            if (OAuth2Info.CheckOAuth(AuthInfo) && !string.IsNullOrEmpty(AuthInfo.Token.refresh_token))
+            {
+                string request = JsonConvert.SerializeObject(new
+                {
+                    refresh_token = AuthInfo.Token.refresh_token,
+                    client_id = AuthInfo.Client_ID,
+                    client_secret = AuthInfo.Client_Secret,
+                    grant_type = "refresh",
+                });
+
+                string response = SendRequest(HttpMethod.POST, URL_API_TOKEN, request, ContentTypeJSON);
+
+                if (!string.IsNullOrEmpty(response))
+                {
+                    OAuth2Token token = JsonConvert.DeserializeObject<OAuth2Token>(response);
+
+                    if (token != null && !string.IsNullOrEmpty(token.access_token))
+                    {
+                        token.UpdateExpireDate();
+                        AuthInfo.Token = token;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool CheckAuthorization()
+        {
+            if (OAuth2Info.CheckOAuth(AuthInfo))
+            {
+                if (AuthInfo.Token.IsExpired && !RefreshAccessToken())
+                {
+                    Errors.Add("Refresh access token failed.");
+                    return false;
+                }
+            }
+            else
+            {
+                Errors.Add("Gfycat login is required.");
+                return false;
+            }
+
+            return true;
+        }
+
         public override UploadResult Upload(Stream stream, string fileName)
         {
-            // Magical official values from http://www.reddit.com/r/gfycat/comments/20xbth/any_word_on_allowing_uploading_a_gif_through_the/
+            OAuth2Token token = GetOrCreateToken();
+            if (token == null)
+            {
+                return null;
+            }
+            NameValueCollection headers = new NameValueCollection();
+            headers.Add("Authorization", "Bearer " + token.access_token);
+            GfycatCreateResponse gfy = CreateGfycat(headers);
+            if (gfy == null)
+            {
+                return null;
+            }
             Dictionary<string, string> args = new Dictionary<string, string>();
-            args.Add("key", Helpers.GetRandomAlphanumeric(10));
-            args.Add("acl", "private");
-            args.Add("AWSAccessKeyId", "AKIAIT4VU4B7G2LQYKZQ");
-            args.Add("policy", "eyAiZXhwaXJhdGlvbiI6ICIyMDIwLTEyLTAxVDEyOjAwOjAwLjAwMFoiLAogICAgICAgICAgICAiY29uZGl0aW9ucyI6IFsKICAgICAgICAgICAgeyJidWNrZXQiOiAiZ2lmYWZmZSJ9LAogICAgICAgICAgICBbInN0YXJ0cy13aXRoIiwgIiRrZXkiLCAiIl0sCiAgICAgICAgICAgIHsiYWNsIjogInByaXZhdGUifSwKCSAgICB7InN1Y2Nlc3NfYWN0aW9uX3N0YXR1cyI6ICIyMDAifSwKICAgICAgICAgICAgWyJzdGFydHMtd2l0aCIsICIkQ29udGVudC1UeXBlIiwgIiJdLAogICAgICAgICAgICBbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwgMCwgNTI0Mjg4MDAwXQogICAgICAgICAgICBdCiAgICAgICAgICB9");
-            args.Add("success_action_status", "200");
-            args.Add("signature", "mk9t/U/wRN4/uU01mXfeTe2Kcoc=");
-            args.Add("Content-Type", Helpers.GetMimeType(fileName));
-
-            UploadResult result = SendRequestFile("https://gifaffe.s3.amazonaws.com/", stream, fileName, "file", args);
-
+            args.Add("key", gfy.GfyName);
+            UploadResult result = SendRequestFile(URL_UPLOAD, stream, fileName, "file", args);
             if (!result.IsError)
             {
-                TranscodeFile(args["key"], result);
+                WaitForTranscode(gfy.GfyName, result);
             }
 
             return result;
         }
 
-        private void TranscodeFile(string key, UploadResult result)
+        private void WaitForTranscode(string name, UploadResult result)
         {
-            Dictionary<string, string> args = new Dictionary<string, string>();
-            if (NoResize) args.Add("noResize", "true");
-            if (IgnoreExisting) args.Add("noMd5", "true");
+            ProgressManager progress = new ProgressManager(10000);
 
-            string transcodeJson = SendRequest(HttpMethod.GET, "https://upload.gfycat.com/transcodeRelease/" + key, args);
-            GfycatTranscodeResponse transcodeResponse = JsonConvert.DeserializeObject<GfycatTranscodeResponse>(transcodeJson);
-
-            if (transcodeResponse.IsOk)
+            if (AllowReportProgress)
             {
-                ProgressManager progress = new ProgressManager(10000);
+                OnProgressChanged(progress);
+            }
 
-                if (AllowReportProgress)
+            int iterations = 0;
+            while (!StopUploadRequested)
+            {
+                string statusJson = SendRequest(HttpMethod.GET, URL_API_STATUS + name);
+                GfycatStatusResponse response = JsonConvert.DeserializeObject<GfycatStatusResponse>(statusJson);
+
+                if (response.Error != null)
+                {
+                    Errors.Add(response.Error);
+                    result.IsSuccess = false;
+                    break;
+                }
+                else if (response.GfyName != null)
+                {
+                    result.IsSuccess = true;
+                    result.URL = "https://gfycat.com/" + response.GfyName;
+                    break;
+                } else if (response.Task == "NotFoundo" && iterations > 10)
+                {
+                    Errors.Add("Gfy not found");
+                    result.IsSuccess = false;
+                    break;
+                }
+
+                if (AllowReportProgress && progress.UpdateProgress((progress.Length - progress.Position) / response.Time))
                 {
                     OnProgressChanged(progress);
                 }
 
-                while (!StopUploadRequested)
+                Thread.Sleep(100);
+                iterations++;
+            }
+        }
+
+        private GfycatCreateResponse CreateGfycat(NameValueCollection headers)
+        {
+            Dictionary<string, object> args = new Dictionary<string, object>();
+            args.Add("private", Private);
+            args.Add("noResize", NoResize);
+            args.Add("noMd5", IgnoreExisting);
+            string response = SendRequest(HttpMethod.POST, URL_API_CREATE_GFY, JsonConvert.SerializeObject(args), ContentTypeJSON, null, headers);
+            if (!string.IsNullOrEmpty(response))
+            {
+                return JsonConvert.DeserializeObject<GfycatCreateResponse>(response);
+            }
+
+            return null;
+        }
+
+        private OAuth2Token GetOrCreateToken()
+        {
+            if (UploadMethod == AccountType.User)
+            {
+                if (!CheckAuthorization())
                 {
-                    string statusJson = SendRequest(HttpMethod.GET, "https://upload.gfycat.com/status/" + key);
-                    GfycatStatusResponse response = JsonConvert.DeserializeObject<GfycatStatusResponse>(statusJson);
-
-                    if (response.Error != null)
-                    {
-                        Errors.Add(response.Error);
-                        result.IsSuccess = false;
-                        break;
-                    }
-                    else if (response.GfyName != null)
-                    {
-                        result.IsSuccess = true;
-                        result.URL = "https://gfycat.com/" + response.GfyName;
-                        break;
-                    }
-
-                    if (AllowReportProgress && progress.UpdateProgress((progress.Length - progress.Position) / response.Time))
-                    {
-                        OnProgressChanged(progress);
-                    }
-
-                    Thread.Sleep(100);
+                    return null;
                 }
+                return AuthInfo.Token;
             }
             else
             {
-                Errors.Add(transcodeResponse.Error);
-                result.IsSuccess = false;
+                if (AnonymousToken == null || AnonymousToken.IsExpired)
+                {
+                    string request = JsonConvert.SerializeObject(new
+                    {
+                        client_id = AuthInfo.Client_ID,
+                        client_secret = AuthInfo.Client_Secret,
+                        grant_type = "client_credentials",
+                    });
+
+                    string response = SendRequest(HttpMethod.POST, URL_API_TOKEN, request, ContentTypeJSON);
+
+                    if (!string.IsNullOrEmpty(response))
+                    {
+                        AnonymousToken = JsonConvert.DeserializeObject<OAuth2Token>(response);
+
+                        if (AnonymousToken != null && !string.IsNullOrEmpty(AnonymousToken.access_token))
+                        {
+                            AnonymousToken.UpdateExpireDate();
+                        }
+                    }
+                }
+                return AnonymousToken;
             }
         }
     }
 
-    public class GfycatTranscodeResponse
+    public class GfycatCreateResponse
     {
-        public bool IsOk { get; set; }
-        public string Error { get; set; }
+        public string GfyName { get; set; }
+        public string Secret { get; set; }
     }
 
     public class GfycatStatusResponse

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -458,6 +458,9 @@
             this.nudEmailSmtpPort = new System.Windows.Forms.NumericUpDown();
             this.lblEmailSmtpPort = new System.Windows.Forms.Label();
             this.txtEmailDefaultSubject = new System.Windows.Forms.TextBox();
+            this.tpGfycat = new System.Windows.Forms.TabPage();
+            this.atcGfycatAccountType = new ShareX.UploadersLib.AccountTypeControl();
+            this.oauth2Gfycat = new ShareX.UploadersLib.OAuthControl();
             this.btnCopyShowFiles = new System.Windows.Forms.Button();
             this.tpTextUploaders = new System.Windows.Forms.TabPage();
             this.tcTextUploaders = new System.Windows.Forms.TabControl();
@@ -599,6 +602,7 @@
             this.ttlvMain = new ShareX.HelpersLib.TabToListView();
             this.actRapidShareAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.cbGfycatIsPublic = new System.Windows.Forms.CheckBox();
             this.tpOtherUploaders.SuspendLayout();
             this.tcOtherUploaders.SuspendLayout();
             this.tpTwitter.SuspendLayout();
@@ -663,6 +667,7 @@
             this.tpSharedFolder.SuspendLayout();
             this.tpEmail.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudEmailSmtpPort)).BeginInit();
+            this.tpGfycat.SuspendLayout();
             this.tpTextUploaders.SuspendLayout();
             this.tcTextUploaders.SuspendLayout();
             this.tpPastebin.SuspendLayout();
@@ -1738,6 +1743,7 @@
             this.tcFileUploaders.Controls.Add(this.tpPlik);
             this.tcFileUploaders.Controls.Add(this.tpSharedFolder);
             this.tcFileUploaders.Controls.Add(this.tpEmail);
+            this.tcFileUploaders.Controls.Add(this.tpGfycat);
             resources.ApplyResources(this.tcFileUploaders, "tcFileUploaders");
             this.tcFileUploaders.Multiline = true;
             this.tcFileUploaders.Name = "tcFileUploaders";
@@ -3814,6 +3820,31 @@
             this.txtEmailDefaultSubject.Name = "txtEmailDefaultSubject";
             this.txtEmailDefaultSubject.TextChanged += new System.EventHandler(this.txtDefaultSubject_TextChanged);
             // 
+            // tpGfycat
+            // 
+            this.tpGfycat.Controls.Add(this.cbGfycatIsPublic);
+            this.tpGfycat.Controls.Add(this.atcGfycatAccountType);
+            this.tpGfycat.Controls.Add(this.oauth2Gfycat);
+            resources.ApplyResources(this.tpGfycat, "tpGfycat");
+            this.tpGfycat.Name = "tpGfycat";
+            this.tpGfycat.UseVisualStyleBackColor = true;
+            // 
+            // atcGfycatAccountType
+            // 
+            resources.ApplyResources(this.atcGfycatAccountType, "atcGfycatAccountType");
+            this.atcGfycatAccountType.Name = "atcGfycatAccountType";
+            this.atcGfycatAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
+            this.atcGfycatAccountType.AccountTypeChanged += new ShareX.UploadersLib.AccountTypeControl.AccountTypeChangedEventHandler(this.atcGfycatAccountType_AccountTypeChanged);
+            // 
+            // oauth2Gfycat
+            // 
+            resources.ApplyResources(this.oauth2Gfycat, "oauth2Gfycat");
+            this.oauth2Gfycat.Name = "oauth2Gfycat";
+            this.oauth2Gfycat.OpenButtonClicked += new ShareX.UploadersLib.OAuthControl.OpenButtonClickedEventHandler(this.oauth2Gfycat_OpenButtonClicked);
+            this.oauth2Gfycat.CompleteButtonClicked += new ShareX.UploadersLib.OAuthControl.CompleteButtonClickedEventHandler(this.oauth2Gfycat_CompleteButtonClicked);
+            this.oauth2Gfycat.ClearButtonClicked += new ShareX.UploadersLib.OAuthControl.ClearButtonclickedEventHandler(this.oauth2Gfycat_ClearButtonClicked);
+            this.oauth2Gfycat.RefreshButtonClicked += new ShareX.UploadersLib.OAuthControl.RefreshButtonClickedEventHandler(this.oauth2Gfycat_RefreshButtonClicked);
+            // 
             // btnCopyShowFiles
             // 
             resources.ApplyResources(this.btnCopyShowFiles, "btnCopyShowFiles");
@@ -4828,6 +4859,13 @@
             this.actRapidShareAccountType.Name = "actRapidShareAccountType";
             this.actRapidShareAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
             // 
+            // cbGfycatIsPublic
+            // 
+            resources.ApplyResources(this.cbGfycatIsPublic, "cbGfycatIsPublic");
+            this.cbGfycatIsPublic.Name = "cbGfycatIsPublic";
+            this.cbGfycatIsPublic.UseVisualStyleBackColor = true;
+            this.cbGfycatIsPublic.CheckedChanged += new System.EventHandler(this.cbGfycatIsPublic_CheckedChanged);
+            // 
             // UploadersConfigForm
             // 
             resources.ApplyResources(this, "$this");
@@ -4952,6 +4990,8 @@
             this.tpEmail.ResumeLayout(false);
             this.tpEmail.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudEmailSmtpPort)).EndInit();
+            this.tpGfycat.ResumeLayout(false);
+            this.tpGfycat.PerformLayout();
             this.tpTextUploaders.ResumeLayout(false);
             this.tcTextUploaders.ResumeLayout(false);
             this.tpPastebin.ResumeLayout(false);
@@ -5568,5 +5608,9 @@
         private System.Windows.Forms.Label lblAmazonS3Endpoint;
         private System.Windows.Forms.CheckBox cbDropboxUseDirectLink;
         private System.Windows.Forms.CheckBox cbAmazonS3UsePathStyle;
+        private System.Windows.Forms.TabPage tpGfycat;
+        private OAuthControl oauth2Gfycat;
+        private AccountTypeControl atcGfycatAccountType;
+        private System.Windows.Forms.CheckBox cbGfycatIsPublic;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -621,6 +621,17 @@ namespace ShareX.UploadersLib
             txtPlikLogin.ReadOnly = !cbPlikIsSecured.Checked;
             txtPlikPassword.ReadOnly = !cbPlikIsSecured.Checked;
 
+            // Gfycat
+
+            oauth2Gfycat.Enabled = Config.GfycatAccountType == AccountType.User;
+
+            if (OAuth2Info.CheckOAuth(Config.GfycatOAuth2Info))
+            {
+                oauth2Gfycat.Status = OAuthLoginStatus.LoginSuccessful;
+            }
+
+            atcGfycatAccountType.SelectedAccountType = Config.GfycatAccountType;
+
             #endregion File uploaders
 
             #region URL shorteners
@@ -2742,6 +2753,41 @@ namespace ShareX.UploadersLib
         }
 
         #endregion Plik
+
+        #region Gfycat
+
+        private void atcGfycatAccountType_AccountTypeChanged(AccountType accountType)
+        {
+            Config.GfycatAccountType = accountType;
+            oauth2Gfycat.Enabled = Config.GfycatAccountType == AccountType.User;
+        }
+
+        private void oauth2Gfycat_OpenButtonClicked()
+        {
+            GfycatAuthOpen();
+        }
+
+        private void oauth2Gfycat_CompleteButtonClicked(string code)
+        {
+            GfycatAuthComplete(code);
+        }
+
+        private void oauth2Gfycat_ClearButtonClicked()
+        {
+            Config.GfycatOAuth2Info = null;
+        }
+
+        private void oauth2Gfycat_RefreshButtonClicked()
+        {
+            GfycatAuthRefresh();
+        }
+
+        private void cbGfycatIsPublic_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.GfycatIsPublic = cbGfycatIsPublic.Checked;
+        }
+
+        #endregion Gfycat
 
         #endregion File Uploaders
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -11161,6 +11161,105 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;tpEmail.ZOrder" xml:space="preserve">
     <value>26</value>
   </data>
+  <data name="cbGfycatIsPublic.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGfycatIsPublic.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGfycatIsPublic.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 310</value>
+  </data>
+  <data name="cbGfycatIsPublic.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 17</value>
+  </data>
+  <data name="cbGfycatIsPublic.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cbGfycatIsPublic.Text" xml:space="preserve">
+    <value>Is public upload?</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Name" xml:space="preserve">
+    <value>cbGfycatIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="atcGfycatAccountType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="atcGfycatAccountType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 40</value>
+  </data>
+  <data name="atcGfycatAccountType.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Name" xml:space="preserve">
+    <value>atcGfycatAccountType</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="oauth2Gfycat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 64</value>
+  </data>
+  <data name="oauth2Gfycat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>328, 240</value>
+  </data>
+  <data name="oauth2Gfycat.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Name" xml:space="preserve">
+    <value>oauth2Gfycat</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpGfycat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpGfycat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGfycat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 475</value>
+  </data>
+  <data name="tpGfycat.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="tpGfycat.Text" xml:space="preserve">
+    <value>Gfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
   <data name="tcFileUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -1979,5 +1979,86 @@ namespace ShareX.UploadersLib
         }
 
         #endregion Gist
+        #region Gfycat
+
+        private void GfycatAuthOpen()
+        {
+            try
+            {
+                OAuth2Info oauth = new OAuth2Info(APIKeys.GfycatClientID, APIKeys.GfycatClientSecret);
+
+                string url = new GfycatUploader(oauth).GetAuthorizationURL();
+
+                if (!string.IsNullOrEmpty(url))
+                {
+                    Config.GfycatOAuth2Info = oauth;
+                    URLHelpers.OpenURL(url);
+                    DebugHelper.WriteLine("GfycatAuthOpen - Authorization URL is opened: " + url);
+                }
+                else
+                {
+                    DebugHelper.WriteLine("GfycatAuthOpen - Authorization URL is empty.");
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString(), Resources.UploadersConfigForm_Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void GfycatAuthComplete(string code)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(code) && Config.GfycatOAuth2Info != null)
+                {
+                    bool result = new GfycatUploader(Config.GfycatOAuth2Info).GetAccessToken(code);
+
+                    if (result)
+                    {
+                        oauth2Gfycat.Status = OAuthLoginStatus.LoginSuccessful;
+                        MessageBox.Show(Resources.UploadersConfigForm_Login_successful, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
+                    else
+                    {
+                        oauth2Gfycat.Status = OAuthLoginStatus.LoginFailed;
+                        MessageBox.Show(Resources.UploadersConfigForm_Login_failed, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString(), Resources.UploadersConfigForm_Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void GfycatAuthRefresh()
+        {
+            try
+            {
+                if (OAuth2Info.CheckOAuth(Config.GfycatOAuth2Info))
+                {
+                    bool result = new GfycatUploader(Config.GfycatOAuth2Info).RefreshAccessToken();
+
+                    if (result)
+                    {
+                        oauth2Gfycat.Status = OAuthLoginStatus.LoginSuccessful;
+                        MessageBox.Show(Resources.UploadersConfigForm_Login_successful, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
+                    else
+                    {
+                        oauth2Gfycat.Status = OAuthLoginStatus.LoginFailed;
+                        MessageBox.Show(Resources.UploadersConfigForm_Login_failed, "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        atcGfycatAccountType.SelectedAccountType = AccountType.Anonymous;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString(), Resources.UploadersConfigForm_Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        #endregion Gfycat
     }
 }

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -156,6 +156,12 @@ namespace ShareX.UploadersLib
         public OneDriveFileInfo OneDriveSelectedFolder = OneDrive.RootFolder;
         public bool OneDriveAutoCreateShareableLink = true;
 
+        // Gfycat
+
+        public OAuth2Info GfycatOAuth2Info = null;
+        public AccountType GfycatAccountType = AccountType.Anonymous;
+        public bool GfycatIsPublic = false;
+
         // Google Drive
 
         public OAuth2Info GoogleDriveOAuth2Info = null;


### PR DESCRIPTION
The config tab doesn't have an icon for gfycat, because I can't find one to use.

Supports anonymous or authenticated uploads, and gives the option to either post gfycats public or private.

Also might theoretically stop that embarrassing issue with incorrect uploads, that some people have mentioned.