### PR TITLE
Custom Domain Support for Azure Blob Storage

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -94,8 +94,10 @@ namespace ShareX.UploadersLib.FileUploaders
             string urlForCopy = url;
             if (!string.IsNullOrEmpty(AzureStorageCustomDomain))
             {
-                urlForCopy = $"http://{AzureStorageCustomDomain}/{AzureStorageContainer}/{fileName}";
+                // Azure Blob Storage does not support https with custom domains at this time
+                urlForCopy = URLHelpers.ForcePrefix(URLHelpers.CombineURL($"{AzureStorageCustomDomain}", $"{AzureStorageContainer}/{fileName}"), "http://");
             }
+
             string contentType = Helpers.GetMimeType(fileName);
 
             NameValueCollection requestHeaders = new NameValueCollection();

--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -95,7 +95,7 @@ namespace ShareX.UploadersLib.FileUploaders
             if (!string.IsNullOrEmpty(AzureStorageCustomDomain))
             {
                 // Azure Blob Storage does not support https with custom domains at this time
-                urlForCopy = URLHelpers.ForcePrefix(URLHelpers.CombineURL($"{AzureStorageCustomDomain}", $"{AzureStorageContainer}/{fileName}"), "http://");
+                urlForCopy = URLHelpers.ForcePrefix(URLHelpers.CombineURL(AzureStorageCustomDomain, AzureStorageContainer, fileName), "http://");
             }
 
             string contentType = Helpers.GetMimeType(fileName);

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -298,6 +298,8 @@
             this.lblAzureStorageAccessKey = new System.Windows.Forms.Label();
             this.txtAzureStorageAccountName = new System.Windows.Forms.TextBox();
             this.lblAzureStorageAccountName = new System.Windows.Forms.Label();
+            this.txtAzureStorageCustomDomain = new System.Windows.Forms.TextBox();
+            this.lblAzureStorageCustomDomain = new System.Windows.Forms.Label();
             this.tpGfycat = new System.Windows.Forms.TabPage();
             this.cbGfycatIsPublic = new System.Windows.Forms.CheckBox();
             this.atcGfycatAccountType = new ShareX.UploadersLib.AccountTypeControl();
@@ -447,6 +449,7 @@
             this.lblStreamablePassword = new System.Windows.Forms.Label();
             this.cbStreamableAnonymous = new System.Windows.Forms.CheckBox();
             this.tpSul = new System.Windows.Forms.TabPage();
+            this.sulKeyLink = new System.Windows.Forms.LinkLabel();
             this.txtSulAPIKey = new System.Windows.Forms.TextBox();
             this.lblSulAPIKey = new System.Windows.Forms.Label();
             this.tpLithiio = new System.Windows.Forms.TabPage();
@@ -650,7 +653,6 @@
             this.lblWidthHint = new System.Windows.Forms.Label();
             this.ttlvMain = new ShareX.HelpersLib.TabToListView();
             this.actRapidShareAccountType = new ShareX.UploadersLib.AccountTypeControl();
-            this.sulKeyLink = new System.Windows.Forms.LinkLabel();
             this.tpOtherUploaders.SuspendLayout();
             this.tcOtherUploaders.SuspendLayout();
             this.tpTwitter.SuspendLayout();
@@ -2695,6 +2697,8 @@
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageAccessKey);
             this.tpAzureStorage.Controls.Add(this.txtAzureStorageAccountName);
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageAccountName);
+            this.tpAzureStorage.Controls.Add(this.txtAzureStorageCustomDomain);
+            this.tpAzureStorage.Controls.Add(this.lblAzureStorageCustomDomain);
             resources.ApplyResources(this.tpAzureStorage, "tpAzureStorage");
             this.tpAzureStorage.Name = "tpAzureStorage";
             this.tpAzureStorage.UseVisualStyleBackColor = true;
@@ -2756,6 +2760,17 @@
             // 
             resources.ApplyResources(this.lblAzureStorageAccountName, "lblAzureStorageAccountName");
             this.lblAzureStorageAccountName.Name = "lblAzureStorageAccountName";
