### PR TITLE
AutoSize Greenshot forms

### DIFF
--- a/Greenshot.ImageEditor/Forms/AboutForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/AboutForm.Designer.cs
@@ -188,6 +188,7 @@ namespace Greenshot {
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(530, 293);
             this.Controls.Add(this.lblTranslation);
             this.Controls.Add(this.linkLabel1);

--- a/Greenshot.ImageEditor/Forms/ColorDialog.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/ColorDialog.Designer.cs
@@ -232,6 +232,7 @@ namespace Greenshot {
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+			this.AutoSize = true;
 			this.ClientSize = new System.Drawing.Size(292, 218);
 			this.Controls.Add(this.pipette);
 			this.Controls.Add(this.btnApply);

--- a/Greenshot.ImageEditor/Forms/DropShadowSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/DropShadowSettingsForm.Designer.cs
@@ -201,6 +201,7 @@ namespace Greenshot.Forms {
             this.AcceptButton = this.buttonOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.CancelButton = this.buttonCancel;
             this.ClientSize = new System.Drawing.Size(230, 144);
             this.ControlBox = false;

--- a/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/EditorSettingsForm.Designer.cs
@@ -145,6 +145,7 @@
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(330, 186);
             this.Controls.Add(this.cbMaximizeWhenLargeImage);

--- a/Greenshot.ImageEditor/Forms/ResizeSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/ResizeSettingsForm.Designer.cs
@@ -142,6 +142,7 @@ namespace Greenshot {
             this.AcceptButton = this.buttonOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.CancelButton = this.buttonCancel;
             this.ClientSize = new System.Drawing.Size(244, 122);
             this.ControlBox = false;

--- a/Greenshot.ImageEditor/Forms/TornEdgeSettingsForm.Designer.cs
+++ b/Greenshot.ImageEditor/Forms/TornEdgeSettingsForm.Designer.cs
@@ -388,6 +388,7 @@ namespace Greenshot.Forms {
             this.AcceptButton = this.buttonOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.CancelButton = this.buttonCancel;
             this.ClientSize = new System.Drawing.Size(454, 224);
             this.ControlBox = false;


### PR DESCRIPTION
Set AutoSize to true to ensure forms are properly displayed.
Fixes #2406.