### PR TITLE
Remove check of whether to save TinyPic login info

### DIFF
--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -952,18 +952,12 @@ namespace ShareX.UploadersLib
 
         private void txtTinyPicUsername_TextChanged(object sender, EventArgs e)
         {
-            if (Config.TinyPicRememberUserPass)
-            {
-                Config.TinyPicUsername = txtTinyPicUsername.Text;
-            }
+            Config.TinyPicUsername = txtTinyPicUsername.Text;
         }
 
         private void txtTinyPicPassword_TextChanged(object sender, EventArgs e)
         {
-            if (Config.TinyPicRememberUserPass)
-            {
-                Config.TinyPicPassword = txtTinyPicPassword.Text;
-            }
+            Config.TinyPicPassword = txtTinyPicPassword.Text;
         }
 
         private void btnTinyPicLogin_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -61,7 +61,6 @@ namespace ShareX.UploadersLib
         public string TinyPicRegistrationCode = "";
         public string TinyPicUsername = "";
         public string TinyPicPassword = "";
-        public bool TinyPicRememberUserPass = false;
 
         #endregion TinyPic
 


### PR DESCRIPTION
If user enters it, then save it.
Fixes #3186 (and linked issues)