### PR TITLE
Support CTRL+A in OCR results window

### DIFF
--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.Designer.cs
@@ -67,6 +67,7 @@
             this.txtResult.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.txtResult.Size = new System.Drawing.Size(544, 368);
             this.txtResult.TabIndex = 2;
+            this.txtResult.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtResult_KeyDown);
             // 
             // lblResult
             // 

--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
@@ -105,6 +105,7 @@ namespace ShareX.UploadersLib
                         UpdateControls();
                         cbLanguages.Enabled = btnStartOCR.Enabled = txtResult.Enabled = true;
                         pbProgress.Visible = false;
+                        txtResult.Focus();
                     }
                 });
             }
@@ -123,6 +124,17 @@ namespace ShareX.UploadersLib
         private void llAttribution_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             URLHelpers.OpenURL("https://ocr.space");
+        }
+
+        private void txtResult_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.A)
+            {
+                if (sender != null)
+                    ((TextBox)sender).SelectAll();
+                e.SuppressKeyPress = true; // TextBox will beep if it gets the CTRL+A
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Also, sets the focus to the result textbox upon completion (which will also select all of the text)

Closes #2852