### PR TITLE
Make ShareX more usable in high DPI monitors

### DIFF
--- a/ShareX.HelpersLib/Colors/ColorPickerForm.Designer.cs
+++ b/ShareX.HelpersLib/Colors/ColorPickerForm.Designer.cs
@@ -574,10 +574,10 @@
             // 
             // ColorPickerForm
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.CancelButton = this.btnCancel;
-            resources.ApplyResources(this, "$this");
             this.Controls.Add(this.pColorPicker);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.pSceenColorPicker);

--- a/ShareX.HelpersLib/Colors/ColorPickerForm.resx
+++ b/ShareX.HelpersLib/Colors/ColorPickerForm.resx
@@ -1719,6 +1719,9 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>640, 328</value>
   </data>

--- a/ShareX.HelpersLib/Controls/MyListView.cs
+++ b/ShareX.HelpersLib/Controls/MyListView.cs
@@ -34,6 +34,7 @@ namespace ShareX.HelpersLib
     public class MyListView : ListView
     {
         public delegate void ListViewItemMovedEventHandler(object sender, int oldIndex, int newIndex);
+
         public event ListViewItemMovedEventHandler ItemMoved;
 
         [DefaultValue(false)]
@@ -328,6 +329,15 @@ namespace ShareX.HelpersLib
 
                 Point[] rightTriangle = new Point[] { new Point(right, y - 4), new Point(right - 8, y), new Point(right, y + 4) };
                 g.FillPolygon(SystemBrushes.HotTrack, rightTriangle);
+            }
+        }
+
+        protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+        {
+            base.ScaleControl(factor, specified);
+            foreach (ColumnHeader column in Columns)
+            {
+                column.Width = (int)Math.Round(column.Width * factor.Width);
             }
         }
     }

--- a/ShareX.HelpersLib/Controls/MyPictureBox.Designer.cs
+++ b/ShareX.HelpersLib/Controls/MyPictureBox.Designer.cs
@@ -82,6 +82,7 @@
             this.Controls.Add(this.lblStatus);
             this.Controls.Add(this.pbMain);
             this.Name = "MyPictureBox";
+            this.Resize += new System.EventHandler(this.MyPictureBox_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.pbMain)).EndInit();
             this.cmsMenu.ResumeLayout(false);
             this.ResumeLayout(false);

--- a/ShareX.HelpersLib/Controls/MyPictureBox.cs
+++ b/ShareX.HelpersLib/Controls/MyPictureBox.cs
@@ -352,5 +352,10 @@ namespace ShareX.HelpersLib
                 ClipboardHelpers.CopyImage(Image);
             }
         }
+
+        private void MyPictureBox_Resize(object sender, EventArgs e)
+        {
+            lblImageSize.Location = new Point((Width - lblImageSize.Width) / 2, Height - lblImageSize.Height);
+        }
     }
 }

--- a/ShareX.HelpersLib/Controls/TabToListView.cs
+++ b/ShareX.HelpersLib/Controls/TabToListView.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
@@ -178,6 +179,12 @@ namespace ShareX.HelpersLib
         public void FocusListView()
         {
             lvMain.Focus();
+        }
+
+        protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+        {
+            base.ScaleControl(factor, specified);
+            scMain.SplitterDistance = (int)Math.Round(scMain.SplitterDistance * factor.Width);
         }
     }
 }

--- a/ShareX.HelpersLib/Controls/TabToTreeView.cs
+++ b/ShareX.HelpersLib/Controls/TabToTreeView.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
@@ -170,6 +171,12 @@ namespace ShareX.HelpersLib
             {
                 TabChanged(tabPage);
             }
+        }
+
+        protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+        {
+            base.ScaleControl(factor, specified);
+            scMain.SplitterDistance = (int)Math.Round(scMain.SplitterDistance * factor.Width);
         }
     }
 }

