### PR TITLE
Added Size and SizeMode properties to the image watermark effect

### DIFF
--- a/ShareX.ImageEffectsLib/Drawings/DrawImage.cs
+++ b/ShareX.ImageEffectsLib/Drawings/DrawImage.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
 using System.IO;
+using System.Windows.Forms;
 
 namespace ShareX.ImageEffectsLib
 {
@@ -58,6 +59,13 @@ namespace ShareX.ImageEffectsLib
         [DefaultValue(""), Editor(typeof(ImageFileNameEditor), typeof(UITypeEditor))]
         public string ImageLocation { get; set; }
 
+        //TODO: Is a custom enum for different watermark image sizes a better idea?
+        [DefaultValue(SizeType.AutoSize)]
+        public SizeType SizeMode { get; set; }
+
+        [DefaultValue(typeof(Size), "0, 0")]
+        public Size Size { get; set; }
+
         public DrawImage()
         {
             this.ApplyDefaultPropertyValues();
@@ -69,8 +77,22 @@ namespace ShareX.ImageEffectsLib
             {
                 using (Image img2 = ImageHelpers.LoadImage(ImageLocation))
                 {
-                    Point imagePosition = Helpers.GetPosition(Placement, Offset, img.Size, img2.Size);
-                    Rectangle imageRectangle = new Rectangle(imagePosition, img2.Size);
+                    //Calculate size first
+                    Size imageSize = img2.Size;
+                    if (SizeMode == SizeType.Absolute)
+                    {
+                        //Use Size property
+                        imageSize = Size;
+                    }
+                    else if (SizeMode == SizeType.Percent)
+                    {
+                        //Relative size
+                        imageSize = new Size((int)(img2.Width * (Size.Width / 100.0)), (int)(img2.Height * (Size.Height / 100.0)));
+                    }
+
+                    //Place the image
+                    Point imagePosition = Helpers.GetPosition(Placement, Offset, img.Size, imageSize);
+                    Rectangle imageRectangle = new Rectangle(imagePosition, imageSize);
 
                     if (AutoHide && !new Rectangle(0, 0, img.Width, img.Height).Contains(imageRectangle))
                     {

--- a/ShareX.ImageEffectsLib/Drawings/DrawImage.cs
+++ b/ShareX.ImageEffectsLib/Drawings/DrawImage.cs
@@ -59,9 +59,8 @@ namespace ShareX.ImageEffectsLib
         [DefaultValue(""), Editor(typeof(ImageFileNameEditor), typeof(UITypeEditor))]
         public string ImageLocation { get; set; }
 
-        //TODO: Is a custom enum for different watermark image sizes a better idea?
-        [DefaultValue(SizeType.AutoSize)]
-        public SizeType SizeMode { get; set; }
+        [DefaultValue(DrawImageSizeMode.DontResize), Description("How the image watermark should be rescaled, if at all.")]
+        public DrawImageSizeMode SizeMode { get; set; }
 
         [DefaultValue(typeof(Size), "0, 0")]
         public Size Size { get; set; }
@@ -79,12 +78,12 @@ namespace ShareX.ImageEffectsLib
                 {
                     //Calculate size first
                     Size imageSize = img2.Size;
-                    if (SizeMode == SizeType.Absolute)
+                    if (SizeMode == DrawImageSizeMode.Absolute)
                     {
                         //Use Size property
                         imageSize = Size;
                     }
-                    else if (SizeMode == SizeType.Percent)
+                    else if (SizeMode == DrawImageSizeMode.Percentage)
                     {
                         //Relative size
                         imageSize = new Size((int)(img2.Width * (Size.Width / 100.0)), (int)(img2.Height * (Size.Height / 100.0)));
@@ -108,6 +107,13 @@ namespace ShareX.ImageEffectsLib
             }
 
             return img;
+        }
+
+        public enum DrawImageSizeMode
+        {
+            DontResize,
+            Absolute,
+            Percentage
         }
     }
 }


### PR DESCRIPTION
Implements the suggestion of #3157.

`SizeMode` has the following values:
- `AutoSize`: size is determined by the image's size, the `Size` property does nothing
- `Absolute`: size is determined by the `Size` property, in pixels
- `Percent`: size is determined by the `Size` property, as a relative percentage of the image's size