### PR TITLE
Added option to remember editor window state, position and size

### DIFF
--- a/ShareX.HelpersLib/WindowState.cs
+++ b/ShareX.HelpersLib/WindowState.cs
@@ -35,7 +35,7 @@ namespace ShareX.HelpersLib
         public Size Size { get; set; }
         public bool IsMaximized { get; set; }
 
-        public void SetFormState(Form form)
+        public void ApplyFormState(Form form)
         {
             if (!Location.IsEmpty && CaptureHelpers.GetScreenBounds().IntersectsWith(new Rectangle(Location, Size)))
             {
@@ -54,7 +54,7 @@ namespace ShareX.HelpersLib
             }
         }
 
-        public void GetFormState(Form form)
+        public void UpdateFormState(Form form)
         {
             WINDOWPLACEMENT wp = new WINDOWPLACEMENT();
             wp.length = Marshal.SizeOf(wp);
@@ -69,8 +69,8 @@ namespace ShareX.HelpersLib
 
         public void AutoHandleFormState(Form form)
         {
-            SetFormState(form);
-            form.FormClosing += (sender, e) => GetFormState(form);
+            ApplyFormState(form);
+            form.FormClosing += (sender, e) => UpdateFormState(form);
         }
     }
 }

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -165,7 +165,11 @@ namespace ShareX.ScreenCaptureLib
                 Size = new Size(900, 700);
                 MinimumSize = new Size(900, 600);
 
-                if (Config.EditorModeStartMaximized)
+                if (Config.EditorModeRememberWindowState)
+                {
+                    Config.EditorModeWindowState.ApplyFormState(this);
+                }
+                else if (Config.EditorModeStartMaximized)
                 {
                     WindowState = FormWindowState.Maximized;
                 }
@@ -183,6 +187,7 @@ namespace ShareX.ScreenCaptureLib
             MouseDown += RegionCaptureForm_MouseDown;
             Resize += RegionCaptureForm_Resize;
             LocationChanged += RegionCaptureForm_LocationChanged;
+            FormClosing += RegionCaptureForm_FormClosing;
 
             ResumeLayout(false);
         }
@@ -364,6 +369,14 @@ namespace ShareX.ScreenCaptureLib
         private void RegionCaptureForm_LocationChanged(object sender, EventArgs e)
         {
             OnMoved();
+        }
+
+        private void RegionCaptureForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (IsEditorMode && Config.EditorModeRememberWindowState)
+            {
+                Config.EditorModeWindowState.UpdateFormState(this);
+            }
         }
 
         internal void RegionCaptureForm_KeyDown(object sender, KeyEventArgs e)

--- a/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using ShareX.HelpersLib;
 using System.Collections.Generic;
 using System.Drawing;
 
@@ -77,5 +78,7 @@ namespace ShareX.ScreenCaptureLib
 
         // Editor mode
         public bool EditorModeStartMaximized = true;
+        public bool EditorModeRememberWindowState = false;
+        public WindowState EditorModeWindowState = new WindowState();
     }
 }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -723,6 +723,12 @@ namespace ShareX.ScreenCaptureLib
                 tsmiEditorModeStartMaximized.Click += (sender, e) => Config.EditorModeStartMaximized = tsmiEditorModeStartMaximized.Checked;
                 tsddbOptions.DropDownItems.Add(tsmiEditorModeStartMaximized);
 
+                ToolStripMenuItem tsmiEditorModeRememberWindowState = new ToolStripMenuItem("Remember editor window state");
+                tsmiEditorModeRememberWindowState.Checked = Config.EditorModeRememberWindowState;
+                tsmiEditorModeRememberWindowState.CheckOnClick = true;
+                tsmiEditorModeRememberWindowState.Click += (sender, e) => Config.EditorModeRememberWindowState = tsmiEditorModeRememberWindowState.Checked;
+                tsddbOptions.DropDownItems.Add(tsmiEditorModeRememberWindowState);
+
                 tsddbOptions.DropDownItems.Add(new ToolStripSeparator());
             }
 


### PR DESCRIPTION
This option saves window state, position and size when window closing and when user re open editor this window states will be applied.