### PR TITLE
Add default build configuration and platform for Greenshot Editor

### DIFF
--- a/Greenshot.ImageEditor/Greenshot.ImageEditor.csproj
+++ b/Greenshot.ImageEditor/Greenshot.ImageEditor.csproj
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CD642BF4-D815-4D67-A0B5-C69F0B8231AF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Greenshot</RootNamespace>


### PR DESCRIPTION
This fixes the following error the user might encounter when building from CMD:
```
"C:\Users\Charles\Git\ShareX\ShareX\ShareX.csproj" (cible par défaut) (1) ->
"C:\Users\Charles\Git\ShareX\Greenshot.ImageEditor\Greenshot.ImageEditor.csproj" (cible par défaut) (3:2) ->
(_CheckForInvalidConfigurationAndPlatform cible) ->
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\bin\Microsoft.Common.CurrentVersion.target
s(748,5): error : The OutputPath property is not set for project 'Greenshot.ImageEditor.csproj'.  Please check to make
sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='Window
sStore'  Platform=''.  You may be seeing this message because you are trying to build a project without a solution file
, and have specified a non-default Configuration or Platform that doesn't exist for this project. [C:\Users\Charles\Git
\ShareX\Greenshot.ImageEditor\Greenshot.ImageEditor.csproj]
```