### PR TITLE
Add streamable upload limit (#1)

### DIFF
--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -65,7 +65,7 @@ namespace ShareX.HelpersLib
 
         public static readonly string[] ImageFileExtensions = new string[] { "jpg", "jpeg", "png", "gif", "bmp", "ico", "tif", "tiff" };
         public static readonly string[] TextFileExtensions = new string[] { "txt", "log", "nfo", "c", "cpp", "cc", "cxx", "h", "hpp", "hxx", "cs", "vb", "html", "htm", "xhtml", "xht", "xml", "css", "js", "php", "bat", "java", "lua", "py", "pl", "cfg", "ini", "dart", "go", "gohtml" };
-        public static readonly string[] VideoFileExtensions = new string[] { "mp4", "webm", "mkv", "avi", "vob", "ogv", "ogg", "mov", "qt", "wmv", "m4p", "m4v", "mpg", "mp2", "mpeg", "mpe", "mpv", "m2v", "m4v", "flv", "f4v" };
+        public static readonly string[] VideoFileExtensions = new string[] { "3g2", "3gp", "aaf", "asf", "avchd", "avi", "drc", "flv", "m2v", "m4p", "m4v", "mkv", "mng", "mov", "mp2", "mp4", "mpe", "mpeg", "mpg", "mpv", "mxf", "nsv", "ogg", "ogv", "qt", "rm", "rmvb", "roq", "svi", "vob", "webm", "wmv", "yuv" };
 
         public static readonly Version OSVersion = Environment.OSVersion.Version;
 

--- a/ShareX.UploadersLib/FileUploaders/Streamable.cs
+++ b/ShareX.UploadersLib/FileUploaders/Streamable.cs
@@ -26,7 +26,10 @@
 using Newtonsoft.Json;
 using ShareX.HelpersLib;
 using ShareX.UploadersLib.Properties;
+using Shell32;
+using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Threading;
@@ -85,7 +88,29 @@ namespace ShareX.UploadersLib.FileUploaders
                 headers = CreateAuthenticationHeader(Email, Password);
             }
 
-            UploadResult result = SendRequestFile(URLHelpers.CombineURL(Host, "upload"), stream, fileName, headers: headers);
+            UploadResult result;
+
+            if (IsVideoFile(fileName))
+            {
+                bool isOverSize, isOverDuration = false;
+                FileStream fs = stream as FileStream;
+                GetDuration(fs.Name, out TimeSpan duration);
+                isOverDuration = duration > TimeSpan.FromMinutes(10); // video is over 10 minutes
+                isOverSize = new FileInfo(fs.Name).Length > 1073741824; // file is over 10GB
+
+                if (isOverSize || isOverDuration)
+                {
+                    result = new UploadResult
+                    {
+                        IsSuccess = false,
+                        Response = "There is a 10 minute limit on video duration and a maximum file size of 1GB for direct file uploads."
+                    };
+                    Errors.Add("Video size or duration over Streamable limit(1GB and 10 minutes)");
+                    return result;
+                }
+            }
+            
+            result = SendRequestFile(URLHelpers.CombineURL(Host, "upload"), stream, fileName, headers: headers);
 
             TranscodeFile(result);
 
@@ -154,6 +179,65 @@ namespace ShareX.UploadersLib.FileUploaders
                 Errors.Add("Could not create video");
                 result.IsSuccess = false;
             }
