### PR TITLE
Allow to create startup shortcut even when startup is disabled via Task Manager

### DIFF
--- a/ShareX/StartupManagers/GenericStartupManager.cs
+++ b/ShareX/StartupManagers/GenericStartupManager.cs
@@ -39,15 +39,24 @@ namespace ShareX
         {
             get
             {
-                byte[] status = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder",
+                if (ShortcutHelpers.CheckShortcut(Environment.SpecialFolder.Startup, StartupTargetPath))
+                {
+                    byte[] status = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder",
                     "ShareX.lnk", null) as byte[];
 
-                if (status != null && status.Length > 0 && status[0] == 3)
-                {
-                    return StartupTaskState.DisabledByUser;
+                    if (status != null && status.Length > 0 && status[0] == 3)
+                    {
+                        return StartupTaskState.DisabledByUser;
+                    }
+                    else
+                    {
+                        return StartupTaskState.Enabled;
+                    }
                 }
-
-                return ShortcutHelpers.CheckShortcut(Environment.SpecialFolder.Startup, StartupTargetPath) ? StartupTaskState.Enabled : StartupTaskState.Disabled;
+                else
+                {
+                    return StartupTaskState.Disabled;
+                }
             }
             set
             {


### PR DESCRIPTION
This prevents the user falling in some cases where enabling startup again was impossible without manually creating the shortcut.