### PR TITLE
Update translation error in test screen patterns

### DIFF
--- a/ShareX.HelpersLib/Forms/MonitorTestForm.nl-NL.resx
+++ b/ShareX.HelpersLib/Forms/MonitorTestForm.nl-NL.resx
@@ -133,13 +133,13 @@
     <value>Kleur 2</value>
   </data>
   <data name="cbShapes.Items" xml:space="preserve">
-    <value>Dambordpatroon</value>
-  </data>
-  <data name="cbShapes.Items1" xml:space="preserve">
     <value>Horizontale lijnen</value>
   </data>
-  <data name="cbShapes.Items2" xml:space="preserve">
+  <data name="cbShapes.Items1" xml:space="preserve">
     <value>Verticale lijnen</value>
+  </data>
+  <data name="cbShapes.Items2" xml:space="preserve">
+    <value>Dambordpatroon</value>
   </data>
   <data name="lblBlue.Text" xml:space="preserve">
     <value>B:</value>


### PR DESCRIPTION
In ShareX 11.7, the test patterns have wrong names, this is also according to the code: https://github.com/ShareX/ShareX/blob/15e63e8a925208a85eb7ef7599c6de62b9e5cea1/ShareX.HelpersLib/Forms/MonitorTestForm.cs#L175

Changed names to match the same order as inside the actual code