+            // 
+            // txtAzureStorageCustomDomain
+            // 
+            resources.ApplyResources(this.txtAzureStorageCustomDomain, "txtAzureStorageCustomDomain");
+            this.txtAzureStorageCustomDomain.Name = "txtAzureStorageCustomDomain";
+            this.txtAzureStorageCustomDomain.TextChanged += new System.EventHandler(this.txtAzureStorageCustomDomain_TextChanged);
+            // 
+            // lblAzureStorageCustomDomain
+            // 
+            resources.ApplyResources(this.lblAzureStorageCustomDomain, "lblAzureStorageCustomDomain");
+            this.lblAzureStorageCustomDomain.Name = "lblAzureStorageCustomDomain";
             // 
             // tpGfycat
             // 
@@ -3813,6 +3828,13 @@
             resources.ApplyResources(this.tpSul, "tpSul");
             this.tpSul.Name = "tpSul";
             this.tpSul.UseVisualStyleBackColor = true;
+            // 
+            // sulKeyLink
+            // 
+            resources.ApplyResources(this.sulKeyLink, "sulKeyLink");
+            this.sulKeyLink.Name = "sulKeyLink";
+            this.sulKeyLink.TabStop = true;
+            this.sulKeyLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.sulKeyLink_LinkClicked);
             // 
             // txtSulAPIKey
             // 
@@ -5291,13 +5313,6 @@
             this.actRapidShareAccountType.Name = "actRapidShareAccountType";
             this.actRapidShareAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
             // 
-            // sulKeyLink
-            // 
-            resources.ApplyResources(this.sulKeyLink, "sulKeyLink");
-            this.sulKeyLink.Name = "sulKeyLink";
-            this.sulKeyLink.TabStop = true;
-            this.sulKeyLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.sulKeyLink_LinkClicked);
-            // 
             // UploadersConfigForm
             // 
             resources.ApplyResources(this, "$this");
@@ -6020,6 +6035,10 @@
         private System.Windows.Forms.TextBox txtAzureStorageContainer;
         private System.Windows.Forms.Label lblAzureStorageContainer;
         private System.Windows.Forms.Button btnAzureStoragePortal;
+        private System.Windows.Forms.ComboBox cbAzureStorageEnvironment;
+        private System.Windows.Forms.Label lblAzureStorageEnvironment;
+        private System.Windows.Forms.TextBox txtAzureStorageCustomDomain;
+        private System.Windows.Forms.Label lblAzureStorageCustomDomain;
         internal System.Windows.Forms.TabPage tpPlik;
         private System.Windows.Forms.GroupBox gbPlikSettings;
         private System.Windows.Forms.TextBox txtPlikComment;
@@ -6100,8 +6119,7 @@
         private System.Windows.Forms.TextBox txtSFTPKeyPassphrase;
         private System.Windows.Forms.Button btnSFTPKeyLocationBrowse;
         private System.Windows.Forms.Label lblSFTPKeyPassphrase;
-        private System.Windows.Forms.ComboBox cbAzureStorageEnvironment;
-        private System.Windows.Forms.Label lblAzureStorageEnvironment;
         private System.Windows.Forms.LinkLabel sulKeyLink;
+
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -603,6 +603,7 @@ namespace ShareX.UploadersLib
             txtAzureStorageAccessKey.Text = Config.AzureStorageAccountAccessKey;
             txtAzureStorageContainer.Text = Config.AzureStorageContainer;
             cbAzureStorageEnvironment.Text = Config.AzureStorageEnvironment;
+            txtAzureStorageCustomDomain.Text = Config.AzureStorageCustomDomain;
 
             // Plik
 
@@ -2920,6 +2921,11 @@ namespace ShareX.UploadersLib
         private void cbAzureStorageEnvironment_SelectedIndexChanged(object sender, EventArgs e)
         {
             Config.AzureStorageEnvironment = cbAzureStorageEnvironment.Text;
+        }
+
+        private void txtAzureStorageCustomDomain_TextChanged(object sender, EventArgs e)
+        {
+            Config.AzureStorageCustomDomain = txtAzureStorageCustomDomain.Text;
         }
 
         private void btnAzureStoragePortal_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -528,7 +528,7 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   </data>
   <data name="tpTwitter.Text" xml:space="preserve">
     <value>Twitter</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
     <value>tpTwitter</value>
   </data>
