### PR TITLE
Static Analysis Results

### DIFF
--- a/Greenshot.ImageEditor/Drawing/ArrowContainer.cs
+++ b/Greenshot.ImageEditor/Drawing/ArrowContainer.cs
@@ -67,37 +67,34 @@ namespace Greenshot.Drawing
                 graphics.PixelOffsetMode = PixelOffsetMode.None;
                 Color lineColor = GetFieldValueAsColor(FieldType.LINE_COLOR);
                 ArrowHeadCombination heads = (ArrowHeadCombination)GetFieldValue(FieldType.ARROWHEADS);
-                if (lineThickness > 0)
+                if (shadow)
                 {
-                    if (shadow)
+                    //draw shadow first
+                    int basealpha = 100;
+                    int alpha = basealpha;
+                    int steps = 5;
+                    int currentStep = 1;
+                    while (currentStep <= steps)
                     {
-                        //draw shadow first
-                        int basealpha = 100;
-                        int alpha = basealpha;
-                        int steps = 5;
-                        int currentStep = 1;
-                        while (currentStep <= steps)
+                        using (Pen shadowCapPen = new Pen(Color.FromArgb(alpha, 100, 100, 100), lineThickness))
                         {
-                            using (Pen shadowCapPen = new Pen(Color.FromArgb(alpha, 100, 100, 100), lineThickness))
-                            {
-                                SetArrowHeads(heads, shadowCapPen);
+                            SetArrowHeads(heads, shadowCapPen);
 
-                                graphics.DrawLine(shadowCapPen,
-                                    Left + currentStep,
-                                    Top + currentStep,
-                                    Left + currentStep + Width,
-                                    Top + currentStep + Height);
+                            graphics.DrawLine(shadowCapPen,
+                                Left + currentStep,
+                                Top + currentStep,
+                                Left + currentStep + Width,
+                                Top + currentStep + Height);
 
-                                currentStep++;
-                                alpha = alpha - basealpha / steps;
-                            }
+                            currentStep++;
+                            alpha = alpha - basealpha / steps;
                         }
                     }
-                    using (Pen pen = new Pen(lineColor, lineThickness))
-                    {
-                        SetArrowHeads(heads, pen);
-                        graphics.DrawLine(pen, Left, Top, Left + Width, Top + Height);
-                    }
+                }
+                using (Pen pen = new Pen(lineColor, lineThickness))
+                {
+                    SetArrowHeads(heads, pen);
+                    graphics.DrawLine(pen, Left, Top, Left + Width, Top + Height);
                 }
             }
         }

--- a/Greenshot.ImageEditor/Drawing/Surface.cs
+++ b/Greenshot.ImageEditor/Drawing/Surface.cs
@@ -1159,7 +1159,7 @@ namespace Greenshot.Drawing
             _mouseDown = true;
             _isSurfaceMoveMadeUndoable = false;
 
-            if (_cropContainer != null && ((_undrawnElement == null) || (_undrawnElement != null && DrawingMode != DrawingModes.Crop)))
+            if (_cropContainer != null && (_undrawnElement == null || DrawingMode != DrawingModes.Crop))
             {
                 RemoveElement(_cropContainer, false);
                 _cropContainer = null;

--- a/ShareX/HotkeyManager.cs
+++ b/ShareX/HotkeyManager.cs
@@ -154,7 +154,7 @@ namespace ShareX
             {
                 foreach (HotkeySettings hotkeySetting in Hotkeys.ToArray())
                 {
-                    if (!temporary || (temporary && hotkeySetting.TaskSettings.Job != HotkeyType.DisableHotkeys))
+                    if (!temporary || hotkeySetting.TaskSettings.Job != HotkeyType.DisableHotkeys)
                     {
                         UnregisterHotkey(hotkeySetting, removeFromList);
                     }


### PR DESCRIPTION
Hi, I have checked this solution with the [CodeRush for Roslyn](https://marketplace.visualstudio.com/items?itemName=DevExpress.CodeRushforRoslyn) static analyzer and found several things to improve:

1. [Logical OR expression has opposite operands](https://documentation.devexpress.com/CodeRushForRoslyn/118112/Static-Code-Analysis/Analyzers-Library/CRR0012-Logical-OR-expression-has-opposite-operands) in two places
2. [Unnecessary conditional](https://documentation.devexpress.com/CodeRushForRoslyn/118219/Static-Code-Analysis/Analyzers-Library/CRR0023-Unnecessary-conditional)
3. I also found [this palce](https://github.com/ShareX/ShareX/blob/206a79d86e752a5e6e9aadf2e2f7348ee9438645/Greenshot.ImageEditor/Configuration/CoreConfiguration.cs#L501) quite strange, but it is way too strange for touching. The overall condition is redundant here, this is [If\-block matches else\-block](https://documentation.devexpress.com/CodeRushForRoslyn/118106/Static-Code-Analysis/Analyzers-Library/CRR0008-If-block-matches-else-block).
4. Also [this conditional](https://github.com/ShareX/ShareX/blob/206a79d86e752a5e6e9aadf2e2f7348ee9438645/Greenshot.ImageEditor/Drawing/Surface.cs#L1174) seems redundant, but maybe I just didn't dig deep enough to find how `DeselectAllElements()` may change the `_undrawnElement` property
