### PR TITLE
Fixed an issue with touch screens not being able to select region/draw/select drawing correctly

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -643,6 +643,8 @@ namespace ShareX.ScreenCaptureLib
                 return;
             }
 
+            InputManager.Update(); //If it's a touch event we don't have the correct point yet, so refresh it now.
+
             BaseShape shape = GetIntersectShape();
 
             if (shape != null && shape.ShapeType == CurrentShapeType) // Select shape


### PR DESCRIPTION
This is a pull request to fix #2673 and #2820.

The issue is that `InputManager` doesn't have the currently touched point location at the moment of `BaseShape.OnCreating()` and `ShapeManager.GetIntersectShape()`.

Since mouse moves continuously, this is not a problem (or at least not noticable). However, since no mouse movement happens between previous MouseUp and next MouseDown event when using touch, this issue becomes important.

So, forcing `InputManager` to update on the beginning of `ShapeManager.StartRegionSelection()` fixes the issue.

(At first I wanted to do it inside `BaseShape.OnCreating()` but then I figured that selecting existing shapes also suffer from the same issue in touch screens. So putting it on the beginning of `StartRegionSelection()` seems more logical)