@@ -585,7 +585,7 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   </data>
   <data name="btnCustomUploadJsonPathHelp.Text" xml:space="preserve">
     <value>?</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Name" xml:space="preserve">
     <value>btnCustomUploadJsonPathHelp</value>
   </data>
@@ -648,7 +648,7 @@ store.book[0].title</value>
   </data>
   <data name="lblCustomUploaderJsonPath.Text" xml:space="preserve">
     <value>JsonPath:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblCustomUploaderJsonPath.Name" xml:space="preserve">
     <value>lblCustomUploaderJsonPath</value>
   </data>
@@ -696,7 +696,7 @@ store.book[0].title</value>
   </data>
   <data name="tpCustomUploaderJsonParse.Text" xml:space="preserve">
     <value>JSON</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
     <value>tpCustomUploaderJsonParse</value>
   </data>
@@ -753,7 +753,7 @@ store.book[0].title</value>
   </data>
   <data name="btnCustomUploaderXPathHelp.Text" xml:space="preserve">
     <value>?</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnCustomUploaderXPathHelp.Name" xml:space="preserve">
     <value>btnCustomUploaderXPathHelp</value>
   </data>
@@ -816,7 +816,7 @@ store.book[0].title</value>
   </data>
   <data name="lblCustomUploaderXPath.Text" xml:space="preserve">
     <value>XPath:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblCustomUploaderXPath.Name" xml:space="preserve">
     <value>lblCustomUploaderXPath</value>
   </data>
@@ -864,7 +864,7 @@ store.book[0].title</value>
   </data>
   <data name="tpCustomUploaderXmlParse.Text" xml:space="preserve">
     <value>XML</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
     <value>tpCustomUploaderXmlParse</value>
   </data>
@@ -891,7 +891,7 @@ store.book[0].title</value>
   </data>
   <data name="btnCustomUploaderRegexHelp.Text" xml:space="preserve">
     <value>?</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnCustomUploaderRegexHelp.Name" xml:space="preserve">
     <value>btnCustomUploaderRegexHelp</value>
   </data>
@@ -1074,7 +1074,7 @@ store.book[0].title</value>
   </data>
   <data name="tpCustomUploaderRegexParse.Text" xml:space="preserve">
     <value>Regex</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
     <value>tpCustomUploaderRegexParse</value>
   </data>
@@ -2382,7 +2382,7 @@ store.book[0].title</value>
   </data>
   <data name="txtCustomUploaderLog.Text" xml:space="preserve">
     <value />
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;txtCustomUploaderLog.Name" xml:space="preserve">
     <value>txtCustomUploaderLog</value>
   </data>
@@ -2544,7 +2544,7 @@ store.book[0].title</value>
   </data>
   <data name="lblCustomUploaderURL.Text" xml:space="preserve">
     <value>URL:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblCustomUploaderURL.Name" xml:space="preserve">
     <value>lblCustomUploaderURL</value>
   </data>
@@ -2721,7 +2721,7 @@ store.book[0].title</value>
   </data>
   <data name="tpBitly.Text" xml:space="preserve">
     <value>bit.ly</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
     <value>tpBitly</value>
   </data>
@@ -2790,7 +2790,7 @@ store.book[0].title</value>
   </data>
   <data name="tpGoogleURLShortener.Text" xml:space="preserve">
     <value>Google</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpGoogleURLShortener.Name" xml:space="preserve">
     <value>tpGoogleURLShortener</value>
   </data>
@@ -3024,7 +3024,7 @@ store.book[0].title</value>
   </data>
   <data name="lblYourlsAPIURL.Text" xml:space="preserve">
     <value>API URL:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblYourlsAPIURL.Name" xml:space="preserve">
     <value>lblYourlsAPIURL</value>
   </data>
@@ -3051,7 +3051,7 @@ store.book[0].title</value>
   </data>
   <data name="tpYourls.Text" xml:space="preserve">
     <value>YOURLS</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
     <value>tpYourls</value>
   </data>
