### PR TITLE
Add %rf to use a random line from a file

### DIFF
--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -277,6 +277,18 @@ namespace ShareX.HelpersLib
             return null;
         }
 
+        public static string GetRandomLineFromFile(string path)
+        {
+            try
+            {
+                return GetRandomLine(File.ReadAllText(path));
+            }
+            catch (Exception e)
+            {
+                return e.Message;
+            }
+        }
+
         public static string GetValidFileName(string fileName, string separator = "")
         {
             char[] invalidFileNameChars = Path.GetInvalidFileNameChars();

--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -277,13 +277,13 @@ namespace ShareX.HelpersLib
             return null;
         }
 
-        public static string GetRandomLineFromFile(string path)
+        public static string GetRandomLineFromFile(string path, bool isPreviewMode = false)
         {
             try
             {
                 return GetRandomLine(File.ReadAllText(path));
             }
-            catch (Exception e)
+            catch (Exception e) when (isPreviewMode)
             {
                 return e.Message;
             }

--- a/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
+++ b/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
@@ -59,9 +59,7 @@ namespace ShareX.HelpersLib
         // TODO: Translate
         public static readonly CodeMenuEntryFilename radjective = new CodeMenuEntryFilename("radjective", "Random adjective", Resources.ReplCodeMenuCategory_Random);
         public static readonly CodeMenuEntryFilename ranimal = new CodeMenuEntryFilename("ranimal", "Random animal", Resources.ReplCodeMenuCategory_Random);
-
-        // TODO: Also Translate
-        public static readonly CodeMenuEntryFilename rf = new CodeMenuEntryFilename("rf", "Random line from file. Use {path} to determine the file", Resources.ReplCodeMenuCategory_Random);
+        public static readonly CodeMenuEntryFilename rf = new CodeMenuEntryFilename("rf", Resources.ReplCodeMenuEntry_rf_Random_line_from_file, Resources.ReplCodeMenuCategory_Random);
 
         public static readonly CodeMenuEntryFilename width = new CodeMenuEntryFilename("width", Resources.ReplCodeMenuEntry_width_Gets_image_width, Resources.ReplCodeMenuCategory_Image);
         public static readonly CodeMenuEntryFilename height = new CodeMenuEntryFilename("height", Resources.ReplCodeMenuEntry_height_Gets_image_height, Resources.ReplCodeMenuCategory_Image);

--- a/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
+++ b/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
@@ -59,6 +59,10 @@ namespace ShareX.HelpersLib
         // TODO: Translate
         public static readonly CodeMenuEntryFilename radjective = new CodeMenuEntryFilename("radjective", "Random adjective", Resources.ReplCodeMenuCategory_Random);
         public static readonly CodeMenuEntryFilename ranimal = new CodeMenuEntryFilename("ranimal", "Random animal", Resources.ReplCodeMenuCategory_Random);
+
+        // TODO: Also Translate
+        public static readonly CodeMenuEntryFilename rf = new CodeMenuEntryFilename("rf", "Random line from file", Resources.ReplCodeMenuCategory_Random);
+
         public static readonly CodeMenuEntryFilename width = new CodeMenuEntryFilename("width", Resources.ReplCodeMenuEntry_width_Gets_image_width, Resources.ReplCodeMenuCategory_Image);
         public static readonly CodeMenuEntryFilename height = new CodeMenuEntryFilename("height", Resources.ReplCodeMenuEntry_height_Gets_image_height, Resources.ReplCodeMenuCategory_Image);
         public static readonly CodeMenuEntryFilename un = new CodeMenuEntryFilename("un", Resources.ReplCodeMenuEntry_un_User_name, Resources.ReplCodeMenuCategory_Computer);

--- a/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
+++ b/ShareX.HelpersLib/NameParser/CodeMenuEntryFilename.cs
@@ -61,7 +61,7 @@ namespace ShareX.HelpersLib
         public static readonly CodeMenuEntryFilename ranimal = new CodeMenuEntryFilename("ranimal", "Random animal", Resources.ReplCodeMenuCategory_Random);
 
         // TODO: Also Translate
-        public static readonly CodeMenuEntryFilename rf = new CodeMenuEntryFilename("rf", "Random line from file", Resources.ReplCodeMenuCategory_Random);
+        public static readonly CodeMenuEntryFilename rf = new CodeMenuEntryFilename("rf", "Random line from file. Use {path} to determine the file", Resources.ReplCodeMenuCategory_Random);
 
         public static readonly CodeMenuEntryFilename width = new CodeMenuEntryFilename("width", Resources.ReplCodeMenuEntry_width_Gets_image_width, Resources.ReplCodeMenuCategory_Image);
         public static readonly CodeMenuEntryFilename height = new CodeMenuEntryFilename("height", Resources.ReplCodeMenuEntry_height_Gets_image_height, Resources.ReplCodeMenuCategory_Image);

--- a/ShareX.HelpersLib/NameParser/NameParser.cs
+++ b/ShareX.HelpersLib/NameParser/NameParser.cs
@@ -53,6 +53,11 @@ namespace ShareX.HelpersLib
         public string ProcessName { get; set; } // %pn
         public TimeZoneInfo CustomTimeZone { get; set; }
 
+        // If we're trying to preview via TaskSettings or not
+        // Used so that %rf throws "File not found" exceptions and brings up a popup on upload
+        // But only returns an error message when previewing to avoid popup spam
+        public bool IsPreviewMode { get; set; } = false;
+
         protected NameParser()
         {
         }
@@ -237,7 +242,7 @@ namespace ShareX.HelpersLib
 
             foreach (Tuple<string, string[]> entry in ListEntryWithArguments(result, CodeMenuEntryFilename.rf.ToPrefixString(), 1))
             {
-                result = result.ReplaceAll(entry.Item1, () => Helpers.GetRandomLineFromFile(entry.Item2[0]));
+                result = result.ReplaceAll(entry.Item1, () => Helpers.GetRandomLineFromFile(entry.Item2[0], IsPreviewMode));
             }
 
             foreach (Tuple<string, int> entry in ListEntryWithValue(result, CodeMenuEntryFilename.rn.ToPrefixString()))

--- a/ShareX.HelpersLib/NameParser/NameParser.cs
+++ b/ShareX.HelpersLib/NameParser/NameParser.cs
@@ -235,6 +235,11 @@ namespace ShareX.HelpersLib
             result = result.ReplaceAll(CodeMenuEntryFilename.ranimal.ToPrefixString(),
                 () => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(Helpers.GetRandomLine(Resources.animals)));
 
+            foreach (Tuple<string, string[]> entry in ListEntryWithArguments(result, CodeMenuEntryFilename.rf.ToPrefixString(), 1))
+            {
+                result = result.ReplaceAll(entry.Item1, () => Helpers.GetRandomLineFromFile(entry.Item2[0]));
+            }
+
             foreach (Tuple<string, int> entry in ListEntryWithValue(result, CodeMenuEntryFilename.rn.ToPrefixString()))
             {
                 result = result.ReplaceAll(entry.Item1, () => Helpers.RepeatGenerator(entry.Item2, () => Helpers.GetRandomChar(Helpers.Numbers).ToString()));

--- a/ShareX.HelpersLib/Properties/Resources.Designer.cs
+++ b/ShareX.HelpersLib/Properties/Resources.Designer.cs
@@ -2645,6 +2645,15 @@ namespace ShareX.HelpersLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Random line from a file. Use {path} to determine the file.
+        /// </summary>
+        internal static string ReplCodeMenuEntry_rf_Random_line_from_file {
+            get {
+                return ResourceManager.GetString("ReplCodeMenuEntry_rf_Random_line_from_file", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Random number 0 to 9. Repeat using {n}.
         /// </summary>
         internal static string ReplCodeMenuEntry_rn_Random_number_0_to_9 {

--- a/ShareX.HelpersLib/Properties/Resources.es.resx
+++ b/ShareX.HelpersLib/Properties/Resources.es.resx
@@ -579,4 +579,7 @@ Tamaño de archivo: {2:n0} / {3:n0} KB</value>
   <data name="ReplCodeMenuEntry_uln_User_login_name" xml:space="preserve">
     <value>Nombre de inicio de sesión de usuario</value>
   </data>
+  <data name="ReplCodeMenuEntry_rf_Random_line_from_file" xml:space="preserve">
+    <value>Línea aleatorio de un archivo. Usa {ruta} para indicar el archivo</value>
+  </data>
 </root>

--- a/ShareX.HelpersLib/Properties/Resources.fr.resx
+++ b/ShareX.HelpersLib/Properties/Resources.fr.resx
@@ -1024,4 +1024,7 @@ Voulez-vous la télécharger ?</value>
   <data name="LinearGradientMode_ForwardDiagonal" xml:space="preserve">
     <value>Diagonale en avant</value>
   </data>
+  <data name="ReplCodeMenuEntry_rf_Random_line_from_file" xml:space="preserve">
+    <value>Line aléatoire d'un fichier. Utilisez {chemin} pour indiquer le fichier</value>
+  </data>
 </root>

--- a/ShareX.HelpersLib/Properties/Resources.resx
+++ b/ShareX.HelpersLib/Properties/Resources.resx
@@ -1145,4 +1145,7 @@ Would you like to download it?</value>
   <data name="animals" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\animals.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="ReplCodeMenuEntry_rf_Random_line_from_file" xml:space="preserve">
+    <value>Random line from a file. Use {path} to determine the file</value>
+  </data>
 </root>

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -1142,7 +1142,8 @@ namespace ShareX
                 ImageHeight = 1080,
                 MaxNameLength = TaskSettings.AdvancedSettings.NamePatternMaxLength,
                 MaxTitleLength = TaskSettings.AdvancedSettings.NamePatternMaxTitleLength,
-                CustomTimeZone = TaskSettings.UploadSettings.UseCustomTimeZone ? TaskSettings.UploadSettings.CustomTimeZone : null
+                CustomTimeZone = TaskSettings.UploadSettings.UseCustomTimeZone ? TaskSettings.UploadSettings.CustomTimeZone : null,
+                IsPreviewMode = true
             };
 
             lblNameFormatPatternPreview.Text = Resources.TaskSettingsForm_txtNameFormatPatternActiveWindow_TextChanged_Preview_ + " " +


### PR DESCRIPTION
This adds `%rf{path}` to Task > Upload > File Naming, which reads the file at `path` and uses a random line from it for the filename (Similar to `%radjective` and `%ranimal`)

https://suplex.me/EasyHariyama.png
![An example of it in action](https://suplex.me/EasyHariyama.png)

If the file is not found/not able to be read/some other error, the preview will display the error message, but trying to upload will popup an error window
https://gfycat.com/BothZealousEstuarinecrocodile