### PR TITLE
add call to GetReply after using OpenRead or OpenWrite according to FluentFTP documentation

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/FTP.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP.cs
@@ -231,10 +231,7 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 try
                 {
-                    using (Stream remoteStream = client.OpenWrite(remotePath))
-                    {
-                        return TransferData(localStream, remoteStream);
-                    }
+                    return UploadData2(localStream, remotePath);
                 }
                 catch (FtpCommandException e)
                 {
@@ -243,10 +240,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         CreateMultiDirectory(URLHelpers.GetDirectoryPath(remotePath));
 
-                        using (Stream remoteStream = client.OpenWrite(remotePath))
-                        {
-                            return TransferData(localStream, remoteStream);
-                        }
+                        return UploadData2(localStream, remotePath);
                     }
 
                     throw e;
@@ -254,6 +248,17 @@ namespace ShareX.UploadersLib.FileUploaders
             }
 
             return false;
+        }
+
+        private bool UploadData2(Stream localStream, string remotePath)
+        {
+            bool result;
+            using (Stream remoteStream = client.OpenWrite(remotePath))
+            {
+                result = TransferData(localStream, remoteStream);
+            }
+            FtpReply ftpReply = client.GetReply();
+            return result && ftpReply.Success;
         }
 
         public void UploadData(byte[] data, string remotePath)
@@ -322,6 +327,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 {
                     TransferData(remoteStream, localStream);
                 }
+                client.GetReply();
             }
         }
 


### PR DESCRIPTION
According to https://github.com/robinrodricks/FluentFTP#file-transfer you need to call `GetReply()` after completing the transfer from `OpenRead()` or `OpenWrite()`

Without this fix I get consistently the problems as described on the discord server (half the image is not there) for large(ish) images. With this fix I get consistently zero issues.

couple notes:
1. I pulled a chuck of code in `UploadData` to its own method, since it appeared twice and it needed the fix in both, so it was easier to just put it like this. However I suck at creating good names of things, so if you dont like the name of that method, gimmy a better one ;) xd
2. I dont know for sure what the `ftpResult` thing will contain, but from what I can tell its the ftp server telling the client if the transfer was ok, so I figured I use that info as well when returning
3. I added the `GetReply()` to `DownloadFile()` as well, I didnt test that, but I assume that'll work just fine since the exact same way works for uploading.