@@ -3132,7 +3132,7 @@ store.book[0].title</value>
   </data>
   <data name="lblAdflyAPIUID.Text" xml:space="preserve">
     <value>API UID:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblAdflyAPIUID.Name" xml:space="preserve">
     <value>lblAdflyAPIUID</value>
   </data>
@@ -3210,7 +3210,7 @@ store.book[0].title</value>
   </data>
   <data name="tpAdFly.Text" xml:space="preserve">
     <value>adf.ly</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
     <value>tpAdFly</value>
   </data>
@@ -3261,7 +3261,7 @@ store.book[0].title</value>
   </data>
   <data name="lblCoinURLUUID.Text" xml:space="preserve">
     <value>UUID:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblCoinURLUUID.Name" xml:space="preserve">
     <value>lblCoinURLUUID</value>
   </data>
@@ -3285,7 +3285,7 @@ store.book[0].title</value>
   </data>
   <data name="tpCoinURL.Text" xml:space="preserve">
     <value>CoinURL</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpCoinURL.Name" xml:space="preserve">
     <value>tpCoinURL</value>
   </data>
@@ -3471,7 +3471,7 @@ store.book[0].title</value>
   </data>
   <data name="tpPolr.Text" xml:space="preserve">
     <value>Polr</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
     <value>tpPolr</value>
   </data>
@@ -3567,7 +3567,7 @@ store.book[0].title</value>
   </data>
   <data name="btnSFTPKeyLocationBrowse.Text" xml:space="preserve">
     <value>...</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Name" xml:space="preserve">
     <value>btnSFTPKeyLocationBrowse</value>
   </data>
@@ -3666,7 +3666,7 @@ store.book[0].title</value>
   </data>
   <data name="gbSFTP.Text" xml:space="preserve">
     <value>SFTP</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
     <value>gbSFTP</value>
   </data>
@@ -4023,7 +4023,7 @@ store.book[0].title</value>
   </data>
   <data name="rbFTPProtocolFTP.Text" xml:space="preserve">
     <value>FTP</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;rbFTPProtocolFTP.Name" xml:space="preserve">
     <value>rbFTPProtocolFTP</value>
   </data>
@@ -4053,7 +4053,7 @@ store.book[0].title</value>
   </data>
   <data name="rbFTPProtocolFTPS.Text" xml:space="preserve">
     <value>FTPS</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;rbFTPProtocolFTPS.Name" xml:space="preserve">
     <value>rbFTPProtocolFTPS</value>
   </data>
@@ -4083,7 +4083,7 @@ store.book[0].title</value>
   </data>
   <data name="rbFTPProtocolSFTP.Text" xml:space="preserve">
     <value>SFTP</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;rbFTPProtocolSFTP.Name" xml:space="preserve">
     <value>rbFTPProtocolSFTP</value>
   </data>
@@ -4470,7 +4470,7 @@ store.book[0].title</value>
   </data>
   <data name="btnFTPSCertificateLocationBrowse.Text" xml:space="preserve">
     <value>...</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Name" xml:space="preserve">
     <value>btnFTPSCertificateLocationBrowse</value>
   </data>
@@ -4590,7 +4590,7 @@ store.book[0].title</value>
   </data>
   <data name="gbFTPS.Text" xml:space="preserve">
     <value>FTPS</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
     <value>gbFTPS</value>
   </data>
@@ -4917,7 +4917,7 @@ store.book[0].title</value>
   </data>
   <data name="tpFTP.Text" xml:space="preserve">
     <value>FTP / FTPS / SFTP</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpFTP.Name" xml:space="preserve">
     <value>tpFTP</value>
   </data>
@@ -5213,7 +5213,7 @@ store.book[0].title</value>
   </data>
   <data name="tpDropbox.Text" xml:space="preserve">
     <value>Dropbox</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpDropbox.Name" xml:space="preserve">
     <value>tpDropbox</value>
   </data>
