### PR TITLE
Support configurable environments for Azure storage

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -51,7 +51,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
         {
-            return new AzureStorage(config.AzureStorageAccountName, config.AzureStorageAccountAccessKey, config.AzureStorageContainer);
+            return new AzureStorage(config.AzureStorageAccountName, config.AzureStorageAccountAccessKey, config.AzureStorageContainer, config.AzureStorageEnvironment);
         }
 
         public override TabPage GetUploadersConfigTabPage(UploadersConfigForm form) => form.tpAzureStorage;
@@ -64,12 +64,14 @@ namespace ShareX.UploadersLib.FileUploaders
         public string AzureStorageAccountName { get; private set; }
         public string AzureStorageAccountAccessKey { get; private set; }
         public string AzureStorageContainer { get; private set; }
+        public string AzureStorageEnvironment { get; private set; }
 
-        public AzureStorage(string azureStorageAccountName, string azureStorageAccessKey, string azureStorageContainer)
+        public AzureStorage(string azureStorageAccountName, string azureStorageAccessKey, string azureStorageContainer, string azureStorageEnvironment)
         {
             AzureStorageAccountName = azureStorageAccountName;
             AzureStorageAccountAccessKey = azureStorageAccessKey;
             AzureStorageContainer = azureStorageContainer;
+            AzureStorageEnvironment = (!string.IsNullOrEmpty(azureStorageEnvironment)) ? azureStorageEnvironment : "blob.core.windows.net";
         }
 
         public override UploadResult Upload(Stream stream, string fileName)
@@ -86,7 +88,7 @@ namespace ShareX.UploadersLib.FileUploaders
             CreateContainerIfNotExists();
 
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
-            string url = $"https://{AzureStorageAccountName}.blob.core.windows.net/{AzureStorageContainer}/{fileName}";
+            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}/{fileName}";
             string contentType = Helpers.GetMimeType(fileName);
 
             NameValueCollection requestHeaders = new NameValueCollection();
@@ -116,7 +118,7 @@ namespace ShareX.UploadersLib.FileUploaders
         private void CreateContainerIfNotExists()
         {
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
-            string url = $"https://{AzureStorageAccountName}.blob.core.windows.net/{AzureStorageContainer}?restype=container";
+            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}?restype=container";
 
             NameValueCollection requestHeaders = new NameValueCollection();
             requestHeaders["Content-Length"] = "0";
@@ -154,7 +156,7 @@ namespace ShareX.UploadersLib.FileUploaders
         private void SetContainerACL()
         {
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
-            string url = $"https://{AzureStorageAccountName}.blob.core.windows.net/{AzureStorageContainer}?restype=container&comp=acl";
+            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}?restype=container&comp=acl";
 
             NameValueCollection requestHeaders = new NameValueCollection();
             requestHeaders["Content-Length"] = "0";

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -648,6 +648,8 @@
             this.lblWidthHint = new System.Windows.Forms.Label();
             this.ttlvMain = new ShareX.HelpersLib.TabToListView();
             this.actRapidShareAccountType = new ShareX.UploadersLib.AccountTypeControl();
+            this.lblAzureStorageEnvironment = new System.Windows.Forms.Label();
+            this.cbAzureStorageEnvironment = new System.Windows.Forms.ComboBox();
             this.tpOtherUploaders.SuspendLayout();
             this.tcOtherUploaders.SuspendLayout();
             this.tpTwitter.SuspendLayout();
@@ -2683,6 +2685,8 @@
             // 
             // tpAzureStorage
             // 
+            this.tpAzureStorage.Controls.Add(this.cbAzureStorageEnvironment);
+            this.tpAzureStorage.Controls.Add(this.lblAzureStorageEnvironment);
             this.tpAzureStorage.Controls.Add(this.btnAzureStoragePortal);
             this.tpAzureStorage.Controls.Add(this.txtAzureStorageContainer);
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageContainer);
@@ -5262,6 +5266,23 @@
             this.actRapidShareAccountType.Name = "actRapidShareAccountType";
             this.actRapidShareAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
             // 
