### PR TITLE
Add new Markdown copying options (Fixes #3115)

### DIFF
--- a/ShareX.HistoryLib/HistoryItemManager.cs
+++ b/ShareX.HistoryLib/HistoryItemManager.cs
@@ -259,6 +259,21 @@ namespace ShareX.HistoryLib
             }
         }
 
+        public void CopyMarkdownLink()
+        {
+            if (HistoryItem != null && IsURLExist) ClipboardHelpers.CopyText(string.Format("[{0}]({1})", HistoryItem.Filename, HistoryItem.URL));
+        }
+
+        public void CopyMarkdownImage()
+        {
+            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("![{0}]({1})", HistoryItem.Filename, HistoryItem.URL));
+        }
+
+        public void CopyMarkdownLinkedImage()
+        {
+            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("[![{0}]({1})]({2})", HistoryItem.Filename, HistoryItem.URL, HistoryItem.URL));
+        }
+
         public void CopyFilePath()
         {
             if (HistoryItem != null && IsFilePathValid) ClipboardHelpers.CopyText(HistoryItem.Filepath);

--- a/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
+++ b/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
@@ -60,6 +60,10 @@ namespace ShareX.HistoryLib
         private ToolStripMenuItem tsmiCopyForumImage;
         private ToolStripMenuItem tsmiCopyForumLinkedImage;
         private ToolStripSeparator tssCopy4;
+        private ToolStripMenuItem tsmiCopyMarkdownLink;
+        private ToolStripMenuItem tsmiCopyMarkdownImage;
+        private ToolStripMenuItem tsmiCopyMarkdownLinkedImage;
+        private ToolStripSeparator tssCopy5;
         private ToolStripMenuItem tsmiCopyFilePath;
         private ToolStripMenuItem tsmiCopyFileName;
         private ToolStripMenuItem tsmiCopyFileNameWithExtension;
@@ -97,6 +101,10 @@ namespace ShareX.HistoryLib
             tsmiCopyForumImage = new ToolStripMenuItem();
             tsmiCopyForumLinkedImage = new ToolStripMenuItem();
             tssCopy4 = new ToolStripSeparator();
+            tsmiCopyMarkdownLink = new ToolStripMenuItem();
+            tsmiCopyMarkdownImage = new ToolStripMenuItem();
+            tsmiCopyMarkdownLinkedImage = new ToolStripMenuItem();
+            tssCopy5 = new ToolStripSeparator();
             tsmiCopyFilePath = new ToolStripMenuItem();
             tsmiCopyFileName = new ToolStripMenuItem();
             tsmiCopyFileNameWithExtension = new ToolStripMenuItem();
@@ -324,6 +332,32 @@ namespace ShareX.HistoryLib
             tssCopy4.Name = "tssCopy4";
             tssCopy4.Size = new Size(230, 6);
             //
+            // tsmiCopyMarkdownLink
+            //
+            tsmiCopyMarkdownLink.Name = "tsmiCopyMarkdownLink";
+            tsmiCopyMarkdownLink.Size = new Size(233, 22);
+            tsmiCopyMarkdownLink.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__link;
+            tsmiCopyMarkdownLink.Click += tsmiCopyMarkdownLink_Click;
+            //
+            // tsmiCopyMarkdownImage
+            //
+            tsmiCopyMarkdownImage.Name = "tsmiCopyMarkdownImage";
+            tsmiCopyMarkdownImage.Size = new Size(233, 22);
+            tsmiCopyMarkdownImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__image;
+            tsmiCopyMarkdownImage.Click += tsmiCopyMarkdownImage_Click;
+            //
+            // tsmiCopyMarkdownLinkedImage
+            //
+            tsmiCopyMarkdownLinkedImage.Name = "tsmiCopyMarkdownLinkedImage";
+            tsmiCopyMarkdownLinkedImage.Size = new Size(233, 22);
+            tsmiCopyMarkdownLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__linked_image;
+            tsmiCopyMarkdownLinkedImage.Click += tsmiCopyMarkdownLinkedImage_Click;
+            //
+            // tssCopy5
+            //
+            tssCopy5.Name = "tssCopy5";
+            tssCopy5.Size = new Size(230, 6);
+            //
             // tsmiCopyFilePath
             //
             tsmiCopyFilePath.Name = "tsmiCopyFilePath";
@@ -530,6 +564,21 @@ namespace ShareX.HistoryLib
         private void tsmiCopyForumLinkedImage_Click(object sender, EventArgs e)
         {
             CopyForumLinkedImage();
+        }
+
+        private void tsmiCopyMarkdownLinkedImage_Click(object sender, EventArgs e)
+        {
+            CopyMarkdownLinkedImage();
+        }
+
+        private void tsmiCopyMarkdownLink_Click(object sender, EventArgs e)
+        {
+            CopyMarkdownLink();
+        }
+
+        private void tsmiCopyMarkdownImage_Click(object sender, EventArgs e)
+        {
+            CopyMarkdownImage();
         }
 
         private void tsmiCopyFilePath_Click(object sender, EventArgs e)

--- a/ShareX.HistoryLib/Properties/Resources.Designer.cs
+++ b/ShareX.HistoryLib/Properties/Resources.Designer.cs
@@ -234,6 +234,33 @@ namespace ShareX.HistoryLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Markdown image.
+        /// </summary>
+        internal static string HistoryItemManager_InitializeComponent_Markdown__image {
+            get {
+                return ResourceManager.GetString("HistoryItemManager_InitializeComponent_Markdown__image", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Markdown link.
+        /// </summary>
+        internal static string HistoryItemManager_InitializeComponent_Markdown__link {
+            get {
+                return ResourceManager.GetString("HistoryItemManager_InitializeComponent_Markdown__link", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Markdown linked image.
+        /// </summary>
+        internal static string HistoryItemManager_InitializeComponent_Markdown__linked_image {
+            get {
+                return ResourceManager.GetString("HistoryItemManager_InitializeComponent_Markdown__linked_image", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to More info.
         /// </summary>
         internal static string HistoryItemManager_InitializeComponent_More_info {

--- a/ShareX.HistoryLib/Properties/Resources.resx
+++ b/ShareX.HistoryLib/Properties/Resources.resx
@@ -226,4 +226,13 @@
   <data name="globe" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\globe.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="HistoryItemManager_InitializeComponent_Markdown__image" xml:space="preserve">
+    <value>Markdown image</value>
+  </data>
+  <data name="HistoryItemManager_InitializeComponent_Markdown__link" xml:space="preserve">
+    <value>Markdown link</value>
+  </data>
+  <data name="HistoryItemManager_InitializeComponent_Markdown__linked_image" xml:space="preserve">
+    <value>Markdown linked image</value>
+  </data>
 </root>


### PR DESCRIPTION
As mentioned in #3115, this adds three new copying options.

Tested and functional as intended.