@@ -5345,7 +5345,7 @@ store.book[0].title</value>
   </data>
   <data name="tpOneDrive.Text" xml:space="preserve">
     <value>OneDrive</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpOneDrive.Name" xml:space="preserve">
     <value>tpOneDrive</value>
   </data>
@@ -5597,7 +5597,7 @@ store.book[0].title</value>
   </data>
   <data name="tpGoogleDrive.Text" xml:space="preserve">
     <value>Google Drive</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpGoogleDrive.Name" xml:space="preserve">
     <value>tpGoogleDrive</value>
   </data>
@@ -5891,7 +5891,7 @@ store.book[0].title</value>
   </data>
   <data name="tpPuush.Text" xml:space="preserve">
     <value>puush</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPuush.Name" xml:space="preserve">
     <value>tpPuush</value>
   </data>
@@ -6086,7 +6086,7 @@ store.book[0].title</value>
   </data>
   <data name="tpBox.Text" xml:space="preserve">
     <value>Box</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpBox.Name" xml:space="preserve">
     <value>tpBox</value>
   </data>
@@ -6317,7 +6317,7 @@ store.book[0].title</value>
   </data>
   <data name="btnAmazonS3BucketNameOpen.Text" xml:space="preserve">
     <value>...</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Name" xml:space="preserve">
     <value>btnAmazonS3BucketNameOpen</value>
   </data>
@@ -6344,7 +6344,7 @@ store.book[0].title</value>
   </data>
   <data name="btnAmazonS3AccessKeyOpen.Text" xml:space="preserve">
     <value>...</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Name" xml:space="preserve">
     <value>btnAmazonS3AccessKeyOpen</value>
   </data>
@@ -6626,7 +6626,7 @@ store.book[0].title</value>
   </data>
   <data name="tpAmazonS3.Text" xml:space="preserve">
     <value>Amazon S3</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpAmazonS3.Name" xml:space="preserve">
     <value>tpAmazonS3</value>
   </data>
@@ -6641,16 +6641,16 @@ store.book[0].title</value>
   </data>
   <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
     <value>blob.core.windows.net</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
     <value>blob.core.usgovcloudapi.net</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
     <value>blob.core.chinacloudapi.cn</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
     <value>blob.core.cloudapi.de</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 173</value>
   </data>
@@ -6716,7 +6716,7 @@ store.book[0].title</value>
   </data>
   <data name="btnAzureStoragePortal.Text" xml:space="preserve">
     <value>...</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;btnAzureStoragePortal.Name" xml:space="preserve">
     <value>btnAzureStoragePortal</value>
   </data>
@@ -6888,6 +6888,51 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 222</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>txtAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 206</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
+    <value>Custom Domain:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>lblAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
   <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 40</value>
   </data>
@@ -6902,7 +6947,7 @@ store.book[0].title</value>
   </data>
   <data name="tpAzureStorage.Text" xml:space="preserve">
     <value>Azure Storage</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpAzureStorage.Name" xml:space="preserve">
     <value>tpAzureStorage</value>
   </data>
@@ -7001,7 +7046,7 @@ store.book[0].title</value>
   </data>
   <data name="tpGfycat.Text" xml:space="preserve">
     <value>Gfycat</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
     <value>tpGfycat</value>
   </data>
@@ -7319,7 +7364,7 @@ store.book[0].title</value>
   </data>
   <data name="tpMega.Text" xml:space="preserve">
     <value>Mega</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpMega.Name" xml:space="preserve">
     <value>tpMega</value>
   </data>
@@ -7670,7 +7715,7 @@ store.book[0].title</value>
   </data>
   <data name="tpOwnCloud.Text" xml:space="preserve">
     <value>ownCloud</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
     <value>tpOwnCloud</value>
   </data>
@@ -7883,7 +7928,7 @@ store.book[0].title</value>
   </data>
   <data name="tpMediaFire.Text" xml:space="preserve">
     <value>MediaFire</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpMediaFire.Name" xml:space="preserve">
     <value>tpMediaFire</value>
   </data>
@@ -8045,7 +8090,7 @@ store.book[0].title</value>
   </data>
   <data name="tpPushbullet.Text" xml:space="preserve">
     <value>Pushbullet</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPushbullet.Name" xml:space="preserve">
     <value>tpPushbullet</value>
   </data>