+            // lblAzureStorageEnvironment
+            // 
+            resources.ApplyResources(this.lblAzureStorageEnvironment, "lblAzureStorageEnvironment");
+            this.lblAzureStorageEnvironment.Name = "lblAzureStorageEnvironment";
+            // 
+            // cbAzureStorageEnvironment
+            // 
+            this.cbAzureStorageEnvironment.FormattingEnabled = true;
+            this.cbAzureStorageEnvironment.Items.AddRange(new object[] {
+            resources.GetString("cbAzureStorageEnvironment.Items"),
+            resources.GetString("cbAzureStorageEnvironment.Items1"),
+            resources.GetString("cbAzureStorageEnvironment.Items2"),
+            resources.GetString("cbAzureStorageEnvironment.Items3")});
+            resources.ApplyResources(this.cbAzureStorageEnvironment, "cbAzureStorageEnvironment");
+            this.cbAzureStorageEnvironment.Name = "cbAzureStorageEnvironment";
+            this.cbAzureStorageEnvironment.SelectedIndexChanged += new System.EventHandler(this.cbAzureStorageEnvironment_SelectedIndexChanged);
+            // 
             // UploadersConfigForm
             // 
             resources.ApplyResources(this, "$this");
@@ -6064,5 +6085,7 @@
         private System.Windows.Forms.TextBox txtSFTPKeyPassphrase;
         private System.Windows.Forms.Button btnSFTPKeyLocationBrowse;
         private System.Windows.Forms.Label lblSFTPKeyPassphrase;
+        private System.Windows.Forms.ComboBox cbAzureStorageEnvironment;
+        private System.Windows.Forms.Label lblAzureStorageEnvironment;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -598,6 +598,7 @@ namespace ShareX.UploadersLib
             txtAzureStorageAccountName.Text = Config.AzureStorageAccountName;
             txtAzureStorageAccessKey.Text = Config.AzureStorageAccountAccessKey;
             txtAzureStorageContainer.Text = Config.AzureStorageContainer;
+            cbAzureStorageEnvironment.Text = Config.AzureStorageEnvironment;
 
             // Plik
 
@@ -2905,6 +2906,11 @@ namespace ShareX.UploadersLib
         private void txtAzureStorageContainer_TextChanged(object sender, EventArgs e)
         {
             Config.AzureStorageContainer = txtAzureStorageContainer.Text;
+        }
+
+        private void cbAzureStorageEnvironment_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Config.AzureStorageEnvironment = cbAzureStorageEnvironment.Text;
         }
 
         private void btnAzureStoragePortal_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6639,6 +6639,69 @@ store.book[0].title</value>
   <data name="&gt;&gt;tpAmazonS3.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+	<data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
+    <value>blob.core.windows.net</value>
+  </data>
+	<data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
+    <value>blob.core.usgovcloudapi.net</value>
+  </data>
+	<data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
+    <value>blob.core.chinacloudapi.cn</value>
+  </data>
+	<data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
+    <value>blob.core.cloudapi.de</value>
+  </data>
+	<data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+		<value>16, 173</value>
+	</data>
+	<data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+		<value>526, 21</value>
+	</data>
+	<data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+		<value>8</value>
+	</data>
+	<data name="&gt;&gt;cbAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>cbAzureStorageEnvironment</value>
+  </data>
+	<data name="&gt;&gt;cbAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+	<data name="&gt;&gt;cbAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+	<data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+	<data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
+		<value>True</value>
+	</data>
+	<data name="lblAzureStorageEnvironment.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+		<value>NoControl</value>
+	</data>
+	<data name="lblAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+		<value>13, 156</value>
+	</data>
+	<data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+		<value>69, 13</value>
+	</data>
+	<data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+		<value>7</value>
+	</data>
+	<data name="lblAzureStorageEnvironment.Text" xml:space="preserve">
+    <value>Environment:</value>
+  </data>
+	<data name="&gt;&gt;lblAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>lblAzureStorageEnvironment</value>
+  </data>
+	<data name="&gt;&gt;lblAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+	<data name="&gt;&gt;lblAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+	<data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -311,6 +311,7 @@ namespace ShareX.UploadersLib
         public string AzureStorageAccountName = "";
         public string AzureStorageAccountAccessKey = "";
         public string AzureStorageContainer = "";
+        public string AzureStorageEnvironment = "blob.core.windows.net";
 
         // Plik
 


### PR DESCRIPTION
Azure has different environments for Azure Germany, Azure China and Azure USGov, and potentially different environments when using an Azure Stack instance.

This PR adds configuration options for these Azure environments to allow the Azure storage uploader to upload to non-'Global' environments.