### PR TITLE
Fix error when pressing F1 during image editing

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -411,7 +411,7 @@ namespace ShareX.ScreenCaptureLib
                     break;
                 case Keys.F1:
                     Config.ShowHotkeys = !Config.ShowHotkeys;
-                    if(form.IsAnnotationMode)
+                    if(tsmiTips != null)
                         tsmiTips.Checked = Config.ShowHotkeys;
                     break;
             }


### PR DESCRIPTION
The proper condition should've been
`if(form.IsAnnotationMode && !form.IsEditorMode)`
but I guess checking for null is more robust here