### PR TITLE
Add escapes to ParseURL

### DIFF
--- a/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
+++ b/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
@@ -271,6 +271,7 @@ namespace ShareX.UploadersLib
                             }
                         }
                     }
+                    escape = false;
                 }
                 else if(url[i] == '\\' && !escape)
                 {

--- a/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
+++ b/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
@@ -244,10 +244,11 @@ namespace ShareX.UploadersLib
 
             bool syntaxStart = false;
             int syntaxStartIndex = 0;
+            bool escape = false;
 
             for (int i = 0; i < url.Length; i++)
             {
-                if (url[i] == '$')
+                if (url[i] == '$' && !escape)
                 {
                     if (!syntaxStart)
                     {
@@ -270,6 +271,10 @@ namespace ShareX.UploadersLib
                             }
                         }
                     }
+                }
+                else if(url[i] == '\\')
+                {
+                    escape = true;
                 }
                 else if (!syntaxStart)
                 {

--- a/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
+++ b/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
@@ -279,6 +279,7 @@ namespace ShareX.UploadersLib
                 else if (!syntaxStart)
                 {
                     result.Append(url[i]);
+                    escape = false;
                 }
             }
 

--- a/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
+++ b/ShareX.UploadersLib/Helpers/CustomUploaderItem.cs
@@ -272,7 +272,7 @@ namespace ShareX.UploadersLib
                         }
                     }
                 }
-                else if(url[i] == '\\')
+                else if(url[i] == '\\' && !escape)
                 {
                     escape = true;
                 }


### PR DESCRIPTION
`\$` is a thing now
`\\$` is a thing now
`\\` is a thing now
Truth table:
```java
\$  -> $
\\  -> \
\\$ -> \$
\X  -> X
```