### PR TITLE
Fixed issue #2933

### DIFF
--- a/ShareX.HelpersLib/Controls/MyPictureBox.cs
+++ b/ShareX.HelpersLib/Controls/MyPictureBox.cs
@@ -331,7 +331,9 @@ namespace ShareX.HelpersLib
         {
             if (FullscreenOnClick && e.Button == MouseButtons.Left && IsValidImage)
             {
+                pbMain.Enabled = false;
                 ImageViewer.ShowImage(Image);
+                pbMain.Enabled = true;
             }
         }
 


### PR DESCRIPTION
Fixed the issue of #2933
There were two options:
1. Deep clone the image.
2. Disable the preview in the main window.

I choosed the second option because I think it's performance-wise better than the first option. Also, as the dedicated preview window is an dialog, the user can't interact with the main window, so there is no need for a preview.