--- a/ShareX.HelpersLib/Controls/ToolStripButtonCounter.cs
+++ b/ShareX.HelpersLib/Controls/ToolStripButtonCounter.cs
@@ -60,7 +60,8 @@ namespace ShareX.HelpersLib
             }
             else
             {
-                Bitmap bmp = new Bitmap(16, 16);
+                int size = Height - ExtraImagePadding * 2;
+                Bitmap bmp = new Bitmap(size, size);
 
                 using (Graphics g = Graphics.FromImage(bmp))
                 using (Brush brush = new SolidBrush(Color.FromArgb(230, 0, 0)))
@@ -69,7 +70,7 @@ namespace ShareX.HelpersLib
                 {
                     g.SmoothingMode = SmoothingMode.HighQuality;
                     g.PixelOffsetMode = PixelOffsetMode.Half;
-                    g.DrawRoundedRectangle(brush, null, new Rectangle(0, 0, 16, 16), 3);
+                    g.DrawRoundedRectangle(brush, null, new Rectangle(0, 0, bmp.Width, bmp.Height), 3);
                     stringFormat.Alignment = StringAlignment.Center;
                     stringFormat.LineAlignment = StringAlignment.Center;
                     string text;
@@ -81,7 +82,7 @@ namespace ShareX.HelpersLib
                     {
                         text = Counter.ToString();
                     }
-                    g.DrawString(text, font, Brushes.White, new Rectangle(0, 0, 16, 16), stringFormat);
+                    g.DrawString(text, font, Brushes.White, new Rectangle(0, 0, bmp.Width, bmp.Height), stringFormat);
                 }
 
                 if (ExtraImage != null)

--- a/ShareX.HelpersLib/Forms/InputBox.cs
+++ b/ShareX.HelpersLib/Forms/InputBox.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using System;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
@@ -48,6 +49,8 @@ namespace ShareX.HelpersLib
         private void InputBox_Shown(object sender, EventArgs e)
         {
             this.ForceActivate();
+            this.MinimumSize = new Size(384, this.Size.Height);
+            this.MaximumSize = new Size(1000, this.Size.Height);
 
             txtInputText.SelectionLength = txtInputText.Text.Length;
         }
@@ -99,28 +102,28 @@ namespace ShareX.HelpersLib
             this.btnCancel = new System.Windows.Forms.Button();
             this.txtInputText = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
-            //
+            // 
             // btnOK
-            //
+            // 
             resources.ApplyResources(this.btnOK, "btnOK");
             this.btnOK.Name = "btnOK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-            //
+            // 
             // btnCancel
-            //
+            // 
             resources.ApplyResources(this.btnCancel, "btnCancel");
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            //
+            // 
             // txtInputText
-            //
+            // 
             resources.ApplyResources(this.txtInputText, "txtInputText");
             this.txtInputText.Name = "txtInputText";
-            //
+            // 
             // InputBox
-            //
+            // 
             this.AcceptButton = this.btnOK;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/ShareX.HelpersLib/Forms/InputBox.resx
+++ b/ShareX.HelpersLib/Forms/InputBox.resx
@@ -207,12 +207,6 @@
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>484, 63</value>
   </data>
-  <data name="$this.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>1000, 102</value>
-  </data>
-  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>384, 102</value>
-  </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
   </data>

--- a/ShareX.HistoryLib/HistoryForm.Designer.cs
+++ b/ShareX.HistoryLib/HistoryForm.Designer.cs
@@ -30,17 +30,18 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HistoryForm));
-            this.btnApplyFilters = new System.Windows.Forms.Button();
             this.scMain = new ShareX.HelpersLib.SplitContainerCustomSplitter();
             this.lvHistory = new ShareX.HelpersLib.MyListView();
             this.chIcon = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chDateTime = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chFilename = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chURL = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.panel1 = new System.Windows.Forms.Panel();
             this.pbThumbnail = new ShareX.HelpersLib.MyPictureBox();
             this.gbFilters = new System.Windows.Forms.GroupBox();
             this.cbHostFilterSelection = new System.Windows.Forms.ComboBox();
             this.btnRemoveFilters = new System.Windows.Forms.Button();
+            this.btnApplyFilters = new System.Windows.Forms.Button();
             this.cbTypeFilterSelection = new System.Windows.Forms.ComboBox();
             this.cbHostFilter = new System.Windows.Forms.CheckBox();
             this.cbTypeFilter = new System.Windows.Forms.CheckBox();
@@ -56,15 +57,9 @@
             this.scMain.Panel1.SuspendLayout();
             this.scMain.Panel2.SuspendLayout();
             this.scMain.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.gbFilters.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // btnApplyFilters
-            // 
-            resources.ApplyResources(this.btnApplyFilters, "btnApplyFilters");
-            this.btnApplyFilters.Name = "btnApplyFilters";
-            this.btnApplyFilters.UseVisualStyleBackColor = true;
-            this.btnApplyFilters.Click += new System.EventHandler(this.btnApplyFilters_Click);
             // 
             // scMain
             // 
@@ -78,8 +73,7 @@
             // 
             // scMain.Panel2
             // 
-            this.scMain.Panel2.Controls.Add(this.pbThumbnail);
-            this.scMain.Panel2.Controls.Add(this.gbFilters);
+            this.scMain.Panel2.Controls.Add(this.panel1);
             this.scMain.SplitterColor = System.Drawing.Color.DarkGray;
             this.scMain.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.scMain_SplitterMoved);
             // 
@@ -120,6 +114,13 @@
             // chURL
             // 
             resources.ApplyResources(this.chURL, "chURL");
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.pbThumbnail);
+            this.panel1.Controls.Add(this.gbFilters);
+            resources.ApplyResources(this.panel1, "panel1");
+            this.panel1.Name = "panel1";
             // 
             // pbThumbnail
             // 
