### PR TITLE
Respect Hotkey Overrides with Auto Capture

### DIFF
--- a/ShareX/Forms/AutoCaptureForm.cs
+++ b/ShareX/Forms/AutoCaptureForm.cs
@@ -51,6 +51,7 @@ namespace ShareX
         }
 
         public static bool IsRunning { get; private set; }
+        public TaskSettings TaskSettings { get; internal set; }
 
         private bool isLoaded;
         private Timer statusTimer;
@@ -107,7 +108,15 @@ namespace ShareX
 
             if (!rect.IsEmpty)
             {
-                TaskSettings taskSettings = TaskSettings.GetDefaultTaskSettings();
+                TaskSettings taskSettings;
+                if(this.TaskSettings != null)
+                {
+                    taskSettings = this.TaskSettings;
+                }
+                else
+                {
+                    taskSettings = TaskSettings.GetDefaultTaskSettings();
+                }
 
                 Image img = TaskHelpers.GetScreenshot(taskSettings).CaptureRectangle(rect);
 

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -135,10 +135,10 @@ namespace ShareX
                     OCRImage(safeTaskSettings);
                     break;
                 case HotkeyType.AutoCapture:
-                    OpenAutoCapture();
+                    OpenAutoCapture(safeTaskSettings);
                     break;
                 case HotkeyType.StartAutoCapture:
-                    StartAutoCapture();
+                    StartAutoCapture(safeTaskSettings);
                     break;
                 // Screen record
                 case HotkeyType.ScreenRecorder:
@@ -653,8 +653,11 @@ namespace ShareX
             scrollingCaptureForm.Show();
         }
 
-        public static void OpenAutoCapture()
+        public static void OpenAutoCapture(TaskSettings taskSettings = null)
         {
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
+            AutoCaptureForm.Instance.TaskSettings = taskSettings;
             AutoCaptureForm.Instance.ForceActivate();
         }
 
@@ -674,11 +677,14 @@ namespace ShareX
             webpageCaptureForm.Show();
         }
 
-        public static void StartAutoCapture()
+        public static void StartAutoCapture(TaskSettings taskSettings = null)
         {
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
             if (!AutoCaptureForm.IsRunning)
             {
                 AutoCaptureForm form = AutoCaptureForm.Instance;
+                form.TaskSettings = taskSettings;
                 form.Show();
                 form.Execute();
             }


### PR DESCRIPTION
This change means that whether it's "Start auto capture using last region", or just opens the "Auto Capture" window, that any task settings overrides associated with the hotkey will be respected.

A use for this change is to be able to create screenshots for a timelapses while still using ShareX as normal. By overriding the capture path and after capture tasks, a user can have the auto captured images be in a separate directory and not be uploaded, without having to make those changes globally.