### PR TITLE
Fix S3 Uploads with random paths

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -125,8 +125,10 @@ namespace ShareX.UploadersLib.FileUploaders
             args.Add("X-Amz-SignedHeaders", signedHeaders);
 
             string uploadPath = GetUploadPath(fileName);
-            if (forcePathStyle) uploadPath = URLHelpers.CombineURL(Settings.Bucket, uploadPath);
-            string canonicalURI = URLHelpers.AddSlash(uploadPath, SlashType.Prefix);
+
+            string canonicalURI = uploadPath;
+            if (forcePathStyle) canonicalURI = URLHelpers.CombineURL(Settings.Bucket, canonicalURI);
+            canonicalURI = URLHelpers.AddSlash(canonicalURI, SlashType.Prefix);
             canonicalURI = URLHelpers.URLPathEncode(canonicalURI);
 
             string canonicalQueryString = URLHelpers.CreateQuery(args);
@@ -176,7 +178,7 @@ namespace ShareX.UploadersLib.FileUploaders
             return new UploadResult
             {
                 IsSuccess = true,
-                URL = GenerateURL(fileName)
+                URL = GenerateURL(uploadPath)
             };
         }
 
@@ -221,18 +223,16 @@ namespace ShareX.UploadersLib.FileUploaders
             return serviceAndRegion.Substring(separatorIndex + 1);
         }
 
-        private string GetUploadPath(string fileName)
+        public string GetUploadPath(string fileName)
         {
             string path = NameParser.Parse(NameParserType.FolderPath, Settings.ObjectPrefix.Trim('/'));
             return URLHelpers.CombineURL(path, fileName);
         }
 
-        public string GenerateURL(string fileName)
+        public string GenerateURL(string uploadPath)
         {
             if (!string.IsNullOrEmpty(Settings.Endpoint) && !string.IsNullOrEmpty(Settings.Bucket))
             {
-                string uploadPath = GetUploadPath(fileName);
-
                 string url;
 
                 if (Settings.UseCustomCNAME && !string.IsNullOrEmpty(Settings.CustomDomain))

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -492,7 +492,8 @@ namespace ShareX.UploadersLib
 
         private void UpdateAmazonS3Status()
         {
-            lblAmazonS3PathPreview.Text = new AmazonS3(Config.AmazonS3Settings).GenerateURL("Example.png");
+            var s3 = new AmazonS3(Config.AmazonS3Settings);
+            lblAmazonS3PathPreview.Text = s3.GenerateURL(s3.GetUploadPath("Example.png"));
         }
 
         #endregion Amazon S3


### PR DESCRIPTION
Fixes an issue where random paths are being calculated twice - once on upload and once on url generation - causing the URL path to be different than the upload path.