### PR TITLE
Cleanup code

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/Drawing/LineDrawingShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Drawing/LineDrawingShape.cs
@@ -51,11 +51,6 @@ namespace ShareX.ScreenCaptureLib
                 newPoints[newPoints.Length - 1] = Points[Points.Length - 1];
             }
 
-            for (int i = 0; i < newPoints.Length; i++)
-            {
-                if (newPoints[i] == null) newPoints[i] = new Point();
-            }
-
             Points = newPoints;
         }
 


### PR DESCRIPTION
newPoints is array of structs "System.Drawing.Point". Any element of an array can not be null. That expression (newPoints[i] == null) always return false. So, we can remove this cycle without changes in program logic.