### PR TITLE
Screen color picker notifications

### DIFF
--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -681,7 +681,10 @@ namespace ShareX
                 if (Program.MainForm.niTray.Visible)
                 {
                     Program.MainForm.niTray.Tag = null;
-                    Program.MainForm.niTray.ShowBalloonTip(3000, "ShareX", string.Format(Resources.TaskHelpers_OpenQuickScreenColorPicker_Copied_to_clipboard___0_, text), ToolTipIcon.Info);
+
+                    //Only show the balloon notification if BalloonTip is selected in settings
+                    if (taskSettings.GeneralSettings.PopUpNotification != PopUpNotificationType.None)
+                        Program.MainForm.niTray.ShowBalloonTip(3000, "ShareX", string.Format(Resources.TaskHelpers_OpenQuickScreenColorPicker_Copied_to_clipboard___0_, text), ToolTipIcon.Info);
                 }
             }
         }


### PR DESCRIPTION
Fix #2499 
Balloon notification for color picker copied to clipboard will not show if no notifications is set in settings