### PR TITLE
Remove unnecessary null check

### DIFF
--- a/ShareX.HelpersLib/Extensions/XMLExtensions.cs
+++ b/ShareX.HelpersLib/Extensions/XMLExtensions.cs
@@ -41,7 +41,7 @@ namespace ShareX.HelpersLib
 
                 string[] splitPath = path.Split('/');
 
-                if (splitPath != null && splitPath.Length > 0)
+                if (splitPath.Length > 0)
                 {
                     foreach (string name in splitPath)
                     {

--- a/ShareX.UploadersLib/FileUploaders/Puush.cs
+++ b/ShareX.UploadersLib/FileUploaders/Puush.cs
@@ -90,7 +90,7 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 string[] values = response.Split(',');
 
-                if (values != null && values.Length > 1)
+                if (values.Length > 1)
                 {
                     int status;
 
@@ -119,7 +119,7 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 string[] lines = response.Lines();
 
-                if (lines != null && lines.Length > 0)
+                if (lines.Length > 0)
                 {
                     int status;
 
@@ -144,7 +144,7 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 string[] values = result.Response.Split(',');
 
-                if (values != null && values.Length > 0)
+                if (values.Length > 0)
                 {
                     int status;
 


### PR DESCRIPTION
Split function always return array. If you look at the source of it, it even guarantees it with code contracts