### PR TITLE
Add panning to image annotate

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -203,18 +203,21 @@ namespace ShareX.ScreenCaptureLib
                 }
 
                 ImageRectangle = new Rectangle(rect.X + rect.Width / 2 - Image.Width / 2, rect.Y + rect.Height / 2 - Image.Height / 2, Image.Width, Image.Height);
-                
+
                 using (Bitmap background = new Bitmap(ScreenRectangle0Based.Width, ScreenRectangle0Based.Height))
                 using (Graphics g = Graphics.FromImage(background))
                 {
+                    Rectangle sourceRect = new Rectangle(0, 0, ImageRectangle.Width, ImageRectangle.Height);
+
                     using (Image checkers = ImageHelpers.DrawCheckers(ImageRectangle.Width, ImageRectangle.Height))
                     {
-                        g.DrawImage(checkers, ImageRectangle);
+                        g.DrawImage(checkers, sourceRect);
                     }
 
-                    g.DrawImage(Image, ImageRectangle);
-                    
-                    backgroundBrush = new TextureBrush(background) { WrapMode = WrapMode.Clamp };
+                    g.DrawImage(Image, sourceRect);
+
+                    backgroundBrush = new TextureBrush(Image) { WrapMode = WrapMode.Clamp };
+                    backgroundBrush.TranslateTransform(ImageRectangle.X, ImageRectangle.Y);
                 }
             }
             else if (Config.UseDimming)
@@ -420,7 +423,7 @@ namespace ShareX.ScreenCaptureLib
                 }
             }
 
-            if(ShapeManager.IsPanning)
+            if (ShapeManager.IsPanning)
             {
                 ImageRectangle = ImageRectangle.LocationOffset(InputManager.MouseVelocity.X, InputManager.MouseVelocity.Y);
                 backgroundBrush.TranslateTransform(InputManager.MouseVelocity.X, InputManager.MouseVelocity.Y);

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -185,6 +185,24 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
+        internal void UpdateBackground()
+        {
+            using (Bitmap background = new Bitmap(ScreenRectangle0Based.Width, ScreenRectangle0Based.Height))
+            using (Graphics g = Graphics.FromImage(background))
+            {
+                g.Clear(Color.FromArgb(14, 14, 14));
+
+                using (Image checkers = ImageHelpers.DrawCheckers(ImageRectangle.Width, ImageRectangle.Height))
+                {
+                    g.DrawImage(checkers, ImageRectangle);
+                }
+
+                g.DrawImage(Image, ImageRectangle);
+
+                backgroundBrush = new TextureBrush(background) { WrapMode = WrapMode.Clamp };
+            }
+        }
+
         internal void InitBackground(Image img)
         {
             if (Image != null) Image.Dispose();
@@ -204,20 +222,7 @@ namespace ShareX.ScreenCaptureLib
 
                 ImageRectangle = new Rectangle(rect.X + rect.Width / 2 - Image.Width / 2, rect.Y + rect.Height / 2 - Image.Height / 2, Image.Width, Image.Height);
 
-                using (Bitmap background = new Bitmap(ScreenRectangle0Based.Width, ScreenRectangle0Based.Height))
-                using (Graphics g = Graphics.FromImage(background))
-                {
-                    g.Clear(Color.FromArgb(14, 14, 14));
-
-                    using (Image checkers = ImageHelpers.DrawCheckers(ImageRectangle.Width, ImageRectangle.Height))
-                    {
-                        g.DrawImage(checkers, ImageRectangle);
-                    }
-
-                    g.DrawImage(Image, ImageRectangle);
-
-                    backgroundBrush = new TextureBrush(background) { WrapMode = WrapMode.Clamp };
-                }
+                UpdateBackground();
             }
             else if (Config.UseDimming)
             {
@@ -420,6 +425,18 @@ namespace ShareX.ScreenCaptureLib
                         obj.IsDragging = false;
                     }
                 }
+            }
+
+            if(ShapeManager.IsPanning)
+            {
+                ImageRectangle = ImageRectangle.LocationOffset(InputManager.MouseVelocity.X, InputManager.MouseVelocity.Y);
+
+                foreach(BaseShape shape in ShapeManager.Shapes)
+                {
+                    shape.Move(InputManager.MouseVelocity.X, InputManager.MouseVelocity.Y);
+                }
+
+                UpdateBackground();
             }
 
             borderDotPen.DashOffset = (float)timerStart.Elapsed.TotalSeconds * -15;

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -144,6 +144,7 @@ namespace ShareX.ScreenCaptureLib
 
         public bool IsCreating { get; set; }
         public bool IsMoving { get; set; }
+        public bool IsPanning { get; set; }
         public bool IsResizing { get; set; }
         public bool IsCornerMoving { get; private set; }
         public bool IsProportionalResizing { get; private set; }
@@ -268,6 +269,13 @@ namespace ShareX.ScreenCaptureLib
                     StartRegionSelection();
                 }
             }
+            else if (e.Button == MouseButtons.Middle)
+            {
+                if (form.IsEditorMode)
+                {
+                    StartPanning();
+                }
+            }
         }
 
         private void form_MouseUp(object sender, MouseEventArgs e)
@@ -301,7 +309,14 @@ namespace ShareX.ScreenCaptureLib
             }
             else if (e.Button == MouseButtons.Middle)
             {
-                RunAction(Config.RegionCaptureActionMiddleClick);
+                if (form.IsEditorMode)
+                {
+                    EndPanning();
+                }
+                else
+                {
+                    RunAction(Config.RegionCaptureActionMiddleClick);
+                }
             }
             else if (e.Button == MouseButtons.XButton1)
             {
@@ -712,6 +727,18 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
+        private void StartPanning()
+        {
+            DeselectCurrentShape();
+            IsPanning = true;
+        }
+
+
+        private void EndPanning()
+        {
+            IsPanning = false;
+        }
+            
         private BaseShape AddShape()
         {
             BaseShape shape = CreateShape();
@@ -1264,7 +1291,16 @@ namespace ShareX.ScreenCaptureLib
 
             if (img != null)
             {
+                Point oldpos = new Point(rect.X, rect.Y);
+
                 form.InitBackground(img);
+
+                Point newpos = new Point(form.ImageRectangle.X, form.ImageRectangle.Y);
+
+                foreach (BaseShape shape in Shapes)
+                {
+                    shape.Move(newpos.X - oldpos.X, newpos.Y - oldpos.Y);
+                }
 
                 isAnnotated = true;
             }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -729,7 +729,7 @@ namespace ShareX.ScreenCaptureLib
 
         private void StartPanning()
         {
-            DeselectCurrentShape();
+            // DeselectCurrentShape();
             IsPanning = true;
         }
 
@@ -1194,6 +1194,14 @@ namespace ShareX.ScreenCaptureLib
             }
 
             return false;
+        }
+
+        public void MoveAll(Point offset)
+        {
+            foreach (BaseShape shape in Shapes)
+            {
+                shape.Move(offset.X, offset.Y);
+            }
         }
 
         private void UpdateNodes()


### PR DESCRIPTION
When annotating image use middle mouse buttnon to pan image and all shapes with it.

Also fixes crop not moving shapes.