### PR TITLE
Properly sort columns with dates in listviews

### DIFF
--- a/ShareX.HelpersLib/Controls/MyListView.cs
+++ b/ShareX.HelpersLib/Controls/MyListView.cs
@@ -308,7 +308,12 @@ namespace ShareX.HelpersLib
                     lvwColumnSorter.Order = SortOrder.Ascending;
                 }
 
+                // if the column is tagged as a DateTime, then sort by date
+                lvwColumnSorter.SortByDate = Columns[e.Column].Tag is DateTime;
+
+                Cursor.Current = Cursors.WaitCursor;
                 Sort();
+                Cursor.Current = Cursors.Default;
             }
         }
 

--- a/ShareX.HelpersLib/ListViewColumnSorter.cs
+++ b/ShareX.HelpersLib/ListViewColumnSorter.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using System;
 using System.Collections;
 using System.Windows.Forms;
 
@@ -42,6 +43,10 @@ namespace ShareX.HelpersLib
         /// </summary>
         private SortOrder OrderOfSort;
         /// <summary>
+        /// Specifies whether to sort as a date
+        /// </summary>
+        public bool SortByDate { get; set; }
+        /// <summary>
         /// Case insensitive comparer object
         /// </summary>
         private CaseInsensitiveComparer ObjectCompare;
@@ -56,6 +61,8 @@ namespace ShareX.HelpersLib
 
             // Initialize the sort order to 'none'
             OrderOfSort = SortOrder.None;
+
+            SortByDate = false;
 
             // Initialize the CaseInsensitiveComparer object
             ObjectCompare = new CaseInsensitiveComparer();
@@ -77,7 +84,10 @@ namespace ShareX.HelpersLib
             listviewY = (ListViewItem)y;
 
             // Compare the two items
-            compareResult = ObjectCompare.Compare(listviewX.SubItems[ColumnToSort].Text, listviewY.SubItems[ColumnToSort].Text);
+            if (SortByDate)
+                compareResult = DateTime.Compare((DateTime)listviewX.SubItems[ColumnToSort].Tag, (DateTime)listviewY.SubItems[ColumnToSort].Tag);
+            else
+                compareResult = ObjectCompare.Compare(listviewX.SubItems[ColumnToSort].Text, listviewY.SubItems[ColumnToSort].Text);
 
             // Calculate correct return value based on object comparison
             if (OrderOfSort == SortOrder.Ascending)

--- a/ShareX.HistoryLib/HistoryForm.cs
+++ b/ShareX.HistoryLib/HistoryForm.cs
@@ -56,6 +56,9 @@ namespace ShareX.HistoryLib
             defaultTitle = Text;
             UpdateTitle();
 
+            // Mark the Date column as having a date; used for sorting
+            chDateTime.Tag = new DateTime();
+
             ImageList il = new ImageList();
             il.ColorDepth = ColorDepth.Depth32Bit;
             il.Images.Add(Resources.image);
@@ -211,7 +214,7 @@ namespace ShareX.HistoryLib
                     lvi.ImageIndex = 3;
                 }
 
-                lvi.SubItems.Add(hi.DateTime.ToString());
+                lvi.SubItems.Add(hi.DateTime.ToString()).Tag = hi.DateTime;
                 lvi.SubItems.Add(hi.Filename);
                 lvi.SubItems.Add(hi.URL);
                 lvi.Tag = hi;


### PR DESCRIPTION
Checks if the column header Tag is a DateTime object and if so, sorts the column by date. This approach prevents performance impact when sorting columns that are not dates and allows any user of MyListView to tag a column to be sorted by date. Supports expansion to other sorting formats.
Tested with history of 80,000 items.

Closes #1685