@@ -8222,7 +8267,7 @@ store.book[0].title</value>
   </data>
   <data name="tpSendSpace.Text" xml:space="preserve">
     <value>SendSpace</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpSendSpace.Name" xml:space="preserve">
     <value>tpSendSpace</value>
   </data>
@@ -8408,7 +8453,7 @@ store.book[0].title</value>
   </data>
   <data name="tpGe_tt.Text" xml:space="preserve">
     <value>Ge.tt</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpGe_tt.Name" xml:space="preserve">
     <value>tpGe_tt</value>
   </data>
@@ -8567,7 +8612,7 @@ store.book[0].title</value>
   </data>
   <data name="tpHostr.Text" xml:space="preserve">
     <value>Hostr</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpHostr.Name" xml:space="preserve">
     <value>tpHostr</value>
   </data>
@@ -9017,7 +9062,7 @@ store.book[0].title</value>
   </data>
   <data name="tpMinus.Text" xml:space="preserve">
     <value>Minus</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpMinus.Name" xml:space="preserve">
     <value>tpMinus</value>
   </data>
@@ -9041,7 +9086,7 @@ store.book[0].title</value>
   </data>
   <data name="txtJiraIssuePrefix.Text" xml:space="preserve">
     <value>PROJECT-</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;txtJiraIssuePrefix.Name" xml:space="preserve">
     <value>txtJiraIssuePrefix</value>
   </data>
@@ -9125,7 +9170,7 @@ store.book[0].title</value>
   </data>
   <data name="txtJiraHost.Text" xml:space="preserve">
     <value>http://</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;txtJiraHost.Name" xml:space="preserve">
     <value>txtJiraHost</value>
   </data>
@@ -9224,7 +9269,7 @@ store.book[0].title</value>
   </data>
   <data name="tpJira.Text" xml:space="preserve">
     <value>Atlassian Jira</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpJira.Name" xml:space="preserve">
     <value>tpJira</value>
   </data>
@@ -9383,7 +9428,7 @@ store.book[0].title</value>
   </data>
   <data name="tpLambda.Text" xml:space="preserve">
     <value>Lambda</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpLambda.Name" xml:space="preserve">
     <value>tpLambda</value>
   </data>
@@ -9593,7 +9638,7 @@ store.book[0].title</value>
   </data>
   <data name="tpPomf.Text" xml:space="preserve">
     <value>Pomf</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPomf.Name" xml:space="preserve">
     <value>tpPomf</value>
   </data>
@@ -9608,10 +9653,10 @@ store.book[0].title</value>
   </data>
   <data name="cbSeafileAPIURL.Items" xml:space="preserve">
     <value>https://seacloud.cc/api2/</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbSeafileAPIURL.Items1" xml:space="preserve">
     <value>https://cloud.mein-seafile.de/api2/</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="cbSeafileAPIURL.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 32</value>
   </data>
@@ -10527,7 +10572,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="lblSeafileAPIURL.Text" xml:space="preserve">
     <value>API URL:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblSeafileAPIURL.Name" xml:space="preserve">
     <value>lblSeafileAPIURL</value>
   </data>
@@ -10554,7 +10599,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpSeafile.Text" xml:space="preserve">
     <value>Seafile</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpSeafile.Name" xml:space="preserve">
     <value>tpSeafile</value>
   </data>
@@ -10755,7 +10800,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpStreamable.Text" xml:space="preserve">
     <value>Streamable</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpStreamable.Name" xml:space="preserve">
     <value>tpStreamable</value>
   </data>
@@ -10860,7 +10905,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpSul.Text" xml:space="preserve">
     <value>s-ul</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpSul.Name" xml:space="preserve">
     <value>tpSul</value>
   </data>
@@ -10965,7 +11010,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpLithiio.Text" xml:space="preserve">
     <value>Lithiio</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpLithiio.Name" xml:space="preserve">
     <value>tpLithiio</value>
   </data>
