### PR TITLE
Removed AutoScaleDimensions assigns for four fullscreen forms

### DIFF
--- a/ShareX.HelpersLib/Forms/ScreenTearingTestForm.cs
+++ b/ShareX.HelpersLib/Forms/ScreenTearingTestForm.cs
@@ -47,8 +47,7 @@ namespace ShareX.HelpersLib
             screenRectangle0Based = new Rectangle(0, 0, screenRectangle.Width, screenRectangle.Height);
 
             SuspendLayout();
-
-            AutoScaleDimensions = new SizeF(6F, 13F);
+            
             AutoScaleMode = AutoScaleMode.Font;
             StartPosition = FormStartPosition.Manual;
             Bounds = screenRectangle;

--- a/ShareX.HelpersLib/Forms/ScreenTearingTestForm.cs
+++ b/ShareX.HelpersLib/Forms/ScreenTearingTestForm.cs
@@ -48,7 +48,7 @@ namespace ShareX.HelpersLib
 
             SuspendLayout();
             
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleMode = AutoScaleMode.None;
             StartPosition = FormStartPosition.Manual;
             Bounds = screenRectangle;
             Cursor = Cursors.Hand;

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -147,8 +147,7 @@ namespace ShareX.ScreenCaptureLib
         private void InitializeComponent()
         {
             SuspendLayout();
-
-            AutoScaleDimensions = new SizeF(6F, 13F);
+            
             AutoScaleMode = AutoScaleMode.Font;
             defaultCursor = Helpers.CreateCursor(Resources.Crosshair);
             SetDefaultCursor();

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -148,7 +148,7 @@ namespace ShareX.ScreenCaptureLib
         {
             SuspendLayout();
             
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleMode = AutoScaleMode.None;
             defaultCursor = Helpers.CreateCursor(Resources.Crosshair);
             SetDefaultCursor();
             Icon = ShareXResources.Icon;

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
@@ -89,8 +89,7 @@ namespace ShareX.ScreenCaptureLib
         private void InitializeComponent()
         {
             SuspendLayout();
-
-            AutoScaleDimensions = new SizeF(6F, 13F);
+            
             AutoScaleMode = AutoScaleMode.Font;
             StartPosition = FormStartPosition.Manual;
             Bounds = ScreenRectangle;

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
@@ -90,7 +90,7 @@ namespace ShareX.ScreenCaptureLib
         {
             SuspendLayout();
             
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleMode = AutoScaleMode.None;
             StartPosition = FormStartPosition.Manual;
             Bounds = ScreenRectangle;
             FormBorderStyle = FormBorderStyle.None;

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureSimpleAnnotateForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureSimpleAnnotateForm.cs
@@ -100,7 +100,7 @@ namespace ShareX.ScreenCaptureLib
         private void InitializeComponent()
         {
             SuspendLayout();
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleMode = AutoScaleMode.None;
             StartPosition = FormStartPosition.Manual;
             Bounds = ScreenRectangle;
             FormBorderStyle = FormBorderStyle.None;

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureSimpleAnnotateForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureSimpleAnnotateForm.cs
@@ -100,7 +100,6 @@ namespace ShareX.ScreenCaptureLib
         private void InitializeComponent()
         {
             SuspendLayout();
-            AutoScaleDimensions = new SizeF(6F, 13F);
             AutoScaleMode = AutoScaleMode.Font;
             StartPosition = FormStartPosition.Manual;
             Bounds = ScreenRectangle;


### PR DESCRIPTION
This fixes the annoying incorrect capture region problem #1800, and I think that this will not cause any significant layout problems for different DPIs. (For example `ShareX.HelpersLib.MonitorTestForm` is a fullscreen form which does not contain `AutoScaleDimensions` assigns, but it works fine.)

However, while this works well on my laptop with different text scale settings, it should be checked on different computers as well.