+        }
+        private bool GetDuration(string filename, out TimeSpan duration)
+        {
+            try
+            {
+                var shl = new Shell();
+                var fldr = shl.NameSpace(Path.GetDirectoryName(filename));
+                var itm = fldr.ParseName(Path.GetFileName(filename));
+
+                // Index 27 is the video duration [This may not always be the case]
+                var propValue = fldr.GetDetailsOf(itm, 27);
+
+                return TimeSpan.TryParse(propValue, out duration);
+            }
+            catch (Exception)
+            {
+                duration = new TimeSpan();
+                return false;
+            }
+        }
+        private string[] videoExtensions = {
+            "3g2",
+            "3gp",
+            "aaf",
+            "asf",
+            "avchd",
+            "avi",
+            "drc",
+            "flv",
+            "m2v",
+            "m4p",
+            "m4v",
+            "mkv",
+            "mng",
+            "mov",
+            "mp2",
+            "mp4",
+            "mpe",
+            "mpeg",
+            "mpg",
+            "mpv",
+            "mxf",
+            "nsv",
+            "ogg",
+            "ogv",
+            "qt",
+            "rm",
+            "rmvb",
+            "roq",
+            "svi",
+            "vob",
+            "webm",
+            "wmv",
+            "yuv"
+        };
+
+        private bool IsVideoFile(string path)
+        {
+            return -1 != Array.IndexOf(videoExtensions, Path.GetExtension(path).ToUpperInvariant());
         }
     }
 

--- a/ShareX.UploadersLib/FileUploaders/Streamable.cs
+++ b/ShareX.UploadersLib/FileUploaders/Streamable.cs
@@ -89,14 +89,14 @@ namespace ShareX.UploadersLib.FileUploaders
 
             UploadResult result;
 
-            if (IsVideoFile(fileName))
+            if (Helpers.IsVideoFile(fileName))
             {
                 bool isOverSize, isOverDuration = false;
                 FileStream fs = stream as FileStream;
                 GetDuration(fs.Name, out TimeSpan duration);
                 isOverDuration = duration > TimeSpan.FromMinutes(10); // video is over 10 minutes
-                isOverSize = new FileInfo(fs.Name).Length > 1073741824; // file is over 10GB
-
+                isOverSize = new FileInfo(fs.Name).Length > 1024 * 1024 * 1024; // file is over 10GB
+                
                 if (isOverSize || isOverDuration)
                 {
                     result = new UploadResult
@@ -108,7 +108,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     return result;
                 }
             }
-            
+
             result = SendRequestFile(URLHelpers.CombineURL(Host, "upload"), stream, fileName, headers: headers);
 
             TranscodeFile(result);
@@ -197,46 +197,6 @@ namespace ShareX.UploadersLib.FileUploaders
                 duration = new TimeSpan();
                 return false;
             }
-        }
-        private string[] videoExtensions = {
-            "3g2",
-            "3gp",
-            "aaf",
-            "asf",
-            "avchd",
-            "avi",
-            "drc",
-            "flv",
-            "m2v",
-            "m4p",
-            "m4v",
-            "mkv",
-            "mng",
-            "mov",
-            "mp2",
-            "mp4",
-            "mpe",
-            "mpeg",
-            "mpg",
-            "mpv",
-            "mxf",
-            "nsv",
-            "ogg",
-            "ogv",
-            "qt",
-            "rm",
-            "rmvb",
-            "roq",
-            "svi",
-            "vob",
-            "webm",
-            "wmv",
-            "yuv"
-        };
-
-        private bool IsVideoFile(string path)
-        {
-            return -1 != Array.IndexOf(videoExtensions, Path.GetExtension(path).ToUpperInvariant());
         }
     }
 

--- a/ShareX.UploadersLib/FileUploaders/Streamable.cs
+++ b/ShareX.UploadersLib/FileUploaders/Streamable.cs
@@ -29,7 +29,6 @@ using ShareX.UploadersLib.Properties;
 using Shell32;
 using System;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Threading;

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -922,6 +922,17 @@
     <None Include="Favicons\Gfycat.png" />
     <None Include="Favicons\GooglePhotos.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="Shell32">
+      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent>cd $(ProjectDir)APIKeys\


### PR DESCRIPTION
* Check limit before uploading to Streamable

Streamable limits video over 1GB and longer than 10 minutes for direct file uploads. And I hope to check if video is under limitation before uploading.

What kind of formats can I upload?
Basically anything that resembles a video file.
https://support.streamable.com/frequently-asked-questions