@@ -163,6 +164,13 @@
             this.btnRemoveFilters.Name = "btnRemoveFilters";
             this.btnRemoveFilters.UseVisualStyleBackColor = true;
             this.btnRemoveFilters.Click += new System.EventHandler(this.btnRemoveFilters_Click);
+            // 
+            // btnApplyFilters
+            // 
+            resources.ApplyResources(this.btnApplyFilters, "btnApplyFilters");
+            this.btnApplyFilters.Name = "btnApplyFilters";
+            this.btnApplyFilters.UseVisualStyleBackColor = true;
+            this.btnApplyFilters.Click += new System.EventHandler(this.btnApplyFilters_Click);
             // 
             // cbTypeFilterSelection
             // 
@@ -248,6 +256,7 @@
             this.scMain.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.scMain)).EndInit();
             this.scMain.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
             this.gbFilters.ResumeLayout(false);
             this.gbFilters.PerformLayout();
             this.ResumeLayout(false);
@@ -260,23 +269,24 @@
         private System.Windows.Forms.ColumnHeader chFilename;
         private System.Windows.Forms.ColumnHeader chDateTime;
         private System.Windows.Forms.ColumnHeader chURL;
-        private System.Windows.Forms.DateTimePicker dtpFilterFrom;
-        private System.Windows.Forms.CheckBox cbDateFilter;
-        private System.Windows.Forms.Label lblFilterFrom;
-        private System.Windows.Forms.Label lblFilterTo;
-        private System.Windows.Forms.DateTimePicker dtpFilterTo;
-        private System.Windows.Forms.Button btnApplyFilters;
-        private System.Windows.Forms.TextBox txtFilenameFilter;
-        private System.Windows.Forms.ComboBox cbFilenameFilterMethod;
-        private System.Windows.Forms.CheckBox cbFilenameFilter;
-        private ShareX.HelpersLib.MyPictureBox pbThumbnail;
+        private System.Windows.Forms.ColumnHeader chIcon;
+        private ShareX.HelpersLib.SplitContainerCustomSplitter scMain;
+        private System.Windows.Forms.Panel panel1;
+        private HelpersLib.MyPictureBox pbThumbnail;
         private System.Windows.Forms.GroupBox gbFilters;
+        private System.Windows.Forms.ComboBox cbHostFilterSelection;
         private System.Windows.Forms.Button btnRemoveFilters;
+        private System.Windows.Forms.Button btnApplyFilters;
         private System.Windows.Forms.ComboBox cbTypeFilterSelection;
         private System.Windows.Forms.CheckBox cbHostFilter;
         private System.Windows.Forms.CheckBox cbTypeFilter;
-        private System.Windows.Forms.ColumnHeader chIcon;
-        private ShareX.HelpersLib.SplitContainerCustomSplitter scMain;
-        private System.Windows.Forms.ComboBox cbHostFilterSelection;
+        private System.Windows.Forms.DateTimePicker dtpFilterFrom;
+        private System.Windows.Forms.Label lblFilterFrom;
+        private System.Windows.Forms.CheckBox cbFilenameFilter;
+        private System.Windows.Forms.Label lblFilterTo;
+        private System.Windows.Forms.CheckBox cbDateFilter;
+        private System.Windows.Forms.DateTimePicker dtpFilterTo;
+        private System.Windows.Forms.TextBox txtFilenameFilter;
+        private System.Windows.Forms.ComboBox cbFilenameFilterMethod;
     }
 }

--- a/ShareX.HistoryLib/HistoryForm.resx
+++ b/ShareX.HistoryLib/HistoryForm.resx
@@ -118,44 +118,17 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="btnApplyFilters.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="btnApplyFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 210</value>
-  </data>
-  <data name="btnApplyFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 24</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="btnApplyFilters.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="btnApplyFilters.Text" xml:space="preserve">
-    <value>Apply filters</value>
-  </data>
-  <data name="&gt;&gt;btnApplyFilters.Name" xml:space="preserve">
-    <value>btnApplyFilters</value>
-  </data>
-  <data name="&gt;&gt;btnApplyFilters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnApplyFilters.Parent" xml:space="preserve">
-    <value>gbFilters</value>
-  </data>
-  <data name="&gt;&gt;btnApplyFilters.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="scMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="scMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
   <data name="chIcon.Text" xml:space="preserve">
     <value />
-  <comment>@Invariant</comment></data>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="chIcon.Width" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
@@ -173,7 +146,7 @@
   </data>
   <data name="chURL.Text" xml:space="preserve">
     <value>URL</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="chURL.Width" type="System.Int32, mscorlib">
     <value>230</value>
   </data>
