### PR TITLE
Made sure that ForceActive will actually force the window to the front.

### DIFF
--- a/ShareX.HelpersLib/Extensions/Extensions.cs
+++ b/ShareX.HelpersLib/Extensions/Extensions.cs
@@ -357,6 +357,9 @@ namespace ShareX.HelpersLib
 
             form.BringToFront();
             form.Activate();
+            form.TopMost = true;
+            form.TopMost = false;
+            form.Focus();
         }
 
         public static int WeekOfYear(this DateTime dateTime)


### PR DESCRIPTION
This will fix Issue [2324](https://github.com/ShareX/ShareX/issues/2324).

To reproduce:
1. Start ShareX
2. Do not bring ShareX into focus, just leave it as it is.
2. Select a large file and right-click "Upload with ShareX".
The dialog window used to open behind everything else and will now open properly.