### PR TITLE
Wav file browser doesn't show "Browse for executable" in title anymore

### DIFF
--- a/ShareX.HelpersLib/Properties/Resources.Designer.cs
+++ b/ShareX.HelpersLib/Properties/Resources.Designer.cs
@@ -78,7 +78,7 @@ namespace ShareX.HelpersLib.Properties {
                         "me_extension_", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to abandoned
         ///able
@@ -377,7 +377,7 @@ namespace ShareX.HelpersLib.Properties {
                 return ResourceManager.GetString("AmazonS3StorageClass_STANDARD_IA", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to aardvark
         ///aardwolf
@@ -3258,6 +3258,15 @@ namespace ShareX.HelpersLib.Properties {
         internal static string UrlShortenerType_CustomURLShortener {
             get {
                 return ResourceManager.GetString("UrlShortenerType_CustomURLShortener", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse for a sound file....
+        /// </summary>
+        internal static string WavFileNameEditor_EditValue_Browse_for_a_sound_file___ {
+            get {
+                return ResourceManager.GetString("WavFileNameEditor_EditValue_Browse_for_a_sound_file___", resourceCulture);
             }
         }
     }

--- a/ShareX.HelpersLib/Properties/Resources.de.resx
+++ b/ShareX.HelpersLib/Properties/Resources.de.resx
@@ -895,4 +895,7 @@ Möchtest du sie herunterladen?</value>
   <data name="ShapeType_ToolCrop" xml:space="preserve">
     <value>Bild zuschneiden</value>
   </data>
+  <data name="WavFileNameEditor_EditValue_Browse_for_a_sound_file___" xml:space="preserve">
+    <value>Nach .wav durchsuchen...</value>
+  </data>
 </root>

--- a/ShareX.HelpersLib/Properties/Resources.resx
+++ b/ShareX.HelpersLib/Properties/Resources.resx
@@ -1151,4 +1151,7 @@ Would you like to download it?</value>
   <data name="ShapeType_DrawingSticker" xml:space="preserve">
     <value>Drawing: Sticker</value>
   </data>
+  <data name="WavFileNameEditor_EditValue_Browse_for_a_sound_file___" xml:space="preserve">
+    <value>Browse for a sound file...</value>
+  </data>
 </root>

--- a/ShareX.HelpersLib/UITypeEditors/WavFileNameEditor.cs
+++ b/ShareX.HelpersLib/UITypeEditors/WavFileNameEditor.cs
@@ -41,7 +41,7 @@ namespace ShareX.HelpersLib
             }
             using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                dlg.Title = Resources.ExeFileNameEditor_EditValue_Browse_for_executable___;
+                dlg.Title = Resources.WavFileNameEditor_EditValue_Browse_for_a_sound_file___;
                 dlg.Filter = "Sound file (*.wav)|*.wav";
                 if (dlg.ShowDialog() == DialogResult.OK)
                 {


### PR DESCRIPTION
Added string resource + German translation for a missing string.
The wav file browser in question shows on `Task Settings -> Advanced -> CustomCaptureSoundPath -> [...]` for example.