@@ -193,7 +166,7 @@
     <value>lvHistory</value>
   </data>
   <data name="&gt;&gt;lvHistory.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lvHistory.Parent" xml:space="preserve">
     <value>scMain.Panel1</value>
@@ -226,16 +199,16 @@
     <value>406, 368</value>
   </data>
   <data name="pbThumbnail.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.Name" xml:space="preserve">
     <value>pbThumbnail</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyPictureBox, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.MyPictureBox, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.Parent" xml:space="preserve">
-    <value>scMain.Panel2</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -290,6 +263,33 @@
   </data>
   <data name="&gt;&gt;btnRemoveFilters.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="btnApplyFilters.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnApplyFilters.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 210</value>
+  </data>
+  <data name="btnApplyFilters.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 24</value>
+  </data>
+  <data name="btnApplyFilters.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="btnApplyFilters.Text" xml:space="preserve">
+    <value>Apply filters</value>
+  </data>
+  <data name="&gt;&gt;btnApplyFilters.Name" xml:space="preserve">
+    <value>btnApplyFilters</value>
+  </data>
+  <data name="&gt;&gt;btnApplyFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnApplyFilters.Parent" xml:space="preserve">
+    <value>gbFilters</value>
+  </data>
+  <data name="&gt;&gt;btnApplyFilters.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbTypeFilterSelection.Location" type="System.Drawing.Point, System.Drawing">
     <value>168, 150</value>
@@ -595,7 +595,7 @@
     <value>406, 250</value>
   </data>
   <data name="gbFilters.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="gbFilters.Text" xml:space="preserve">
     <value>Filters</value>
@@ -607,10 +607,34 @@
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;gbFilters.Parent" xml:space="preserve">
-    <value>scMain.Panel2</value>
+    <value>panel1</value>
   </data>
   <data name="&gt;&gt;gbFilters.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>428, 641</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>scMain.Panel2</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="&gt;&gt;scMain.Panel2.Name" xml:space="preserve">
     <value>scMain.Panel2</value>
@@ -643,7 +667,7 @@
     <value>scMain</value>
   </data>
   <data name="&gt;&gt;scMain.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.SplitContainerCustomSplitter, ShareX.HelpersLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.SplitContainerCustomSplitter, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;scMain.Parent" xml:space="preserve">
     <value>$this</value>

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -100,19 +100,6 @@ namespace ShareX.ScreenCaptureLib
 
             tsMain.SuspendLayout();
 
-            // https://www.medo64.com/2014/01/scaling-toolstrip-with-dpi/
-            using (Graphics g = menuForm.CreateGraphics())
-            {
-                double scale = Math.Max(g.DpiX, g.DpiY) / 96.0;
-                double newScale = ((int)Math.Floor(scale * 100) / 25 * 25) / 100.0;
-                if (newScale > 1)
-                {
-                    int newWidth = (int)(tsMain.ImageScalingSize.Width * newScale);
-                    int newHeight = (int)(tsMain.ImageScalingSize.Height * newScale);
-                    tsMain.ImageScalingSize = new Size(newWidth, newHeight);
-                }
-            }
-
             menuForm.Controls.Add(tsMain);
 
             if (Form.IsFullscreen)

--- a/ShareX/Forms/ActionsToolbarForm.cs
+++ b/ShareX/Forms/ActionsToolbarForm.cs
@@ -101,19 +101,6 @@ namespace ShareX
                 ShowItemToolTips = false
             };
 
-            // https://www.medo64.com/2014/01/scaling-toolstrip-with-dpi/
-            using (Graphics g = CreateGraphics())
-            {
-                double scale = Math.Max(g.DpiX, g.DpiY) / 96.0;
-                double newScale = ((int)Math.Floor(scale * 100) / 25 * 25) / 100.0;
-                if (newScale > 1)
-                {
-                    int newWidth = (int)(tsMain.ImageScalingSize.Width * newScale);
-                    int newHeight = (int)(tsMain.ImageScalingSize.Height * newScale);
-                    tsMain.ImageScalingSize = new Size(newWidth, newHeight);
-                }
-            }
-
             tsMain.MouseLeave += tsMain_MouseLeave;
 
             Controls.Add(tsMain);

--- a/ShareX/app.config
+++ b/ShareX/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
@@ -20,4 +20,7 @@
     <idn enabled="All" />
     <iriParsing enabled="true" />
   </uri>
+  <appSettings>
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+  </appSettings>
 </configuration>


### PR DESCRIPTION
Enables .NET 4.5 DPI fixes and fixes UI elements that were clipped or unusable at high DPI.

Before: https://imgur.com/a/WLh3y
After: https://imgur.com/a/bp8RQ

Should fix issues like #2672, #3249, #2635 etc.