@@ -11343,7 +11388,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpUplea.Text" xml:space="preserve">
     <value>Uplea</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpUplea.Name" xml:space="preserve">
     <value>tpUplea</value>
   </data>
@@ -11853,7 +11898,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPlik.Text" xml:space="preserve">
     <value>Plik</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPlik.Name" xml:space="preserve">
     <value>tpPlik</value>
   </data>
@@ -12996,7 +13041,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPastebin.Text" xml:space="preserve">
     <value>Pastebin</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
     <value>tpPastebin</value>
   </data>
@@ -13074,7 +13119,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPaste_ee.Text" xml:space="preserve">
     <value>Paste.ee</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
     <value>tpPaste_ee</value>
   </data>
@@ -13308,7 +13353,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpGist.Text" xml:space="preserve">
     <value>GitHub Gist</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
     <value>tpGist</value>
   </data>
@@ -13416,7 +13461,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpUpaste.Text" xml:space="preserve">
     <value>uPaste</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
     <value>tpUpaste</value>
   </data>
@@ -13575,7 +13620,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpHastebin.Text" xml:space="preserve">
     <value>Hastebin</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
     <value>tpHastebin</value>
   </data>
@@ -13704,7 +13749,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpOneTimeSecret.Text" xml:space="preserve">
     <value>OneTimeSecret</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
     <value>tpOneTimeSecret</value>
   </data>
@@ -13761,7 +13806,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPastie.Text" xml:space="preserve">
     <value>Pastie</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPastie.Name" xml:space="preserve">
     <value>tpPastie</value>
   </data>
@@ -13989,7 +14034,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="chImgurID.Text" xml:space="preserve">
     <value>ID</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="chImgurTitle.Text" xml:space="preserve">
     <value>Title</value>
   </data>
@@ -14118,7 +14163,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpImgur.Text" xml:space="preserve">
     <value>Imgur</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
     <value>tpImgur</value>
   </data>
@@ -14358,7 +14403,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpImageShack.Text" xml:space="preserve">
     <value>ImageShack</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
     <value>tpImageShack</value>
   </data>
@@ -14562,7 +14607,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpTinyPic.Text" xml:space="preserve">
     <value>TinyPic</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
     <value>tpTinyPic</value>
   </data>
@@ -14742,7 +14787,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpFlickr.Text" xml:space="preserve">
     <value>Flickr</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
     <value>tpFlickr</value>
   </data>
@@ -15234,7 +15279,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPhotobucket.Text" xml:space="preserve">
     <value>Photobucket</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
     <value>tpPhotobucket</value>
   </data>
@@ -15300,7 +15345,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="chPicasaID.Text" xml:space="preserve">
     <value>ID</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="chPicasaID.Width" type="System.Int32, mscorlib">
     <value>135</value>
   </data>
@@ -15402,7 +15447,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpPicasa.Text" xml:space="preserve">
     <value>Google Photos (Picasa)</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpPicasa.Name" xml:space="preserve">
     <value>tpPicasa</value>
   </data>
@@ -15672,7 +15717,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpChevereto.Text" xml:space="preserve">
     <value>Chevereto</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
     <value>tpChevereto</value>
   </data>
@@ -15780,7 +15825,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpVgyme.Text" xml:space="preserve">
     <value>vgy.me</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
     <value>tpVgyme</value>
   </data>
@@ -15924,7 +15969,7 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="tpSomeImage.Text" xml:space="preserve">
     <value>SomeImage</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;tpSomeImage.Name" xml:space="preserve">
     <value>tpSomeImage</value>
   </data>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -312,6 +312,7 @@ namespace ShareX.UploadersLib
         public string AzureStorageAccountAccessKey = "";
         public string AzureStorageContainer = "";
         public string AzureStorageEnvironment = "blob.core.windows.net";
+        public string AzureStorageCustomDomain = "";
 
         // Plik
 


### PR DESCRIPTION
Users can now add a custom domain to be used. Since uploading over HTTPS to a custom domain is currently forbidden in Azure, we still use the normal endpoint for uploading over HTTPS, but then use a custom domain to serve to the user instead.

Fixes issue #2318. Thanks @wi5nia for the initial Azure support.