### PR TITLE
Check limit before uploading to Streamable

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Streamable.cs
+++ b/ShareX.UploadersLib/FileUploaders/Streamable.cs
@@ -87,8 +87,11 @@ namespace ShareX.UploadersLib.FileUploaders
                 headers = CreateAuthenticationHeader(Email, Password);
             }
             UploadResult result;
-            FileStream fs = stream as FileStream;
-            GetDuration(fs.Name, out TimeSpan duration);
+            TimeSpan duration;
+            using (FileStream fs = stream as FileStream)
+            {
+                GetDuration(fs.Name, out duration);
+            }
             if (stream.Length > 1073741824 || duration > TimeSpan.FromMinutes(10))
             {
                 result = new UploadResult

--- a/ShareX.UploadersLib/FileUploaders/Streamable.cs
+++ b/ShareX.UploadersLib/FileUploaders/Streamable.cs
@@ -26,6 +26,8 @@
 using Newtonsoft.Json;
 using ShareX.HelpersLib;
 using ShareX.UploadersLib.Properties;
+using Shell32;
+using System;
 using System.Collections.Specialized;
 using System.Drawing;
 using System.IO;
@@ -84,8 +86,20 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 headers = CreateAuthenticationHeader(Email, Password);
             }
-
-            UploadResult result = SendRequestFile(URLHelpers.CombineURL(Host, "upload"), stream, fileName, headers: headers);
+            UploadResult result;
+            FileStream fs = stream as FileStream;
+            GetDuration(fs.Name, out TimeSpan duration);
+            if (stream.Length > 1073741824 || duration > TimeSpan.FromMinutes(10))
+            {
+                result = new UploadResult
+                {
+                    IsSuccess = false,
+                    Response = "There is a 10 minute limit on video duration and a maximum file size of 1GB for direct file uploads."
+                };
+                Errors.Add("Video size or duration over Streamable limit(1GB and 10 minutes)");
+                return result;
+            }
+            result = SendRequestFile(URLHelpers.CombineURL(Host, "upload"), stream, fileName, headers: headers);
 
             TranscodeFile(result);
 
@@ -153,6 +167,25 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 Errors.Add("Could not create video");
                 result.IsSuccess = false;
+            }
+        }
+        private bool GetDuration(string filename, out TimeSpan duration)
+        {
+            try
+            {
+                var shl = new Shell();
+                var fldr = shl.NameSpace(Path.GetDirectoryName(filename));
+                var itm = fldr.ParseName(Path.GetFileName(filename));
+
+                // Index 27 is the video duration [This may not always be the case]
+                var propValue = fldr.GetDetailsOf(itm, 27);
+
+                return TimeSpan.TryParse(propValue, out duration);
+            }
+            catch (Exception)
+            {
+                duration = new TimeSpan();
+                return false;
             }
         }
     }

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -922,6 +922,17 @@
     <None Include="Favicons\Gfycat.png" />
     <None Include="Favicons\GooglePhotos.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="Shell32">
+      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)APIKeys\


### PR DESCRIPTION
Streamable limits video over 1GB and longer than 10 minutes for direct file uploads. And I hope to check if video is under limitation before uploading starts.