### PR TITLE
Azure Storage Updates

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -95,7 +95,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
             string targetPath = GetUploadPath(fileName);
-            string url = "";
+            string url;
             if (AzureStorageContainer == "$root")
             {
                 url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{targetPath}";
@@ -112,7 +112,7 @@ namespace ShareX.UploadersLib.FileUploaders
             requestHeaders["x-ms-blob-type"] = "BlockBlob";
 
             string canonicalizedHeaders = $"x-ms-blob-type:BlockBlob\nx-ms-date:{date}\nx-ms-version:{APIVersion}\n";
-            string canonicalizedResource = "";
+            string canonicalizedResource;
             if (AzureStorageContainer == "$root")
             {
                 canonicalizedResource = $"/{AzureStorageAccountName}/{targetPath}";

--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -95,10 +95,14 @@ namespace ShareX.UploadersLib.FileUploaders
 
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
             string targetPath = GetUploadPath(fileName);
-            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}/{targetPath}";
+            string url = "";
             if (AzureStorageContainer == "$root")
             {
                 url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{targetPath}";
+            }
+            else
+            {
+                url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}/{targetPath}";
             }
             string contentType = Helpers.GetMimeType(fileName);
 
@@ -108,10 +112,14 @@ namespace ShareX.UploadersLib.FileUploaders
             requestHeaders["x-ms-blob-type"] = "BlockBlob";
 
             string canonicalizedHeaders = $"x-ms-blob-type:BlockBlob\nx-ms-date:{date}\nx-ms-version:{APIVersion}\n";
-            string canonicalizedResource = $"/{AzureStorageAccountName}/{AzureStorageContainer}/{targetPath}";
+            string canonicalizedResource = "";
             if (AzureStorageContainer == "$root")
             {
                 canonicalizedResource = $"/{AzureStorageAccountName}/{targetPath}";
+            }
+            else
+            {
+                canonicalizedResource = $"/{AzureStorageAccountName}/{AzureStorageContainer}/{targetPath}";
             }
             string stringToSign = GenerateStringToSign(canonicalizedHeaders, canonicalizedResource, stream.Length.ToString(), contentType);
 

--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -51,7 +51,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
         {
-            return new AzureStorage(config.AzureStorageAccountName, config.AzureStorageAccountAccessKey, config.AzureStorageContainer, config.AzureStorageEnvironment, config.AzureStorageCustomDomain);
+            return new AzureStorage(config.AzureStorageAccountName, config.AzureStorageAccountAccessKey, config.AzureStorageContainer, config.AzureStorageEnvironment, config.AzureStorageCustomDomain, config.AzureStorageUploadPath, config.AzureStorageExcludeContainer);
         }
 
         public override TabPage GetUploadersConfigTabPage(UploadersConfigForm form) => form.tpAzureStorage;
@@ -66,14 +66,18 @@ namespace ShareX.UploadersLib.FileUploaders
         public string AzureStorageContainer { get; private set; }
         public string AzureStorageEnvironment { get; private set; }
         public string AzureStorageCustomDomain { get; private set; }
+        public string AzureStorageUploadPath { get; private set; }
+        public bool AzureStorageExcludeContainer { get; private set; }
 
-        public AzureStorage(string azureStorageAccountName, string azureStorageAccessKey, string azureStorageContainer, string azureStorageEnvironment, string customDomain)
+        public AzureStorage(string azureStorageAccountName, string azureStorageAccessKey, string azureStorageContainer, string azureStorageEnvironment, string customDomain, string uploadPath, bool excludeContainer)
         {
             AzureStorageAccountName = azureStorageAccountName;
             AzureStorageAccountAccessKey = azureStorageAccessKey;
             AzureStorageContainer = azureStorageContainer;
             AzureStorageEnvironment = (!string.IsNullOrEmpty(azureStorageEnvironment)) ? azureStorageEnvironment : "blob.core.windows.net";
             AzureStorageCustomDomain = customDomain;
+            AzureStorageUploadPath = uploadPath;
+            AzureStorageExcludeContainer = excludeContainer;
         }
 
         public override UploadResult Upload(Stream stream, string fileName)
@@ -90,7 +94,12 @@ namespace ShareX.UploadersLib.FileUploaders
             CreateContainerIfNotExists();
 
             string date = DateTime.UtcNow.ToString("R", CultureInfo.InvariantCulture);
-            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}/{fileName}";
+            string targetPath = GetUploadPath(fileName);
+            string url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{AzureStorageContainer}/{targetPath}";
+            if (AzureStorageContainer == "$root")
+            {
+                url = $"https://{AzureStorageAccountName}.{AzureStorageEnvironment}/{targetPath}";
+            }
             string contentType = Helpers.GetMimeType(fileName);
 
             NameValueCollection requestHeaders = new NameValueCollection();
@@ -99,7 +108,11 @@ namespace ShareX.UploadersLib.FileUploaders
             requestHeaders["x-ms-blob-type"] = "BlockBlob";
 
             string canonicalizedHeaders = $"x-ms-blob-type:BlockBlob\nx-ms-date:{date}\nx-ms-version:{APIVersion}\n";
-            string canonicalizedResource = $"/{AzureStorageAccountName}/{AzureStorageContainer}/{fileName}";
+            string canonicalizedResource = $"/{AzureStorageAccountName}/{AzureStorageContainer}/{targetPath}";
+            if (AzureStorageContainer == "$root")
+            {
+                canonicalizedResource = $"/{AzureStorageAccountName}/{targetPath}";
+            }
             string stringToSign = GenerateStringToSign(canonicalizedHeaders, canonicalizedResource, stream.Length.ToString(), contentType);
 
             requestHeaders["Authorization"] = $"SharedKey {AzureStorageAccountName}:{stringToSign}";
@@ -112,7 +125,14 @@ namespace ShareX.UploadersLib.FileUploaders
 
                 if (!string.IsNullOrEmpty(AzureStorageCustomDomain))
                 {
-                    result = URLHelpers.CombineURL(AzureStorageCustomDomain, AzureStorageContainer, fileName);
+                    if (AzureStorageExcludeContainer)
+                    {
+                        result = URLHelpers.CombineURL(AzureStorageCustomDomain, targetPath);
+                    }
+                    else
+                    {
+                        result = URLHelpers.CombineURL(AzureStorageCustomDomain, AzureStorageContainer, targetPath);
+                    }
                     result = URLHelpers.FixPrefix(result);
                 }
                 else
@@ -223,6 +243,19 @@ namespace ShareX.UploadersLib.FileUploaders
             }
 
             return hashedString;
+        }
+
+        private string GetUploadPath(string fileName)
+        {
+            if (!String.IsNullOrEmpty(AzureStorageUploadPath))
+            {
+                string path = NameParser.Parse(NameParserType.FolderPath, AzureStorageUploadPath.Trim('/'));
+                return URLHelpers.CombineURL(path, fileName);
+            }
+            else
+            {
+                return fileName;
+            }
         }
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -1466,6 +1466,7 @@
             // 
             this.eiCustomUploaders.CustomFilter = "ShareX custom uploader (*.sxcu)|*.sxcu";
             this.eiCustomUploaders.DefaultFileName = null;
+            this.eiCustomUploaders.ExportIgnoreDefaultValue = true;
             this.eiCustomUploaders.ExportIgnoreNull = true;
             resources.ApplyResources(this.eiCustomUploaders, "eiCustomUploaders");
             this.eiCustomUploaders.Name = "eiCustomUploaders";

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -310,6 +310,9 @@
             this.txtGoogleCloudStorageBucket = new System.Windows.Forms.TextBox();
             this.oauth2GoogleCloudStorage = new ShareX.UploadersLib.OAuthControl();
             this.tpAzureStorage = new System.Windows.Forms.TabPage();
+            this.cbAzureStorageExcludeContainer = new System.Windows.Forms.CheckBox();
+            this.txtAzureStorageUploadPath = new System.Windows.Forms.TextBox();
+            this.lblAzureStorageUploadPath = new System.Windows.Forms.Label();
             this.cbAzureStorageEnvironment = new System.Windows.Forms.ComboBox();
             this.lblAzureStorageEnvironment = new System.Windows.Forms.Label();
             this.btnAzureStoragePortal = new System.Windows.Forms.Button();
@@ -1463,7 +1466,6 @@
             // 
             this.eiCustomUploaders.CustomFilter = "ShareX custom uploader (*.sxcu)|*.sxcu";
             this.eiCustomUploaders.DefaultFileName = null;
-            this.eiCustomUploaders.ExportIgnoreDefaultValue = true;
             this.eiCustomUploaders.ExportIgnoreNull = true;
             resources.ApplyResources(this.eiCustomUploaders, "eiCustomUploaders");
             this.eiCustomUploaders.Name = "eiCustomUploaders";
@@ -2835,6 +2837,9 @@
             // tpAzureStorage
             // 
             this.tpAzureStorage.BackColor = System.Drawing.SystemColors.Window;
+            this.tpAzureStorage.Controls.Add(this.cbAzureStorageExcludeContainer);
+            this.tpAzureStorage.Controls.Add(this.txtAzureStorageUploadPath);
+            this.tpAzureStorage.Controls.Add(this.lblAzureStorageUploadPath);
             this.tpAzureStorage.Controls.Add(this.cbAzureStorageEnvironment);
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageEnvironment);
             this.tpAzureStorage.Controls.Add(this.btnAzureStoragePortal);
@@ -2848,6 +2853,24 @@
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageCustomDomain);
             resources.ApplyResources(this.tpAzureStorage, "tpAzureStorage");
             this.tpAzureStorage.Name = "tpAzureStorage";
+            // 
+            // cbAzureStorageExcludeContainer
+            // 
+            resources.ApplyResources(this.cbAzureStorageExcludeContainer, "cbAzureStorageExcludeContainer");
+            this.cbAzureStorageExcludeContainer.Name = "cbAzureStorageExcludeContainer";
+            this.cbAzureStorageExcludeContainer.UseVisualStyleBackColor = true;
+            this.cbAzureStorageExcludeContainer.CheckedChanged += new System.EventHandler(this.cbAzureStorageExcludeContainer_CheckedChanged);
+            // 
+            // txtAzureStorageUploadPath
+            // 
+            resources.ApplyResources(this.txtAzureStorageUploadPath, "txtAzureStorageUploadPath");
+            this.txtAzureStorageUploadPath.Name = "txtAzureStorageUploadPath";
+            this.txtAzureStorageUploadPath.TextChanged += new System.EventHandler(this.txtAzureStorageUploadPath_TextChanged);
+            // 
+            // lblAzureStorageUploadPath
+            // 
+            resources.ApplyResources(this.lblAzureStorageUploadPath, "lblAzureStorageUploadPath");
+            this.lblAzureStorageUploadPath.Name = "lblAzureStorageUploadPath";
             // 
             // cbAzureStorageEnvironment
             // 
@@ -6083,5 +6106,8 @@
         private System.Windows.Forms.ListBox lbSharedFolderAccounts;
         private System.Windows.Forms.Label lblGoogleCloudStoragePathPreviewLabel;
         private System.Windows.Forms.Label lblGoogleCloudStoragePathPreview;
+        private System.Windows.Forms.TextBox txtAzureStorageUploadPath;
+        private System.Windows.Forms.Label lblAzureStorageUploadPath;
+        private System.Windows.Forms.CheckBox cbAzureStorageExcludeContainer;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -3756,11 +3756,9 @@ namespace ShareX.UploadersLib
                 case URLType.URL:
                     tb = txtCustomUploaderURL;
                     break;
-
                 case URLType.ThumbnailURL:
                     tb = txtCustomUploaderThumbnailURL;
                     break;
-
                 case URLType.DeletionURL:
                     tb = txtCustomUploaderDeletionURL;
                     break;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -667,6 +667,8 @@ namespace ShareX.UploadersLib
             txtAzureStorageContainer.Text = Config.AzureStorageContainer;
             cbAzureStorageEnvironment.Text = Config.AzureStorageEnvironment;
             txtAzureStorageCustomDomain.Text = Config.AzureStorageCustomDomain;
+            txtAzureStorageUploadPath.Text = Config.AzureStorageUploadPath;
+            cbAzureStorageExcludeContainer.Checked = Config.AzureStorageExcludeContainer;
 
             #endregion Azure Storage
 
@@ -2870,6 +2872,16 @@ namespace ShareX.UploadersLib
             Config.AzureStorageCustomDomain = txtAzureStorageCustomDomain.Text;
         }
 
+        private void txtAzureStorageUploadPath_TextChanged(object sender, EventArgs e)
+        {
+            Config.AzureStorageUploadPath = txtAzureStorageUploadPath.Text;
+        }
+
+        private void cbAzureStorageExcludeContainer_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.AzureStorageExcludeContainer = cbAzureStorageExcludeContainer.Checked;
+        }
+
         private void btnAzureStoragePortal_Click(object sender, EventArgs e)
         {
             URLHelpers.OpenURL("https://portal.azure.com/?feature.customportal=false#blade/HubsExtension/Resources/resourceType/Microsoft.Storage%2FStorageAccounts");
@@ -3744,9 +3756,11 @@ namespace ShareX.UploadersLib
                 case URLType.URL:
                     tb = txtCustomUploaderURL;
                     break;
+
                 case URLType.ThumbnailURL:
                     tb = txtCustomUploaderThumbnailURL;
                     break;
+
                 case URLType.DeletionURL:
                     tb = txtCustomUploaderDeletionURL;
                     break;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -8398,6 +8398,7 @@ store.book[0].title</value>
   </data>
   <data name="tpFirebaseDynamicLinks.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
+  </data>
   <data name="tpPlik.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 0</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -218,237 +218,6 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;mbCustomUploaderDestinationType.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
-    <value>tpOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpOtherUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
-  </data>
-  <data name="tpOtherUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="tpOtherUploaders.Text" xml:space="preserve">
-    <value>Other uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOtherUploaders.Name" xml:space="preserve">
-    <value>tpOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOtherUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOtherUploaders.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOtherUploaders.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tcOtherUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
-  </data>
-  <data name="tcOtherUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
-    <value>tpOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterNameUpdate.Name" xml:space="preserve">
-    <value>btnTwitterNameUpdate</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterNameUpdate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterNameUpdate.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterNameUpdate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lbTwitterAccounts.Name" xml:space="preserve">
-    <value>lbTwitterAccounts</value>
-  </data>
-  <data name="&gt;&gt;lbTwitterAccounts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbTwitterAccounts.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;lbTwitterAccounts.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDefaultMessage.Name" xml:space="preserve">
-    <value>lblTwitterDefaultMessage</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDefaultMessage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDefaultMessage.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDefaultMessage.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDefaultMessage.Name" xml:space="preserve">
-    <value>txtTwitterDefaultMessage</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDefaultMessage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDefaultMessage.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDefaultMessage.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbTwitterSkipMessageBox.Name" xml:space="preserve">
-    <value>cbTwitterSkipMessageBox</value>
-  </data>
-  <data name="&gt;&gt;cbTwitterSkipMessageBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbTwitterSkipMessageBox.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;cbTwitterSkipMessageBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;oauthTwitter.Name" xml:space="preserve">
-    <value>oauthTwitter</value>
-  </data>
-  <data name="&gt;&gt;oauthTwitter.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauthTwitter.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;oauthTwitter.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDescription.Name" xml:space="preserve">
-    <value>txtTwitterDescription</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDescription.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;txtTwitterDescription.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDescription.Name" xml:space="preserve">
-    <value>lblTwitterDescription</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDescription.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;lblTwitterDescription.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterRemove.Name" xml:space="preserve">
-    <value>btnTwitterRemove</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterRemove.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterRemove.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterAdd.Name" xml:space="preserve">
-    <value>btnTwitterAdd</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterAdd.Parent" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;btnTwitterAdd.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="tpTwitter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTwitter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
-  </data>
-  <data name="tpTwitter.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpTwitter.Text" xml:space="preserve">
-    <value>Twitter</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
-    <value>tpTwitter</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnTwitterNameUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -716,296 +485,29 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;btnTwitterAdd.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Name" xml:space="preserve">
-    <value>btnCustomUploaderURLSharingServiceTest</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Name" xml:space="preserve">
-    <value>cbCustomUploaderURLSharingService</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Name" xml:space="preserve">
-    <value>lblCustomUploaderURLSharingService</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderExamples.Name" xml:space="preserve">
-    <value>btnCustomUploaderExamples</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderExamples.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderExamples.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderExamples.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHelp.Name" xml:space="preserve">
-    <value>btnCustomUploaderHelp</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHelp.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHelp.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderImageUploader.Name" xml:space="preserve">
-    <value>lblCustomUploaderImageUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderImageUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderImageUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderImageUploader.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Name" xml:space="preserve">
-    <value>btnCustomUploaderFileUploaderTest</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileUploader.Name" xml:space="preserve">
-    <value>lblCustomUploaderFileUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileUploader.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Name" xml:space="preserve">
-    <value>btnCustomUploaderImageUploaderTest</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTestResult.Name" xml:space="preserve">
-    <value>lblCustomUploaderTestResult</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTestResult.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTestResult.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTestResult.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderFileUploader.Name" xml:space="preserve">
-    <value>cbCustomUploaderFileUploader</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderFileUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderFileUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderFileUploader.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Name" xml:space="preserve">
-    <value>btnCustomUploaderShowLastResponse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLShortener.Name" xml:space="preserve">
-    <value>cbCustomUploaderURLShortener</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLShortener.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLShortener.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderURLShortener.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTextUploader.Name" xml:space="preserve">
-    <value>lblCustomUploaderTextUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTextUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTextUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderTextUploader.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Name" xml:space="preserve">
-    <value>btnCustomUploaderURLShortenerTest</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderTextUploader.Name" xml:space="preserve">
-    <value>cbCustomUploaderTextUploader</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderTextUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderTextUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderTextUploader.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLShortener.Name" xml:space="preserve">
-    <value>lblCustomUploaderURLShortener</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLShortener.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLShortener.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURLShortener.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Name" xml:space="preserve">
-    <value>btnCustomUploaderTextUploaderTest</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderImageUploader.Name" xml:space="preserve">
-    <value>cbCustomUploaderImageUploader</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderImageUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderImageUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderImageUploader.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderLog.Name" xml:space="preserve">
-    <value>txtCustomUploaderLog</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderLog.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderLog.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="tpCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpTwitter.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCustomUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="tpTwitter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
   </data>
-  <data name="tpCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="tpTwitter.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpCustomUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="tpTwitter.Text" xml:space="preserve">
+    <value>Twitter</value>
   </data>
-  <data name="tpCustomUploaders.Text" xml:space="preserve">
-    <value>Custom uploaders</value>
+  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
+    <value>tpTwitter</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
     <value>tcOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCustomUploaderURLSharingServiceTest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1085,243 +587,6 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;lblCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;lblCustomUploaderName.Name" xml:space="preserve">
-    <value>lblCustomUploaderName</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderName.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderName.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderRequestType.Name" xml:space="preserve">
-    <value>cbCustomUploaderRequestType</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderRequestType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderRequestType.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderRequestType.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURL.Name" xml:space="preserve">
-    <value>lblCustomUploaderURL</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderFileForm.Name" xml:space="preserve">
-    <value>txtCustomUploaderFileForm</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderFileForm.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderFileForm.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderFileForm.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestType.Name" xml:space="preserve">
-    <value>lblCustomUploaderRequestType</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestType.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestType.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileForm.Name" xml:space="preserve">
-    <value>lblCustomUploaderFileForm</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileForm.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileForm.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderFileForm.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderName.Name" xml:space="preserve">
-    <value>txtCustomUploaderName</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderName.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderName.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Name" xml:space="preserve">
-    <value>lblCustomUploaderThumbnailURL</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRequestURL.Name" xml:space="preserve">
-    <value>txtCustomUploaderRequestURL</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRequestURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRequestURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRequestURL.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderURL.Name" xml:space="preserve">
-    <value>txtCustomUploaderURL</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderURL.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderResponseType.Name" xml:space="preserve">
-    <value>cbCustomUploaderResponseType</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderResponseType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderResponseType.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;cbCustomUploaderResponseType.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Name" xml:space="preserve">
-    <value>txtCustomUploaderThumbnailURL</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Name" xml:space="preserve">
-    <value>txtCustomUploaderDeletionURL</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestURL.Name" xml:space="preserve">
-    <value>lblCustomUploaderRequestURL</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderRequestURL.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderResponseType.Name" xml:space="preserve">
-    <value>lblCustomUploaderResponseType</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderResponseType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderResponseType.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderResponseType.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Name" xml:space="preserve">
-    <value>lblCustomUploaderDeletionURL</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="pCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 8</value>
-  </data>
-  <data name="pCustomUploader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>528, 432</value>
-  </data>
-  <data name="pCustomUploader.TabIndex" type="System.Int32, mscorlib">
-    <value>37</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="lblCustomUploaderName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1372,150 +637,6 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   </data>
   <data name="&gt;&gt;cbCustomUploaderRequestType.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 48</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 184</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.TabIndex" type="System.Int32, mscorlib">
-    <value>36</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Name" xml:space="preserve">
-    <value>btnCustomUploaderJsonAddSyntax</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Parent" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Name" xml:space="preserve">
-    <value>btnCustomUploadJsonPathHelp</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Parent" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Name" xml:space="preserve">
-    <value>lblCustomUploaderJsonPathExample</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Parent" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPath.Name" xml:space="preserve">
-    <value>lblCustomUploaderJsonPath</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPath.Parent" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderJsonPath.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderJsonPath.Name" xml:space="preserve">
-    <value>txtCustomUploaderJsonPath</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderJsonPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderJsonPath.Parent" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderJsonPath.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpCustomUploaderJsonParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCustomUploaderJsonParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCustomUploaderJsonParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 158</value>
-  </data>
-  <data name="tpCustomUploaderJsonParse.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpCustomUploaderJsonParse.Text" xml:space="preserve">
-    <value>JSON</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnCustomUploaderJsonAddSyntax.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1655,92 +776,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderJsonPath.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Name" xml:space="preserve">
-    <value>btnCustomUploaderXmlSyntaxAdd</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Parent" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Name" xml:space="preserve">
-    <value>btnCustomUploaderXPathHelp</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Parent" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderXPathHelp.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPathExample.Name" xml:space="preserve">
-    <value>lblCustomUploaderXPathExample</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPathExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPathExample.Parent" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPathExample.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPath.Name" xml:space="preserve">
-    <value>lblCustomUploaderXPath</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPath.Parent" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;lblCustomUploaderXPath.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderXPath.Name" xml:space="preserve">
-    <value>txtCustomUploaderXPath</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderXPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderXPath.Parent" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderXPath.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpCustomUploaderXmlParse.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpCustomUploaderJsonParse.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpCustomUploaderJsonParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpCustomUploaderJsonParse.Size" type="System.Drawing.Size, System.Drawing">
     <value>248, 158</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpCustomUploaderJsonParse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Text" xml:space="preserve">
-    <value>XML</value>
+  <data name="tpCustomUploaderJsonParse.Text" xml:space="preserve">
+    <value>JSON</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
     <value>tcCustomUploaderResponseParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCustomUploaderXmlSyntaxAdd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1880,116 +941,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderXPath.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Name" xml:space="preserve">
-    <value>btnCustomUploaderRegexHelp</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexHelp.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Name" xml:space="preserve">
-    <value>btnCustomUploaderRegexAddSyntax</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRegexp.Name" xml:space="preserve">
-    <value>txtCustomUploaderRegexp</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRegexp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRegexp.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderRegexp.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Name" xml:space="preserve">
-    <value>btnCustomUploaderRegexpUpdate</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Name" xml:space="preserve">
-    <value>btnCustomUploaderRegexpAdd</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Name" xml:space="preserve">
-    <value>btnCustomUploaderRegexpRemove</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderRegexps.Name" xml:space="preserve">
-    <value>lvCustomUploaderRegexps</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderRegexps.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderRegexps.Parent" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderRegexps.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpCustomUploaderRegexParse.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpCustomUploaderXmlParse.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCustomUploaderRegexParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpCustomUploaderXmlParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpCustomUploaderRegexParse.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpCustomUploaderXmlParse.Size" type="System.Drawing.Size, System.Drawing">
     <value>248, 158</value>
   </data>
-  <data name="tpCustomUploaderRegexParse.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpCustomUploaderXmlParse.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpCustomUploaderRegexParse.Text" xml:space="preserve">
-    <value>Regex</value>
+  <data name="tpCustomUploaderXmlParse.Text" xml:space="preserve">
+    <value>XML</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
     <value>tcCustomUploaderResponseParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnCustomUploaderRegexHelp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2147,6 +1124,9 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderRegexpRemove.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="lvRegexpsColumn.Width" type="System.Int32, mscorlib">
+    <value>227</value>
+  </data>
   <data name="lvCustomUploaderRegexps.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -2168,8 +1148,53 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderRegexps.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="lvRegexpsColumn.Width" type="System.Int32, mscorlib">
-    <value>227</value>
+  <data name="tpCustomUploaderRegexParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 158</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Text" xml:space="preserve">
+    <value>Regex</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 48</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 184</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lblCustomUploaderURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2200,150 +1225,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblCustomUploaderURL.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tcCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 186</value>
-  </data>
-  <data name="tcCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 240</value>
-  </data>
-  <data name="tcCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Name" xml:space="preserve">
-    <value>btnCustomUploaderArgUpdate</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgUpdate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgName.Name" xml:space="preserve">
-    <value>txtCustomUploaderArgName</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgName.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgName.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgValue.Name" xml:space="preserve">
-    <value>txtCustomUploaderArgValue</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgValue.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderArgValue.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgAdd.Name" xml:space="preserve">
-    <value>btnCustomUploaderArgAdd</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgAdd.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgAdd.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgRemove.Name" xml:space="preserve">
-    <value>btnCustomUploaderArgRemove</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgRemove.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderArgRemove.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderArguments.Name" xml:space="preserve">
-    <value>lvCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderArguments.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCustomUploaderArguments.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 214</value>
-  </data>
-  <data name="tpCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpCustomUploaderArguments.Text" xml:space="preserve">
-    <value>Arguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnCustomUploaderArgUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2468,6 +1349,18 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderArgRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="chCustomUploaderArgumentsName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="chCustomUploaderArgumentsName.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
+  <data name="chCustomUploaderArgumentsValue.Text" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="chCustomUploaderArgumentsValue.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
   <data name="lvCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -2489,116 +1382,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderArguments.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="chCustomUploaderArgumentsName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="chCustomUploaderArgumentsName.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
-  <data name="chCustomUploaderArgumentsValue.Text" xml:space="preserve">
-    <value>Value</value>
-  </data>
-  <data name="chCustomUploaderArgumentsValue.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Name" xml:space="preserve">
-    <value>btnCustomUploaderHeaderUpdate</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderName.Name" xml:space="preserve">
-    <value>txtCustomUploaderHeaderName</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderName.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderName.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Name" xml:space="preserve">
-    <value>txtCustomUploaderHeaderValue</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;txtCustomUploaderHeaderValue.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Name" xml:space="preserve">
-    <value>btnCustomUploaderHeaderAdd</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Name" xml:space="preserve">
-    <value>btnCustomUploaderHeaderRemove</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderHeaders.Name" xml:space="preserve">
-    <value>lvCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderHeaders.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderHeaders.Parent" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;lvCustomUploaderHeaders.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpCustomUploaderArguments.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
     <value>248, 214</value>
   </data>
-  <data name="tpCustomUploaderHeaders.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Text" xml:space="preserve">
-    <value>Headers</value>
+  <data name="tpCustomUploaderArguments.Text" xml:space="preserve">
+    <value>Arguments</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
     <value>tcCustomUploaderArguments</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCustomUploaderHeaderUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -2723,6 +1532,18 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderHeaderRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="chCustomUploaderHeadersName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="chCustomUploaderHeadersName.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
+  <data name="chCustomUploaderHeadersValue.Text" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="chCustomUploaderHeadersValue.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
   <data name="lvCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -2744,17 +1565,53 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderHeaders.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="chCustomUploaderHeadersName.Text" xml:space="preserve">
-    <value>Name</value>
+  <data name="tpCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="chCustomUploaderHeadersName.Width" type="System.Int32, mscorlib">
-    <value>114</value>
+  <data name="tpCustomUploaderHeaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="chCustomUploaderHeadersValue.Text" xml:space="preserve">
-    <value>Value</value>
+  <data name="tpCustomUploaderHeaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 214</value>
   </data>
-  <data name="chCustomUploaderHeadersValue.Width" type="System.Int32, mscorlib">
-    <value>114</value>
+  <data name="tpCustomUploaderHeaders.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpCustomUploaderHeaders.Text" xml:space="preserve">
+    <value>Headers</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tcCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 186</value>
+  </data>
+  <data name="tcCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 240</value>
+  </data>
+  <data name="tcCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="txtCustomUploaderFileForm.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 162</value>
@@ -3083,6 +1940,27 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
     <value>18</value>
   </data>
+  <data name="pCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
+    <value>272, 8</value>
+  </data>
+  <data name="pCustomUploader.Size" type="System.Drawing.Size, System.Drawing">
+    <value>528, 432</value>
+  </data>
+  <data name="pCustomUploader.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="btnCustomUploaderExamples.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -3353,114 +2231,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbCustomUploaderURLShortener.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="&gt;&gt;btnCustomUploaderDuplicate.Name" xml:space="preserve">
-    <value>btnCustomUploaderDuplicate</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderDuplicate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderDuplicate.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderDuplicate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadersExportAll.Name" xml:space="preserve">
-    <value>btnCustomUploadersExportAll</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadersExportAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadersExportAll.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploadersExportAll.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Name" xml:space="preserve">
-    <value>btnCustomUploaderClearUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderClearUploaders.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;eiCustomUploaders.Name" xml:space="preserve">
-    <value>eiCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;eiCustomUploaders.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;eiCustomUploaders.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;eiCustomUploaders.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lbCustomUploaderList.Name" xml:space="preserve">
-    <value>lbCustomUploaderList</value>
-  </data>
-  <data name="&gt;&gt;lbCustomUploaderList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbCustomUploaderList.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;lbCustomUploaderList.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRemove.Name" xml:space="preserve">
-    <value>btnCustomUploaderRemove</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRemove.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderRemove.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderAdd.Name" xml:space="preserve">
-    <value>btnCustomUploaderAdd</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderAdd.Parent" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;btnCustomUploaderAdd.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="gbCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="gbCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 344</value>
-  </data>
-  <data name="gbCustomUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbCustomUploaders.Text" xml:space="preserve">
-    <value>Uploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="btnCustomUploaderDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -3644,6 +2414,30 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderAdd.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="gbCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="gbCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 344</value>
+  </data>
+  <data name="gbCustomUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbCustomUploaders.Text" xml:space="preserve">
+    <value>Uploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
   <data name="lblCustomUploaderTextUploader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3824,191 +2618,83 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderLog.ZOrder" xml:space="preserve">
     <value>21</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
-    <value>tpURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpURLShorteners.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpCustomUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
+  <data name="tpCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
   </data>
-  <data name="tpURLShorteners.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpCustomUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="tpURLShorteners.Text" xml:space="preserve">
-    <value>URL shorteners</value>
+  <data name="tpCustomUploaders.Text" xml:space="preserve">
+    <value>Custom uploaders</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Name" xml:space="preserve">
-    <value>tpURLShorteners</value>
+  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
+    <value>tpCustomUploaders</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
+  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
+    <value>tcOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
-    <value>tpBitly</value>
-  </data>
-  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
-  </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tcURLShorteners.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tcOtherUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tcURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tcOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="tcURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tcOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
     <value>980, 563</value>
   </data>
-  <data name="tcURLShorteners.TabIndex" type="System.Int32, mscorlib">
+  <data name="tcOtherUploaders.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
-    <value>tcURLShorteners</value>
+  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
+    <value>tcOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
+  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
-    <value>tpURLShorteners</value>
+  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
+    <value>tpOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;txtBitlyDomain.Name" xml:space="preserve">
-    <value>txtBitlyDomain</value>
-  </data>
-  <data name="&gt;&gt;txtBitlyDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtBitlyDomain.Parent" xml:space="preserve">
-    <value>tpBitly</value>
-  </data>
-  <data name="&gt;&gt;txtBitlyDomain.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblBitlyDomain.Name" xml:space="preserve">
-    <value>lblBitlyDomain</value>
-  </data>
-  <data name="&gt;&gt;lblBitlyDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBitlyDomain.Parent" xml:space="preserve">
-    <value>tpBitly</value>
-  </data>
-  <data name="&gt;&gt;lblBitlyDomain.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;oauth2Bitly.Name" xml:space="preserve">
-    <value>oauth2Bitly</value>
-  </data>
-  <data name="&gt;&gt;oauth2Bitly.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Bitly.Parent" xml:space="preserve">
-    <value>tpBitly</value>
-  </data>
-  <data name="&gt;&gt;oauth2Bitly.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpBitly.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpBitly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpOtherUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpBitly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="tpOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
   </data>
-  <data name="tpBitly.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpOtherUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
-  <data name="tpBitly.Text" xml:space="preserve">
-    <value>bit.ly</value>
+  <data name="tpOtherUploaders.Text" xml:space="preserve">
+    <value>Other uploaders</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
-    <value>tpBitly</value>
+  <data name="&gt;&gt;tpOtherUploaders.Name" xml:space="preserve">
+    <value>tpOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpOtherUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
+  <data name="&gt;&gt;tpOtherUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpOtherUploaders.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="txtBitlyDomain.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 248</value>
@@ -4082,140 +2768,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Bitly.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;txtYourlsPassword.Name" xml:space="preserve">
-    <value>txtYourlsPassword</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsPassword.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsPassword.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsUsername.Name" xml:space="preserve">
-    <value>txtYourlsUsername</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsUsername.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsUsername.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsSignature.Name" xml:space="preserve">
-    <value>txtYourlsSignature</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsSignature.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsSignature.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsSignature.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsNote.Name" xml:space="preserve">
-    <value>lblYourlsNote</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsNote.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsNote.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsNote.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsPassword.Name" xml:space="preserve">
-    <value>lblYourlsPassword</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsPassword.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsPassword.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsUsername.Name" xml:space="preserve">
-    <value>lblYourlsUsername</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsUsername.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsUsername.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsSignature.Name" xml:space="preserve">
-    <value>lblYourlsSignature</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsSignature.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsSignature.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsSignature.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsAPIURL.Name" xml:space="preserve">
-    <value>txtYourlsAPIURL</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsAPIURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsAPIURL.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;txtYourlsAPIURL.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsAPIURL.Name" xml:space="preserve">
-    <value>lblYourlsAPIURL</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsAPIURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsAPIURL.Parent" xml:space="preserve">
-    <value>tpYourls</value>
-  </data>
-  <data name="&gt;&gt;lblYourlsAPIURL.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpYourls.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpBitly.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpYourls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpBitly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpYourls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="tpBitly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
   </data>
-  <data name="tpYourls.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpBitly.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpYourls.Text" xml:space="preserve">
-    <value>YOURLS</value>
+  <data name="tpBitly.Text" xml:space="preserve">
+    <value>bit.ly</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
-    <value>tpYourls</value>
+  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
+    <value>tpBitly</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="txtYourlsPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 200</value>
@@ -4451,92 +3029,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblYourlsAPIURL.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;llAdflyLink.Name" xml:space="preserve">
-    <value>llAdflyLink</value>
-  </data>
-  <data name="&gt;&gt;llAdflyLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;llAdflyLink.Parent" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;llAdflyLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIUID.Name" xml:space="preserve">
-    <value>txtAdflyAPIUID</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIUID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIUID.Parent" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIUID.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIUID.Name" xml:space="preserve">
-    <value>lblAdflyAPIUID</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIUID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIUID.Parent" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIUID.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIKEY.Name" xml:space="preserve">
-    <value>txtAdflyAPIKEY</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIKEY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIKEY.Parent" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;txtAdflyAPIKEY.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIKEY.Name" xml:space="preserve">
-    <value>lblAdflyAPIKEY</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIKEY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIKEY.Parent" xml:space="preserve">
-    <value>tpAdFly</value>
-  </data>
-  <data name="&gt;&gt;lblAdflyAPIKEY.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpAdFly.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpYourls.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpAdFly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpYourls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpAdFly.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpYourls.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpAdFly.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpYourls.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpAdFly.Text" xml:space="preserve">
-    <value>adf.ly</value>
+  <data name="tpYourls.Text" xml:space="preserve">
+    <value>YOURLS</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
-    <value>tpAdFly</value>
+  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
+    <value>tpYourls</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="llAdflyLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4670,101 +3188,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblAdflyAPIKEY.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;cbPolrUseAPIv1.Name" xml:space="preserve">
-    <value>cbPolrUseAPIv1</value>
-  </data>
-  <data name="&gt;&gt;cbPolrUseAPIv1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPolrUseAPIv1.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;cbPolrUseAPIv1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbPolrIsSecret.Name" xml:space="preserve">
-    <value>cbPolrIsSecret</value>
-  </data>
-  <data name="&gt;&gt;cbPolrIsSecret.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPolrIsSecret.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;cbPolrIsSecret.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIKey.Name" xml:space="preserve">
-    <value>txtPolrAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIKey.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIKey.Name" xml:space="preserve">
-    <value>lblPolrAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIKey.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIKey.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIHostname.Name" xml:space="preserve">
-    <value>txtPolrAPIHostname</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIHostname.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIHostname.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;txtPolrAPIHostname.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIHostname.Name" xml:space="preserve">
-    <value>lblPolrAPIHostname</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIHostname.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIHostname.Parent" xml:space="preserve">
-    <value>tpPolr</value>
-  </data>
-  <data name="&gt;&gt;lblPolrAPIHostname.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpPolr.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpAdFly.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPolr.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpAdFly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAdFly.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpPolr.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="tpAdFly.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpPolr.Text" xml:space="preserve">
-    <value>Polr</value>
+  <data name="tpAdFly.Text" xml:space="preserve">
+    <value>adf.ly</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
-    <value>tpPolr</value>
+  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
+    <value>tpAdFly</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbPolrUseAPIv1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4928,92 +3377,29 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblPolrAPIHostname.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;cbFirebaseIsShort.Name" xml:space="preserve">
-    <value>cbFirebaseIsShort</value>
-  </data>
-  <data name="&gt;&gt;cbFirebaseIsShort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFirebaseIsShort.Parent" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;cbFirebaseIsShort.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseDomain.Name" xml:space="preserve">
-    <value>lblFirebaseDomain</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseDomain.Parent" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseDomain.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseDomain.Name" xml:space="preserve">
-    <value>txtFirebaseDomain</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseDomain.Parent" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseDomain.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseWebAPIKey.Name" xml:space="preserve">
-    <value>txtFirebaseWebAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseWebAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseWebAPIKey.Parent" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;txtFirebaseWebAPIKey.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseWebAPIKey.Name" xml:space="preserve">
-    <value>lblFirebaseWebAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseWebAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseWebAPIKey.Parent" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
-  </data>
-  <data name="&gt;&gt;lblFirebaseWebAPIKey.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpFirebaseDynamicLinks.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpPolr.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpFirebaseDynamicLinks.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpPolr.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+  <data name="tpPolr.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Text" xml:space="preserve">
-    <value>Firebase Dynamic Links</value>
+  <data name="tpPolr.Text" xml:space="preserve">
+    <value>Polr</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
+  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
+    <value>tpPolr</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lblFirebaseDomain.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5144,4214 +3530,83 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblFirebaseWebAPIKey.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
-    <value>gbFTPAccount</value>
+  <data name="tpFirebaseDynamicLinks.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnFTPDuplicate.Name" xml:space="preserve">
-    <value>btnFTPDuplicate</value>
-  </data>
-  <data name="&gt;&gt;btnFTPDuplicate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPDuplicate.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;btnFTPDuplicate.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnFTPRemove.Name" xml:space="preserve">
-    <value>btnFTPRemove</value>
-  </data>
-  <data name="&gt;&gt;btnFTPRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPRemove.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;btnFTPRemove.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnFTPAdd.Name" xml:space="preserve">
-    <value>btnFTPAdd</value>
-  </data>
-  <data name="&gt;&gt;btnFTPAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPAdd.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;btnFTPAdd.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAccounts.Name" xml:space="preserve">
-    <value>cbFTPAccounts</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAccounts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAccounts.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAccounts.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblFTPAccounts.Name" xml:space="preserve">
-    <value>lblFTPAccounts</value>
-  </data>
-  <data name="&gt;&gt;lblFTPAccounts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPAccounts.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;lblFTPAccounts.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblFTPFile.Name" xml:space="preserve">
-    <value>lblFTPFile</value>
-  </data>
-  <data name="&gt;&gt;lblFTPFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPFile.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;lblFTPFile.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblFTPText.Name" xml:space="preserve">
-    <value>lblFTPText</value>
-  </data>
-  <data name="&gt;&gt;lblFTPText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPText.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;lblFTPText.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblFTPImage.Name" xml:space="preserve">
-    <value>lblFTPImage</value>
-  </data>
-  <data name="&gt;&gt;lblFTPImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPImage.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;lblFTPImage.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cbFTPImage.Name" xml:space="preserve">
-    <value>cbFTPImage</value>
-  </data>
-  <data name="&gt;&gt;cbFTPImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPImage.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;cbFTPImage.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cbFTPFile.Name" xml:space="preserve">
-    <value>cbFTPFile</value>
-  </data>
-  <data name="&gt;&gt;cbFTPFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPFile.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;cbFTPFile.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cbFTPText.Name" xml:space="preserve">
-    <value>cbFTPText</value>
-  </data>
-  <data name="&gt;&gt;cbFTPText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPText.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;cbFTPText.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="tpFTP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpFTP.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 519</value>
-  </data>
-  <data name="tpFTP.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tpFTP.Text" xml:space="preserve">
-    <value>FTP / FTPS / SFTP</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Name" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxUseDirectLink.Name" xml:space="preserve">
-    <value>cbDropboxUseDirectLink</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxUseDirectLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxUseDirectLink.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxUseDirectLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Name" xml:space="preserve">
-    <value>cbDropboxAutoCreateShareableLink</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pbDropboxLogo.Name" xml:space="preserve">
-    <value>pbDropboxLogo</value>
-  </data>
-  <data name="&gt;&gt;pbDropboxLogo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pbDropboxLogo.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;pbDropboxLogo.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblDropboxPath.Name" xml:space="preserve">
-    <value>lblDropboxPath</value>
-  </data>
-  <data name="&gt;&gt;lblDropboxPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDropboxPath.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;lblDropboxPath.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtDropboxPath.Name" xml:space="preserve">
-    <value>txtDropboxPath</value>
-  </data>
-  <data name="&gt;&gt;txtDropboxPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtDropboxPath.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;txtDropboxPath.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;oauth2Dropbox.Name" xml:space="preserve">
-    <value>oauth2Dropbox</value>
-  </data>
-  <data name="&gt;&gt;oauth2Dropbox.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Dropbox.Parent" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;oauth2Dropbox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpDropbox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpDropbox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpDropbox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpDropbox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpDropbox.Text" xml:space="preserve">
-    <value>Dropbox</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Name" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tvOneDrive.Name" xml:space="preserve">
-    <value>tvOneDrive</value>
-  </data>
-  <data name="&gt;&gt;tvOneDrive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tvOneDrive.Parent" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;tvOneDrive.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblOneDriveFolderID.Name" xml:space="preserve">
-    <value>lblOneDriveFolderID</value>
-  </data>
-  <data name="&gt;&gt;lblOneDriveFolderID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOneDriveFolderID.Parent" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;lblOneDriveFolderID.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Name" xml:space="preserve">
-    <value>cbOneDriveCreateShareableLink</value>
-  </data>
-  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Parent" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;cbOneDriveCreateShareableLink.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;oAuth2OneDrive.Name" xml:space="preserve">
-    <value>oAuth2OneDrive</value>
-  </data>
-  <data name="&gt;&gt;oAuth2OneDrive.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oAuth2OneDrive.Parent" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;oAuth2OneDrive.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpOneDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpOneDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOneDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpOneDrive.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="tpOneDrive.Text" xml:space="preserve">
-    <value>OneDrive</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Name" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveDirectLink.Name" xml:space="preserve">
-    <value>cbGoogleDriveDirectLink</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveDirectLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveDirectLink.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveDirectLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveUseFolder.Name" xml:space="preserve">
-    <value>cbGoogleDriveUseFolder</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveUseFolder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveUseFolder.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveUseFolder.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleDriveFolderID.Name" xml:space="preserve">
-    <value>txtGoogleDriveFolderID</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleDriveFolderID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleDriveFolderID.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleDriveFolderID.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleDriveFolderID.Name" xml:space="preserve">
-    <value>lblGoogleDriveFolderID</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleDriveFolderID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleDriveFolderID.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleDriveFolderID.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lvGoogleDriveFoldersList.Name" xml:space="preserve">
-    <value>lvGoogleDriveFoldersList</value>
-  </data>
-  <data name="&gt;&gt;lvGoogleDriveFoldersList.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvGoogleDriveFoldersList.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;lvGoogleDriveFoldersList.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Name" xml:space="preserve">
-    <value>btnGoogleDriveRefreshFolders</value>
-  </data>
-  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveIsPublic.Name" xml:space="preserve">
-    <value>cbGoogleDriveIsPublic</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveIsPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveIsPublic.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;cbGoogleDriveIsPublic.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleDrive.Name" xml:space="preserve">
-    <value>oauth2GoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleDrive.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleDrive.Parent" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleDrive.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGoogleDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGoogleDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGoogleDrive.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpGoogleDrive.Text" xml:space="preserve">
-    <value>Google Drive</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Name" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;pbPuush.Name" xml:space="preserve">
-    <value>pbPuush</value>
-  </data>
-  <data name="&gt;&gt;pbPuush.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pbPuush.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;pbPuush.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblPuushAPIKey.Name" xml:space="preserve">
-    <value>lblPuushAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPuushAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPuushAPIKey.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;lblPuushAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPuushAPIKey.Name" xml:space="preserve">
-    <value>txtPuushAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPuushAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPuushAPIKey.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;txtPuushAPIKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;llPuushForgottenPassword.Name" xml:space="preserve">
-    <value>llPuushForgottenPassword</value>
-  </data>
-  <data name="&gt;&gt;llPuushForgottenPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;llPuushForgottenPassword.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;llPuushForgottenPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnPuushLogin.Name" xml:space="preserve">
-    <value>btnPuushLogin</value>
-  </data>
-  <data name="&gt;&gt;btnPuushLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPuushLogin.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;btnPuushLogin.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtPuushPassword.Name" xml:space="preserve">
-    <value>txtPuushPassword</value>
-  </data>
-  <data name="&gt;&gt;txtPuushPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPuushPassword.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;txtPuushPassword.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtPuushEmail.Name" xml:space="preserve">
-    <value>txtPuushEmail</value>
-  </data>
-  <data name="&gt;&gt;txtPuushEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPuushEmail.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;txtPuushEmail.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblPuushEmail.Name" xml:space="preserve">
-    <value>lblPuushEmail</value>
-  </data>
-  <data name="&gt;&gt;lblPuushEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPuushEmail.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;lblPuushEmail.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblPuushPassword.Name" xml:space="preserve">
-    <value>lblPuushPassword</value>
-  </data>
-  <data name="&gt;&gt;lblPuushPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPuushPassword.Parent" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;lblPuushPassword.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpPuush.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPuush.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPuush.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPuush.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="tpPuush.Text" xml:space="preserve">
-    <value>puush</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Name" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderTip.Name" xml:space="preserve">
-    <value>lblBoxFolderTip</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderTip.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderTip.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbBoxShare.Name" xml:space="preserve">
-    <value>cbBoxShare</value>
-  </data>
-  <data name="&gt;&gt;cbBoxShare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbBoxShare.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;cbBoxShare.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lvBoxFolders.Name" xml:space="preserve">
-    <value>lvBoxFolders</value>
-  </data>
-  <data name="&gt;&gt;lvBoxFolders.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvBoxFolders.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;lvBoxFolders.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderID.Name" xml:space="preserve">
-    <value>lblBoxFolderID</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderID.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;lblBoxFolderID.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnBoxRefreshFolders.Name" xml:space="preserve">
-    <value>btnBoxRefreshFolders</value>
-  </data>
-  <data name="&gt;&gt;btnBoxRefreshFolders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnBoxRefreshFolders.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;btnBoxRefreshFolders.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;oauth2Box.Name" xml:space="preserve">
-    <value>oauth2Box</value>
-  </data>
-  <data name="&gt;&gt;oauth2Box.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Box.Parent" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;oauth2Box.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpBox.Text" xml:space="preserve">
-    <value>Box</value>
-  </data>
-  <data name="&gt;&gt;tpBox.Name" xml:space="preserve">
-    <value>tpBox</value>
-  </data>
-  <data name="&gt;&gt;tpBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpBox.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoint.Name" xml:space="preserve">
-    <value>lblAmazonS3Endpoint</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoint.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoint.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoint.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Endpoint.Name" xml:space="preserve">
-    <value>txtAmazonS3Endpoint</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Endpoint.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Endpoint.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Endpoint.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Region.Name" xml:space="preserve">
-    <value>lblAmazonS3Region</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Region.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Region.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Region.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Region.Name" xml:space="preserve">
-    <value>txtAmazonS3Region</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Region.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Region.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3Region.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3CustomDomain.Name" xml:space="preserve">
-    <value>txtAmazonS3CustomDomain</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3CustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3CustomDomain.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3CustomDomain.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Name" xml:space="preserve">
-    <value>lblAmazonS3PathPreviewLabel</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreview.Name" xml:space="preserve">
-    <value>lblAmazonS3PathPreview</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreview.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3PathPreview.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Name" xml:space="preserve">
-    <value>btnAmazonS3BucketNameOpen</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Name" xml:space="preserve">
-    <value>btnAmazonS3AccessKeyOpen</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3Endpoints.Name" xml:space="preserve">
-    <value>cbAmazonS3Endpoints</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3Endpoints.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3Endpoints.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3Endpoints.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3BucketName.Name" xml:space="preserve">
-    <value>lblAmazonS3BucketName</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3BucketName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3BucketName.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3BucketName.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3BucketName.Name" xml:space="preserve">
-    <value>txtAmazonS3BucketName</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3BucketName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3BucketName.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3BucketName.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoints.Name" xml:space="preserve">
-    <value>lblAmazonS3Endpoints</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoints.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoints.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3Endpoints.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Name" xml:space="preserve">
-    <value>txtAmazonS3ObjectPrefix</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Name" xml:space="preserve">
-    <value>lblAmazonS3ObjectPrefix</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3SecretKey.Name" xml:space="preserve">
-    <value>txtAmazonS3SecretKey</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3SecretKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3SecretKey.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3SecretKey.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3SecretKey.Name" xml:space="preserve">
-    <value>lblAmazonS3SecretKey</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3SecretKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3SecretKey.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3SecretKey.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3AccessKey.Name" xml:space="preserve">
-    <value>lblAmazonS3AccessKey</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3AccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3AccessKey.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3AccessKey.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3AccessKey.Name" xml:space="preserve">
-    <value>txtAmazonS3AccessKey</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3AccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3AccessKey.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;txtAmazonS3AccessKey.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="tpAmazonS3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpAmazonS3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAmazonS3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpAmazonS3.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="tpAmazonS3.Text" xml:space="preserve">
-    <value>Amazon S3</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Name" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Name" xml:space="preserve">
-    <value>lblGoogleCloudStoragePathPreview</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Name" xml:space="preserve">
-    <value>lblGoogleCloudStoragePathPreviewLabel</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Name" xml:space="preserve">
-    <value>txtGoogleCloudStorageObjectPrefix</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Name" xml:space="preserve">
-    <value>lblGoogleCloudStorageObjectPrefix</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Name" xml:space="preserve">
-    <value>lblGoogleCloudStorageDomain</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageDomain.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Name" xml:space="preserve">
-    <value>txtGoogleCloudStorageDomain</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageDomain.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Name" xml:space="preserve">
-    <value>lblGoogleCloudStorageBucket</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;lblGoogleCloudStorageBucket.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Name" xml:space="preserve">
-    <value>txtGoogleCloudStorageBucket</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;txtGoogleCloudStorageBucket.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleCloudStorage.Name" xml:space="preserve">
-    <value>oauth2GoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleCloudStorage.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleCloudStorage.Parent" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;oauth2GoogleCloudStorage.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGoogleCloudStorage.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Text" xml:space="preserve">
-    <value>Google Cloud Storage</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Name" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 299</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>230, 17</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="cbAzureStorageExcludeContainer.Text" xml:space="preserve">
-    <value>Exclude container name from returned URL</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Name" xml:space="preserve">
-    <value>cbAzureStorageExcludeContainer</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageExcludeContainer.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 223</value>
-  </data>
-  <data name="txtAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageUploadPath.Name" xml:space="preserve">
-    <value>txtAzureStorageUploadPath</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageUploadPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageUploadPath.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageUploadPath.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblAzureStorageUploadPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 207</value>
-  </data>
-  <data name="lblAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="lblAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="lblAzureStorageUploadPath.Text" xml:space="preserve">
-    <value>Upload Path:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageUploadPath.Name" xml:space="preserve">
-    <value>lblAzureStorageUploadPath</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageUploadPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageUploadPath.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageUploadPath.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
-    <value>blob.core.windows.net</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
-    <value>blob.core.usgovcloudapi.net</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
-    <value>blob.core.chinacloudapi.cn</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
-    <value>blob.core.cloudapi.de</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 173</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 21</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Name" xml:space="preserve">
-    <value>cbAzureStorageEnvironment</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 156</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Text" xml:space="preserve">
-    <value>Environment:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Name" xml:space="preserve">
-    <value>lblAzureStorageEnvironment</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAzureStoragePortal.Location" type="System.Drawing.Point, System.Drawing">
-    <value>552, 30</value>
-  </data>
-  <data name="btnAzureStoragePortal.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 24</value>
-  </data>
-  <data name="btnAzureStoragePortal.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="btnAzureStoragePortal.Text" xml:space="preserve">
-    <value>...</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Name" xml:space="preserve">
-    <value>btnAzureStoragePortal</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="txtAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 128</value>
-  </data>
-  <data name="txtAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Name" xml:space="preserve">
-    <value>txtAzureStorageContainer</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lblAzureStorageContainer.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 112</value>
-  </data>
-  <data name="lblAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
-  </data>
-  <data name="lblAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="lblAzureStorageContainer.Text" xml:space="preserve">
-    <value>Container:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Name" xml:space="preserve">
-    <value>lblAzureStorageContainer</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 80</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Name" xml:space="preserve">
-    <value>txtAzureStorageAccessKey</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 64</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Text" xml:space="preserve">
-    <value>Access key:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Name" xml:space="preserve">
-    <value>lblAzureStorageAccessKey</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="txtAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Name" xml:space="preserve">
-    <value>txtAzureStorageAccountName</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="lblAzureStorageAccountName.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageAccountName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 13</value>
-  </data>
-  <data name="lblAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Text" xml:space="preserve">
-    <value>Account name:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Name" xml:space="preserve">
-    <value>lblAzureStorageAccountName</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 273</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Name" xml:space="preserve">
-    <value>txtAzureStorageCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 257</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
-    <value>Custom Domain:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Name" xml:space="preserve">
-    <value>lblAzureStorageCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAzureStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 519</value>
-  </data>
-  <data name="tpAzureStorage.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
-  </data>
-  <data name="tpAzureStorage.Text" xml:space="preserve">
-    <value>Azure Storage</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Name" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cbGfycatIsPublic.Name" xml:space="preserve">
-    <value>cbGfycatIsPublic</value>
-  </data>
-  <data name="&gt;&gt;cbGfycatIsPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGfycatIsPublic.Parent" xml:space="preserve">
-    <value>tpGfycat</value>
-  </data>
-  <data name="&gt;&gt;cbGfycatIsPublic.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;atcGfycatAccountType.Name" xml:space="preserve">
-    <value>atcGfycatAccountType</value>
-  </data>
-  <data name="&gt;&gt;atcGfycatAccountType.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;atcGfycatAccountType.Parent" xml:space="preserve">
-    <value>tpGfycat</value>
-  </data>
-  <data name="&gt;&gt;atcGfycatAccountType.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;oauth2Gfycat.Name" xml:space="preserve">
-    <value>oauth2Gfycat</value>
-  </data>
-  <data name="&gt;&gt;oauth2Gfycat.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Gfycat.Parent" xml:space="preserve">
-    <value>tpGfycat</value>
-  </data>
-  <data name="&gt;&gt;oauth2Gfycat.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpGfycat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGfycat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGfycat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGfycat.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
-  </data>
-  <data name="tpGfycat.Text" xml:space="preserve">
-    <value>Gfycat</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
-    <value>tpGfycat</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRefreshFolders.Name" xml:space="preserve">
-    <value>btnMegaRefreshFolders</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRefreshFolders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRefreshFolders.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRefreshFolders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatus.Name" xml:space="preserve">
-    <value>lblMegaStatus</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatus.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatus.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRegister.Name" xml:space="preserve">
-    <value>btnMegaRegister</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRegister.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRegister.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;btnMegaRegister.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblMegaFolder.Name" xml:space="preserve">
-    <value>lblMegaFolder</value>
-  </data>
-  <data name="&gt;&gt;lblMegaFolder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMegaFolder.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;lblMegaFolder.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatusTitle.Name" xml:space="preserve">
-    <value>lblMegaStatusTitle</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatusTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatusTitle.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;lblMegaStatusTitle.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbMegaFolder.Name" xml:space="preserve">
-    <value>cbMegaFolder</value>
-  </data>
-  <data name="&gt;&gt;cbMegaFolder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbMegaFolder.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;cbMegaFolder.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblMegaEmail.Name" xml:space="preserve">
-    <value>lblMegaEmail</value>
-  </data>
-  <data name="&gt;&gt;lblMegaEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMegaEmail.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;lblMegaEmail.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;btnMegaLogin.Name" xml:space="preserve">
-    <value>btnMegaLogin</value>
-  </data>
-  <data name="&gt;&gt;btnMegaLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnMegaLogin.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;btnMegaLogin.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;txtMegaEmail.Name" xml:space="preserve">
-    <value>txtMegaEmail</value>
-  </data>
-  <data name="&gt;&gt;txtMegaEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMegaEmail.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;txtMegaEmail.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtMegaPassword.Name" xml:space="preserve">
-    <value>txtMegaPassword</value>
-  </data>
-  <data name="&gt;&gt;txtMegaPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMegaPassword.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;txtMegaPassword.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblMegaPassword.Name" xml:space="preserve">
-    <value>lblMegaPassword</value>
-  </data>
-  <data name="&gt;&gt;lblMegaPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMegaPassword.Parent" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;lblMegaPassword.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="tpMega.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpMega.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpMega.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="tpMega.Text" xml:space="preserve">
-    <value>Mega</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Name" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Name" xml:space="preserve">
-    <value>cbOwnCloudUsePreviewLinks</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHostExample.Name" xml:space="preserve">
-    <value>lblOwnCloudHostExample</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHostExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHostExample.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHostExample.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloud81Compatibility.Name" xml:space="preserve">
-    <value>cbOwnCloud81Compatibility</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloud81Compatibility.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloud81Compatibility.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloud81Compatibility.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudDirectLink.Name" xml:space="preserve">
-    <value>cbOwnCloudDirectLink</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudDirectLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudDirectLink.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudDirectLink.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudCreateShare.Name" xml:space="preserve">
-    <value>cbOwnCloudCreateShare</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudCreateShare.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudCreateShare.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;cbOwnCloudCreateShare.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPath.Name" xml:space="preserve">
-    <value>txtOwnCloudPath</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPath.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPath.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPassword.Name" xml:space="preserve">
-    <value>txtOwnCloudPassword</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPassword.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudPassword.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudUsername.Name" xml:space="preserve">
-    <value>txtOwnCloudUsername</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudUsername.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudUsername.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudHost.Name" xml:space="preserve">
-    <value>txtOwnCloudHost</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudHost.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;txtOwnCloudHost.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPath.Name" xml:space="preserve">
-    <value>lblOwnCloudPath</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPath.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPath.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPassword.Name" xml:space="preserve">
-    <value>lblOwnCloudPassword</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPassword.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudPassword.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudUsername.Name" xml:space="preserve">
-    <value>lblOwnCloudUsername</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudUsername.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudUsername.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHost.Name" xml:space="preserve">
-    <value>lblOwnCloudHost</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHost.Parent" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;lblOwnCloudHost.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOwnCloud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpOwnCloud.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="tpOwnCloud.Text" xml:space="preserve">
-    <value>ownCloud / Nextcloud</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;cbMediaFireUseLongLink.Name" xml:space="preserve">
-    <value>cbMediaFireUseLongLink</value>
-  </data>
-  <data name="&gt;&gt;cbMediaFireUseLongLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbMediaFireUseLongLink.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;cbMediaFireUseLongLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePath.Name" xml:space="preserve">
-    <value>txtMediaFirePath</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePath.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePath.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePath.Name" xml:space="preserve">
-    <value>lblMediaFirePath</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePath.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePath.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePassword.Name" xml:space="preserve">
-    <value>txtMediaFirePassword</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePassword.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFirePassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFireEmail.Name" xml:space="preserve">
-    <value>txtMediaFireEmail</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFireEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFireEmail.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;txtMediaFireEmail.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePassword.Name" xml:space="preserve">
-    <value>lblMediaFirePassword</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePassword.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFirePassword.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFireEmail.Name" xml:space="preserve">
-    <value>lblMediaFireEmail</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFireEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFireEmail.Parent" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;lblMediaFireEmail.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpMediaFire.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpMediaFire.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpMediaFire.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 519</value>
-  </data>
-  <data name="tpMediaFire.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="tpMediaFire.Text" xml:space="preserve">
-    <value>MediaFire</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Name" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletDevices.Name" xml:space="preserve">
-    <value>lblPushbulletDevices</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletDevices.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletDevices.Parent" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletDevices.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cboPushbulletDevices.Name" xml:space="preserve">
-    <value>cboPushbulletDevices</value>
-  </data>
-  <data name="&gt;&gt;cboPushbulletDevices.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboPushbulletDevices.Parent" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;cboPushbulletDevices.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnPushbulletGetDeviceList.Name" xml:space="preserve">
-    <value>btnPushbulletGetDeviceList</value>
-  </data>
-  <data name="&gt;&gt;btnPushbulletGetDeviceList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPushbulletGetDeviceList.Parent" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;btnPushbulletGetDeviceList.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletUserKey.Name" xml:space="preserve">
-    <value>lblPushbulletUserKey</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletUserKey.Parent" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;lblPushbulletUserKey.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtPushbulletUserKey.Name" xml:space="preserve">
-    <value>txtPushbulletUserKey</value>
-  </data>
-  <data name="&gt;&gt;txtPushbulletUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPushbulletUserKey.Parent" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;txtPushbulletUserKey.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpPushbullet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPushbullet.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPushbullet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPushbullet.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="tpPushbullet.Text" xml:space="preserve">
-    <value>Pushbullet</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Name" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;btnSendSpaceRegister.Name" xml:space="preserve">
-    <value>btnSendSpaceRegister</value>
-  </data>
-  <data name="&gt;&gt;btnSendSpaceRegister.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSendSpaceRegister.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;btnSendSpaceRegister.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpacePassword.Name" xml:space="preserve">
-    <value>lblSendSpacePassword</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpacePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpacePassword.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpacePassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpaceUsername.Name" xml:space="preserve">
-    <value>lblSendSpaceUsername</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpaceUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpaceUsername.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;lblSendSpaceUsername.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpacePassword.Name" xml:space="preserve">
-    <value>txtSendSpacePassword</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpacePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpacePassword.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpacePassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpaceUserName.Name" xml:space="preserve">
-    <value>txtSendSpaceUserName</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpaceUserName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpaceUserName.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;txtSendSpaceUserName.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;atcSendSpaceAccountType.Name" xml:space="preserve">
-    <value>atcSendSpaceAccountType</value>
-  </data>
-  <data name="&gt;&gt;atcSendSpaceAccountType.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;atcSendSpaceAccountType.Parent" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;atcSendSpaceAccountType.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpSendSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSendSpace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSendSpace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSendSpace.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="tpSendSpace.Text" xml:space="preserve">
-    <value>SendSpace</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Name" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttStatus.Name" xml:space="preserve">
-    <value>lblGe_ttStatus</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttStatus.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttStatus.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttPassword.Name" xml:space="preserve">
-    <value>lblGe_ttPassword</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttPassword.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttPassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttEmail.Name" xml:space="preserve">
-    <value>lblGe_ttEmail</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttEmail.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;lblGe_ttEmail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnGe_ttLogin.Name" xml:space="preserve">
-    <value>btnGe_ttLogin</value>
-  </data>
-  <data name="&gt;&gt;btnGe_ttLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnGe_ttLogin.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;btnGe_ttLogin.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttPassword.Name" xml:space="preserve">
-    <value>txtGe_ttPassword</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttPassword.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttPassword.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttEmail.Name" xml:space="preserve">
-    <value>txtGe_ttEmail</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttEmail.Parent" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;txtGe_ttEmail.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpGe_tt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGe_tt.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGe_tt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGe_tt.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tpGe_tt.Text" xml:space="preserve">
-    <value>Ge.tt</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Name" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cbLocalhostrDirectURL.Name" xml:space="preserve">
-    <value>cbLocalhostrDirectURL</value>
-  </data>
-  <data name="&gt;&gt;cbLocalhostrDirectURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbLocalhostrDirectURL.Parent" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;cbLocalhostrDirectURL.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrPassword.Name" xml:space="preserve">
-    <value>lblLocalhostrPassword</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrPassword.Parent" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrPassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrEmail.Name" xml:space="preserve">
-    <value>lblLocalhostrEmail</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrEmail.Parent" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;lblLocalhostrEmail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrPassword.Name" xml:space="preserve">
-    <value>txtLocalhostrPassword</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrPassword.Parent" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrEmail.Name" xml:space="preserve">
-    <value>txtLocalhostrEmail</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrEmail.Parent" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;txtLocalhostrEmail.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpHostr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpHostr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpHostr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpHostr.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="tpHostr.Text" xml:space="preserve">
-    <value>Hostr</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Name" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;txtJiraIssuePrefix.Name" xml:space="preserve">
-    <value>txtJiraIssuePrefix</value>
-  </data>
-  <data name="&gt;&gt;txtJiraIssuePrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtJiraIssuePrefix.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;txtJiraIssuePrefix.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblJiraIssuePrefix.Name" xml:space="preserve">
-    <value>lblJiraIssuePrefix</value>
-  </data>
-  <data name="&gt;&gt;lblJiraIssuePrefix.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblJiraIssuePrefix.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;lblJiraIssuePrefix.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;oAuthJira.Name" xml:space="preserve">
-    <value>oAuthJira</value>
-  </data>
-  <data name="&gt;&gt;oAuthJira.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oAuthJira.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;oAuthJira.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpJira.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpJira.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpJira.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="tpJira.Text" xml:space="preserve">
-    <value>Atlassian Jira</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Name" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpJira.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaInfo.Name" xml:space="preserve">
-    <value>lblLambdaInfo</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaInfo.Parent" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaInfo.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaApiKey.Name" xml:space="preserve">
-    <value>lblLambdaApiKey</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaApiKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaApiKey.Parent" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaApiKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtLambdaApiKey.Name" xml:space="preserve">
-    <value>txtLambdaApiKey</value>
-  </data>
-  <data name="&gt;&gt;txtLambdaApiKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLambdaApiKey.Parent" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;txtLambdaApiKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaUploadURL.Name" xml:space="preserve">
-    <value>lblLambdaUploadURL</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaUploadURL.Parent" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;lblLambdaUploadURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbLambdaUploadURL.Name" xml:space="preserve">
-    <value>cbLambdaUploadURL</value>
-  </data>
-  <data name="&gt;&gt;cbLambdaUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbLambdaUploadURL.Parent" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;cbLambdaUploadURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpLambda.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpLambda.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpLambda.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpLambda.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="tpLambda.Text" xml:space="preserve">
-    <value>Lambda</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Name" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;btnPomfTest.Name" xml:space="preserve">
-    <value>btnPomfTest</value>
-  </data>
-  <data name="&gt;&gt;btnPomfTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPomfTest.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;btnPomfTest.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtPomfResultURL.Name" xml:space="preserve">
-    <value>txtPomfResultURL</value>
-  </data>
-  <data name="&gt;&gt;txtPomfResultURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPomfResultURL.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;txtPomfResultURL.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPomfUploadURL.Name" xml:space="preserve">
-    <value>txtPomfUploadURL</value>
-  </data>
-  <data name="&gt;&gt;txtPomfUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPomfUploadURL.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;txtPomfUploadURL.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblPomfResultURL.Name" xml:space="preserve">
-    <value>lblPomfResultURL</value>
-  </data>
-  <data name="&gt;&gt;lblPomfResultURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPomfResultURL.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;lblPomfResultURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploadURL.Name" xml:space="preserve">
-    <value>lblPomfUploadURL</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploadURL.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploadURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploaders.Name" xml:space="preserve">
-    <value>lblPomfUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploaders.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;lblPomfUploaders.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cbPomfUploaders.Name" xml:space="preserve">
-    <value>cbPomfUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbPomfUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPomfUploaders.Parent" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;cbPomfUploaders.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpPomf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPomf.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPomf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPomf.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="tpPomf.Text" xml:space="preserve">
-    <value>Pomf</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Name" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileAPIURL.Name" xml:space="preserve">
-    <value>cbSeafileAPIURL</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileAPIURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileAPIURL.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileAPIURL.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Name" xml:space="preserve">
-    <value>btnSeafileLibraryPasswordValidate</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileLibraryPassword.Name" xml:space="preserve">
-    <value>txtSeafileLibraryPassword</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileLibraryPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileLibraryPassword.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileLibraryPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileLibraryPassword.Name" xml:space="preserve">
-    <value>lblSeafileLibraryPassword</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileLibraryPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileLibraryPassword.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileLibraryPassword.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvSeafileLibraries.Name" xml:space="preserve">
-    <value>lvSeafileLibraries</value>
-  </data>
-  <data name="&gt;&gt;lvSeafileLibraries.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvSeafileLibraries.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lvSeafileLibraries.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnSeafilePathValidate.Name" xml:space="preserve">
-    <value>btnSeafilePathValidate</value>
-  </data>
-  <data name="&gt;&gt;btnSeafilePathValidate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSeafilePathValidate.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;btnSeafilePathValidate.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileDirectoryPath.Name" xml:space="preserve">
-    <value>txtSeafileDirectoryPath</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileDirectoryPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileDirectoryPath.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileDirectoryPath.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileWritePermNotif.Name" xml:space="preserve">
-    <value>lblSeafileWritePermNotif</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileWritePermNotif.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileWritePermNotif.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileWritePermNotif.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePath.Name" xml:space="preserve">
-    <value>lblSeafilePath</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePath.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePath.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Name" xml:space="preserve">
-    <value>txtSeafileUploadLocationRefresh</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSelectLibrary.Name" xml:space="preserve">
-    <value>lblSeafileSelectLibrary</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSelectLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSelectLibrary.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSelectLibrary.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAuthToken.Name" xml:space="preserve">
-    <value>btnSeafileCheckAuthToken</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAuthToken.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAPIURL.Name" xml:space="preserve">
-    <value>btnSeafileCheckAPIURL</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAPIURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAPIURL.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileCheckAPIURL.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Name" xml:space="preserve">
-    <value>cbSeafileIgnoreInvalidCert</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURL.Name" xml:space="preserve">
-    <value>cbSeafileCreateShareableURL</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURL.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAuthToken.Name" xml:space="preserve">
-    <value>txtSeafileAuthToken</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAuthToken.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAuthToken.Name" xml:space="preserve">
-    <value>lblSeafileAuthToken</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAuthToken.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAPIURL.Name" xml:space="preserve">
-    <value>lblSeafileAPIURL</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAPIURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAPIURL.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAPIURL.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="tpSeafile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSeafile.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSeafile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSeafile.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="tpSeafile.Text" xml:space="preserve">
-    <value>Seafile</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Name" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableUseDirectURL.Name" xml:space="preserve">
-    <value>cbStreamableUseDirectURL</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableUseDirectURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableUseDirectURL.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableUseDirectURL.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtStreamablePassword.Name" xml:space="preserve">
-    <value>txtStreamablePassword</value>
-  </data>
-  <data name="&gt;&gt;txtStreamablePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtStreamablePassword.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;txtStreamablePassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtStreamableUsername.Name" xml:space="preserve">
-    <value>txtStreamableUsername</value>
-  </data>
-  <data name="&gt;&gt;txtStreamableUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtStreamableUsername.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;txtStreamableUsername.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblStreamableUsername.Name" xml:space="preserve">
-    <value>lblStreamableUsername</value>
-  </data>
-  <data name="&gt;&gt;lblStreamableUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblStreamableUsername.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;lblStreamableUsername.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblStreamablePassword.Name" xml:space="preserve">
-    <value>lblStreamablePassword</value>
-  </data>
-  <data name="&gt;&gt;lblStreamablePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblStreamablePassword.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;lblStreamablePassword.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableAnonymous.Name" xml:space="preserve">
-    <value>cbStreamableAnonymous</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableAnonymous.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableAnonymous.Parent" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;cbStreamableAnonymous.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpStreamable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpStreamable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpStreamable.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="tpStreamable.Text" xml:space="preserve">
-    <value>Streamable</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Name" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;btnSulGetAPIKey.Name" xml:space="preserve">
-    <value>btnSulGetAPIKey</value>
-  </data>
-  <data name="&gt;&gt;btnSulGetAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSulGetAPIKey.Parent" xml:space="preserve">
-    <value>tpSul</value>
-  </data>
-  <data name="&gt;&gt;btnSulGetAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtSulAPIKey.Name" xml:space="preserve">
-    <value>txtSulAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtSulAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSulAPIKey.Parent" xml:space="preserve">
-    <value>tpSul</value>
-  </data>
-  <data name="&gt;&gt;txtSulAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblSulAPIKey.Name" xml:space="preserve">
-    <value>lblSulAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblSulAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSulAPIKey.Parent" xml:space="preserve">
-    <value>tpSul</value>
-  </data>
-  <data name="&gt;&gt;lblSulAPIKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpSul.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSul.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSul.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSul.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
-  </data>
-  <data name="tpSul.Text" xml:space="preserve">
-    <value>s-ul</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Name" xml:space="preserve">
-    <value>tpSul</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSul.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioFetchAPIKey.Name" xml:space="preserve">
-    <value>btnLithiioFetchAPIKey</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioFetchAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioFetchAPIKey.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioFetchAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioPassword.Name" xml:space="preserve">
-    <value>txtLithiioPassword</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioPassword.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioPassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioEmail.Name" xml:space="preserve">
-    <value>txtLithiioEmail</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioEmail.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioEmail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioPassword.Name" xml:space="preserve">
-    <value>lblLithiioPassword</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioPassword.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioEmail.Name" xml:space="preserve">
-    <value>lblLithiioEmail</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioEmail.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioEmail.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioGetAPIKey.Name" xml:space="preserve">
-    <value>btnLithiioGetAPIKey</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioGetAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioGetAPIKey.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;btnLithiioGetAPIKey.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioApiKey.Name" xml:space="preserve">
-    <value>lblLithiioApiKey</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioApiKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioApiKey.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;lblLithiioApiKey.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioApiKey.Name" xml:space="preserve">
-    <value>txtLithiioApiKey</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioApiKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioApiKey.Parent" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;txtLithiioApiKey.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpLithiio.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpLithiio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpLithiio.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpLithiio.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="tpLithiio.Text" xml:space="preserve">
-    <value>Lithiio</value>
-  </data>
-  <data name="&gt;&gt;tpLithiio.Name" xml:space="preserve">
-    <value>tpLithiio</value>
-  </data>
-  <data name="&gt;&gt;tpLithiio.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpLithiio.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpLithiio.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
-    <value>gbPlikSettings</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpPlik.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPlik.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpFirebaseDynamicLinks.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tpFirebaseDynamicLinks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+    <value>178, 42</value>
   </data>
-  <data name="tpPlik.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPlik.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="tpPlik.Text" xml:space="preserve">
-    <value>Plik</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Name" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Name" xml:space="preserve">
-    <value>cbYouTubeUseShortenedLink</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Parent" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubeUseShortenedLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubePrivacyType.Name" xml:space="preserve">
-    <value>cbYouTubePrivacyType</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubePrivacyType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubePrivacyType.Parent" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;cbYouTubePrivacyType.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblYouTubePrivacyType.Name" xml:space="preserve">
-    <value>lblYouTubePrivacyType</value>
-  </data>
-  <data name="&gt;&gt;lblYouTubePrivacyType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblYouTubePrivacyType.Parent" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;lblYouTubePrivacyType.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;oauth2YouTube.Name" xml:space="preserve">
-    <value>oauth2YouTube</value>
-  </data>
-  <data name="&gt;&gt;oauth2YouTube.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2YouTube.Parent" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;oauth2YouTube.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpYouTube.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpYouTube.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpYouTube.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
-  </data>
-  <data name="tpYouTube.Text" xml:space="preserve">
-    <value>YouTube</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Name" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;lbSharedFolderAccounts.Name" xml:space="preserve">
-    <value>lbSharedFolderAccounts</value>
-  </data>
-  <data name="&gt;&gt;lbSharedFolderAccounts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbSharedFolderAccounts.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;lbSharedFolderAccounts.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pgSharedFolderAccount.Name" xml:space="preserve">
-    <value>pgSharedFolderAccount</value>
-  </data>
-  <data name="&gt;&gt;pgSharedFolderAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PropertyGrid, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pgSharedFolderAccount.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;pgSharedFolderAccount.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderDuplicate.Name" xml:space="preserve">
-    <value>btnSharedFolderDuplicate</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderDuplicate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderDuplicate.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderDuplicate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderRemove.Name" xml:space="preserve">
-    <value>btnSharedFolderRemove</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderRemove.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderRemove.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderAdd.Name" xml:space="preserve">
-    <value>btnSharedFolderAdd</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderAdd.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;btnSharedFolderAdd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderFiles.Name" xml:space="preserve">
-    <value>lblSharedFolderFiles</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderFiles.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderFiles.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderFiles.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderText.Name" xml:space="preserve">
-    <value>lblSharedFolderText</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderText.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderText.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderFiles.Name" xml:space="preserve">
-    <value>cboSharedFolderFiles</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderFiles.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderFiles.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderFiles.ZOrder" xml:space="preserve">
+  <data name="tpFirebaseDynamicLinks.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;lblSharedFolderImages.Name" xml:space="preserve">
-    <value>lblSharedFolderImages</value>
+  <data name="tpFirebaseDynamicLinks.Text" xml:space="preserve">
+    <value>Firebase Dynamic Links</value>
   </data>
-  <data name="&gt;&gt;lblSharedFolderImages.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
   </data>
-  <data name="&gt;&gt;lblSharedFolderImages.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;lblSharedFolderImages.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderText.Name" xml:space="preserve">
-    <value>cboSharedFolderText</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderText.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderText.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderImages.Name" xml:space="preserve">
-    <value>cboSharedFolderImages</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderImages.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderImages.Parent" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;cboSharedFolderImages.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="tpSharedFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSharedFolder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSharedFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSharedFolder.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="tpSharedFolder.Text" xml:space="preserve">
-    <value>Shared folder</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.Name" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpSharedFolder.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpSharedFolder.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;txtEmailAutomaticSendTo.Name" xml:space="preserve">
-    <value>txtEmailAutomaticSendTo</value>
-  </data>
-  <data name="&gt;&gt;txtEmailAutomaticSendTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailAutomaticSendTo.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailAutomaticSendTo.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbEmailAutomaticSend.Name" xml:space="preserve">
-    <value>cbEmailAutomaticSend</value>
-  </data>
-  <data name="&gt;&gt;cbEmailAutomaticSend.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbEmailAutomaticSend.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;cbEmailAutomaticSend.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpServer.Name" xml:space="preserve">
-    <value>lblEmailSmtpServer</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpServer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpServer.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpServer.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblEmailPassword.Name" xml:space="preserve">
-    <value>lblEmailPassword</value>
-  </data>
-  <data name="&gt;&gt;lblEmailPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailPassword.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbEmailRememberLastTo.Name" xml:space="preserve">
-    <value>cbEmailRememberLastTo</value>
-  </data>
-  <data name="&gt;&gt;cbEmailRememberLastTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbEmailRememberLastTo.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;cbEmailRememberLastTo.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;txtEmailFrom.Name" xml:space="preserve">
-    <value>txtEmailFrom</value>
-  </data>
-  <data name="&gt;&gt;txtEmailFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailFrom.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailFrom.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtEmailPassword.Name" xml:space="preserve">
-    <value>txtEmailPassword</value>
-  </data>
-  <data name="&gt;&gt;txtEmailPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailPassword.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailPassword.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultBody.Name" xml:space="preserve">
-    <value>txtEmailDefaultBody</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultBody.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultBody.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultBody.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblEmailFrom.Name" xml:space="preserve">
-    <value>lblEmailFrom</value>
-  </data>
-  <data name="&gt;&gt;lblEmailFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailFrom.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailFrom.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtEmailSmtpServer.Name" xml:space="preserve">
-    <value>txtEmailSmtpServer</value>
-  </data>
-  <data name="&gt;&gt;txtEmailSmtpServer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailSmtpServer.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailSmtpServer.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultSubject.Name" xml:space="preserve">
-    <value>lblEmailDefaultSubject</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultSubject.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultSubject.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultSubject.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultBody.Name" xml:space="preserve">
-    <value>lblEmailDefaultBody</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultBody.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultBody.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailDefaultBody.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;nudEmailSmtpPort.Name" xml:space="preserve">
-    <value>nudEmailSmtpPort</value>
-  </data>
-  <data name="&gt;&gt;nudEmailSmtpPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudEmailSmtpPort.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;nudEmailSmtpPort.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpPort.Name" xml:space="preserve">
-    <value>lblEmailSmtpPort</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpPort.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;lblEmailSmtpPort.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultSubject.Name" xml:space="preserve">
-    <value>txtEmailDefaultSubject</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultSubject.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultSubject.Parent" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;txtEmailDefaultSubject.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="tpEmail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpEmail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpEmail.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="tpEmail.Text" xml:space="preserve">
-    <value>Email</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Name" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="tcFileUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tcURLShorteners.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tcFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tcURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="tcFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tcURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
     <value>980, 563</value>
   </data>
-  <data name="tcFileUploaders.TabIndex" type="System.Int32, mscorlib">
+  <data name="tcURLShorteners.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcFileUploaders.Name" xml:space="preserve">
-    <value>tcFileUploaders</value>
+  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
+    <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tcFileUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcFileUploaders.Parent" xml:space="preserve">
-    <value>tpFileUploaders</value>
+  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
+    <value>tpURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tcFileUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpFileUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpURLShorteners.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
     <value>986, 569</value>
   </data>
-  <data name="tpFileUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpURLShorteners.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpFileUploaders.Text" xml:space="preserve">
-    <value>File uploaders</value>
+  <data name="tpURLShorteners.Text" xml:space="preserve">
+    <value>URL shorteners</value>
   </data>
-  <data name="&gt;&gt;tpFileUploaders.Name" xml:space="preserve">
-    <value>tpFileUploaders</value>
+  <data name="&gt;&gt;tpURLShorteners.Name" xml:space="preserve">
+    <value>tpURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpFileUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFileUploaders.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.Parent" xml:space="preserve">
     <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpFileUploaders.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Name" xml:space="preserve">
-    <value>cbFTPAppendRemoteDirectory</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnFTPTest.Name" xml:space="preserve">
-    <value>btnFTPTest</value>
-  </data>
-  <data name="&gt;&gt;btnFTPTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPTest.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;btnFTPTest.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblFTPProtocol.Name" xml:space="preserve">
-    <value>lblFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;lblFTPProtocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPProtocol.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPProtocol.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblFTPName.Name" xml:space="preserve">
-    <value>lblFTPName</value>
-  </data>
-  <data name="&gt;&gt;lblFTPName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPName.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPName.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbFTPRemoveFileExtension.Name" xml:space="preserve">
-    <value>cbFTPRemoveFileExtension</value>
-  </data>
-  <data name="&gt;&gt;cbFTPRemoveFileExtension.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPRemoveFileExtension.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;cbFTPRemoveFileExtension.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtFTPName.Name" xml:space="preserve">
-    <value>txtFTPName</value>
-  </data>
-  <data name="&gt;&gt;txtFTPName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPName.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPName.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblFTPHost.Name" xml:space="preserve">
-    <value>lblFTPHost</value>
-  </data>
-  <data name="&gt;&gt;lblFTPHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPHost.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPHost.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;eiFTP.Name" xml:space="preserve">
-    <value>eiFTP</value>
-  </data>
-  <data name="&gt;&gt;eiFTP.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;eiFTP.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;eiFTP.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
-    <value>pFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;btnFTPClient.Name" xml:space="preserve">
-    <value>btnFTPClient</value>
-  </data>
-  <data name="&gt;&gt;btnFTPClient.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPClient.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;btnFTPClient.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;txtFTPHost.Name" xml:space="preserve">
-    <value>txtFTPHost</value>
-  </data>
-  <data name="&gt;&gt;txtFTPHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPHost.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPHost.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPort.Name" xml:space="preserve">
-    <value>lblFTPPort</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPort.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPort.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;lblFTPTransferMode.Name" xml:space="preserve">
-    <value>lblFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;lblFTPTransferMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPTransferMode.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPTransferMode.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;nudFTPPort.Name" xml:space="preserve">
-    <value>nudFTPPort</value>
-  </data>
-  <data name="&gt;&gt;nudFTPPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudFTPPort.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;nudFTPPort.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreviewValue.Name" xml:space="preserve">
-    <value>lblFTPURLPreviewValue</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreviewValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreviewValue.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreviewValue.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;lblFTPUsername.Name" xml:space="preserve">
-    <value>lblFTPUsername</value>
-  </data>
-  <data name="&gt;&gt;lblFTPUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPUsername.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPUsername.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreview.Name" xml:space="preserve">
-    <value>lblFTPURLPreview</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreview.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPreview.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;txtFTPUsername.Name" xml:space="preserve">
-    <value>txtFTPUsername</value>
-  </data>
-  <data name="&gt;&gt;txtFTPUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPUsername.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPUsername.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;cbFTPURLPathProtocol.Name" xml:space="preserve">
-    <value>cbFTPURLPathProtocol</value>
-  </data>
-  <data name="&gt;&gt;cbFTPURLPathProtocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPURLPathProtocol.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;cbFTPURLPathProtocol.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPassword.Name" xml:space="preserve">
-    <value>lblFTPPassword</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPassword.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPPassword.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;txtFTPURLPath.Name" xml:space="preserve">
-    <value>txtFTPURLPath</value>
-  </data>
-  <data name="&gt;&gt;txtFTPURLPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPURLPath.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPURLPath.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;txtFTPPassword.Name" xml:space="preserve">
-    <value>txtFTPPassword</value>
-  </data>
-  <data name="&gt;&gt;txtFTPPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPPassword.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPPassword.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPath.Name" xml:space="preserve">
-    <value>lblFTPURLPath</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPath.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPURLPath.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="&gt;&gt;lblFTPRemoteDirectory.Name" xml:space="preserve">
-    <value>lblFTPRemoteDirectory</value>
-  </data>
-  <data name="&gt;&gt;lblFTPRemoteDirectory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPRemoteDirectory.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;lblFTPRemoteDirectory.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;txtFTPRemoteDirectory.Name" xml:space="preserve">
-    <value>txtFTPRemoteDirectory</value>
-  </data>
-  <data name="&gt;&gt;txtFTPRemoteDirectory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPRemoteDirectory.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;txtFTPRemoteDirectory.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="gbFTPAccount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 72</value>
-  </data>
-  <data name="gbFTPAccount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>776, 416</value>
-  </data>
-  <data name="gbFTPAccount.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="gbFTPAccount.Text" xml:space="preserve">
-    <value>Account</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyPassphrase.Name" xml:space="preserve">
-    <value>txtSFTPKeyPassphrase</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyPassphrase.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyPassphrase.Parent" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyPassphrase.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Name" xml:space="preserve">
-    <value>btnSFTPKeyLocationBrowse</value>
-  </data>
-  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Parent" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyPassphrase.Name" xml:space="preserve">
-    <value>lblSFTPKeyPassphrase</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyPassphrase.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyPassphrase.Parent" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyPassphrase.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyLocation.Name" xml:space="preserve">
-    <value>txtSFTPKeyLocation</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyLocation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyLocation.Parent" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;txtSFTPKeyLocation.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyLocation.Name" xml:space="preserve">
-    <value>lblSFTPKeyLocation</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyLocation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyLocation.Parent" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;lblSFTPKeyLocation.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="gbSFTP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 288</value>
-  </data>
-  <data name="gbSFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>744, 76</value>
-  </data>
-  <data name="gbSFTP.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="gbSFTP.Text" xml:space="preserve">
-    <value>SFTP</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="txtSFTPKeyPassphrase.Location" type="System.Drawing.Point, System.Drawing">
     <value>184, 44</value>
@@ -9481,6 +3736,30 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblSFTPKeyLocation.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="gbSFTP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 288</value>
+  </data>
+  <data name="gbSFTP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>744, 76</value>
+  </data>
+  <data name="gbSFTP.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="gbSFTP.Text" xml:space="preserve">
+    <value>SFTP</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbFTPAppendRemoteDirectory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -9704,51 +3983,6 @@ store.book[0].title</value>
   <data name="pFTPTransferMode.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
-  <data name="&gt;&gt;rbFTPTransferModeActive.Name" xml:space="preserve">
-    <value>rbFTPTransferModeActive</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModeActive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModeActive.Parent" xml:space="preserve">
-    <value>pFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModeActive.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModePassive.Name" xml:space="preserve">
-    <value>rbFTPTransferModePassive</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModePassive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModePassive.Parent" xml:space="preserve">
-    <value>pFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;rbFTPTransferModePassive.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pFTPTransferMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 141</value>
-  </data>
-  <data name="pFTPTransferMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 20</value>
-  </data>
-  <data name="pFTPTransferMode.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
-    <value>pFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="rbFTPTransferModeActive.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -9809,6 +4043,27 @@ store.book[0].title</value>
   <data name="&gt;&gt;rbFTPTransferModePassive.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="pFTPTransferMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 141</value>
+  </data>
+  <data name="pFTPTransferMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>336, 20</value>
+  </data>
+  <data name="pFTPTransferMode.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
+    <value>pFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
   <data name="btnFTPClient.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -9859,63 +4114,6 @@ store.book[0].title</value>
   </data>
   <data name="pFTPProtocol.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTP.Name" xml:space="preserve">
-    <value>rbFTPProtocolFTP</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTP.Parent" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTPS.Name" xml:space="preserve">
-    <value>rbFTPProtocolFTPS</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTPS.Parent" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolFTPS.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolSFTP.Name" xml:space="preserve">
-    <value>rbFTPProtocolSFTP</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolSFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolSFTP.Parent" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;rbFTPProtocolSFTP.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="pFTPProtocol.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 45</value>
-  </data>
-  <data name="pFTPProtocol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 20</value>
-  </data>
-  <data name="pFTPProtocol.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="rbFTPProtocolFTP.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -10006,6 +4204,27 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;rbFTPProtocolSFTP.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="pFTPProtocol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 45</value>
+  </data>
+  <data name="pFTPProtocol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>336, 20</value>
+  </data>
+  <data name="pFTPProtocol.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
   <data name="lblFTPPort.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -10373,90 +4592,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtFTPRemoteDirectory.ZOrder" xml:space="preserve">
     <value>26</value>
   </data>
-  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Name" xml:space="preserve">
-    <value>btnFTPSCertificateLocationBrowse</value>
-  </data>
-  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Parent" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtFTPSCertificateLocation.Name" xml:space="preserve">
-    <value>txtFTPSCertificateLocation</value>
-  </data>
-  <data name="&gt;&gt;txtFTPSCertificateLocation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFTPSCertificateLocation.Parent" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;txtFTPSCertificateLocation.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSCertificateLocation.Name" xml:space="preserve">
-    <value>lblFTPSCertificateLocation</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSCertificateLocation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSCertificateLocation.Parent" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSCertificateLocation.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbFTPSEncryption.Name" xml:space="preserve">
-    <value>cbFTPSEncryption</value>
-  </data>
-  <data name="&gt;&gt;cbFTPSEncryption.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFTPSEncryption.Parent" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;cbFTPSEncryption.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSEncryption.Name" xml:space="preserve">
-    <value>lblFTPSEncryption</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSEncryption.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSEncryption.Parent" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;lblFTPSEncryption.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="gbFTPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 288</value>
-  </data>
-  <data name="gbFTPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>744, 76</value>
-  </data>
-  <data name="gbFTPS.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="gbFTPS.Text" xml:space="preserve">
-    <value>FTPS</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
   <data name="btnFTPSCertificateLocationBrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -10585,6 +4720,54 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblFTPSEncryption.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="gbFTPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 288</value>
+  </data>
+  <data name="gbFTPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>744, 76</value>
+  </data>
+  <data name="gbFTPS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="gbFTPS.Text" xml:space="preserve">
+    <value>FTPS</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="gbFTPAccount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 72</value>
+  </data>
+  <data name="gbFTPAccount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>776, 416</value>
+  </data>
+  <data name="gbFTPAccount.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="gbFTPAccount.Text" xml:space="preserve">
+    <value>Account</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnFTPDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -10871,6 +5054,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbFTPText.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="tpFTP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpFTP.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpFTP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 519</value>
+  </data>
+  <data name="tpFTP.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tpFTP.Text" xml:space="preserve">
+    <value>FTP / FTPS / SFTP</value>
+  </data>
+  <data name="&gt;&gt;tpFTP.Name" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;tpFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpFTP.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbDropboxUseDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -11143,6 +5353,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Dropbox.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="tpDropbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpDropbox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpDropbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpDropbox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpDropbox.Text" xml:space="preserve">
+    <value>Dropbox</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Name" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="tvOneDrive.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -11247,6 +5484,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oAuth2OneDrive.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="tpOneDrive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpOneDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOneDrive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpOneDrive.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="tpOneDrive.Text" xml:space="preserve">
+    <value>OneDrive</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Name" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbGoogleDriveDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -11359,6 +5623,18 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblGoogleDriveFolderID.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="chGoogleDriveTitle.Text" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="chGoogleDriveTitle.Width" type="System.Int32, mscorlib">
+    <value>200</value>
+  </data>
+  <data name="chGoogleDriveDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chGoogleDriveDescription.Width" type="System.Int32, mscorlib">
+    <value>228</value>
+  </data>
   <data name="lvGoogleDriveFoldersList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 112</value>
   </data>
@@ -11379,18 +5655,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvGoogleDriveFoldersList.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="chGoogleDriveTitle.Text" xml:space="preserve">
-    <value>Title</value>
-  </data>
-  <data name="chGoogleDriveTitle.Width" type="System.Int32, mscorlib">
-    <value>200</value>
-  </data>
-  <data name="chGoogleDriveDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chGoogleDriveDescription.Width" type="System.Int32, mscorlib">
-    <value>228</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -11472,6 +5736,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oauth2GoogleDrive.ZOrder" xml:space="preserve">
     <value>7</value>
+  </data>
+  <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGoogleDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGoogleDrive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGoogleDrive.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpGoogleDrive.Text" xml:space="preserve">
+    <value>Google Drive</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Name" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="pbPuush.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -11710,6 +6001,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblPuushPassword.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="tpPuush.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPuush.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPuush.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPuush.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="tpPuush.Text" xml:space="preserve">
+    <value>puush</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Name" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="lblBoxFolderTip.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -11770,6 +6088,12 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbBoxShare.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="chBoxFoldersName.Text" xml:space="preserve">
+    <value>Folder name</value>
+  </data>
+  <data name="chBoxFoldersName.Width" type="System.Int32, mscorlib">
+    <value>435</value>
+  </data>
   <data name="lvBoxFolders.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 72</value>
   </data>
@@ -11790,12 +6114,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvBoxFolders.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="chBoxFoldersName.Text" xml:space="preserve">
-    <value>Folder name</value>
-  </data>
-  <data name="chBoxFoldersName.Width" type="System.Int32, mscorlib">
-    <value>435</value>
   </data>
   <data name="lblBoxFolderID.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -11878,137 +6196,32 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Box.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;lblAmazonS3StripExtension.Name" xml:space="preserve">
-    <value>lblAmazonS3StripExtension</value>
+  <data name="tpBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
   </data>
-  <data name="&gt;&gt;lblAmazonS3StripExtension.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;lblAmazonS3StripExtension.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
+  <data name="tpBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
   </data>
-  <data name="&gt;&gt;lblAmazonS3StripExtension.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Name" xml:space="preserve">
-    <value>cbAmazonS3StripExtensionText</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionText.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StorageClass.Name" xml:space="preserve">
-    <value>cbAmazonS3StorageClass</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StorageClass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StorageClass.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StorageClass.ZOrder" xml:space="preserve">
+  <data name="tpBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Name" xml:space="preserve">
-    <value>cbAmazonS3StripExtensionVideo</value>
+  <data name="tpBox.Text" xml:space="preserve">
+    <value>Box</value>
   </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpBox.Name" xml:space="preserve">
+    <value>tpBox</value>
   </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
+  <data name="&gt;&gt;tpBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpBox.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
   </data>
-  <data name="&gt;&gt;cbAmazonS3PublicACL.Name" xml:space="preserve">
-    <value>cbAmazonS3PublicACL</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3PublicACL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3PublicACL.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3PublicACL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Name" xml:space="preserve">
-    <value>cbAmazonS3StripExtensionImage</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpBox.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Name" xml:space="preserve">
-    <value>cbAmazonS3UsePathStyle</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;cbAmazonS3UsePathStyle.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Name" xml:space="preserve">
-    <value>btnAmazonS3StorageClassHelp</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3StorageClass.Name" xml:space="preserve">
-    <value>lblAmazonS3StorageClass</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3StorageClass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3StorageClass.Parent" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;lblAmazonS3StorageClass.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 408</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>416, 144</value>
-  </data>
-  <data name="gbAmazonS3Advanced.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Text" xml:space="preserve">
-    <value>Advanced</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblAmazonS3StripExtension.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -12267,6 +6480,30 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblAmazonS3StorageClass.ZOrder" xml:space="preserve">
     <value>8</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 408</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Size" type="System.Drawing.Size, System.Drawing">
+    <value>416, 144</value>
+  </data>
+  <data name="gbAmazonS3Advanced.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Text" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblAmazonS3Endpoint.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -12760,6 +6997,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtAmazonS3AccessKey.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
+  <data name="tpAmazonS3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpAmazonS3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAmazonS3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpAmazonS3.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="tpAmazonS3.Text" xml:space="preserve">
+    <value>Amazon S3</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Name" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="lblGoogleCloudStoragePathPreview.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -12988,6 +7252,435 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2GoogleCloudStorage.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="tpGoogleCloudStorage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGoogleCloudStorage.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Text" xml:space="preserve">
+    <value>Google Cloud Storage</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Name" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 299</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>230, 17</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Text" xml:space="preserve">
+    <value>Exclude container name from returned URL</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Name" xml:space="preserve">
+    <value>cbAzureStorageExcludeContainer</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 223</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Name" xml:space="preserve">
+    <value>txtAzureStorageUploadPath</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 207</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Text" xml:space="preserve">
+    <value>Upload Path:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Name" xml:space="preserve">
+    <value>lblAzureStorageUploadPath</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
+    <value>blob.core.windows.net</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
+    <value>blob.core.usgovcloudapi.net</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
+    <value>blob.core.chinacloudapi.cn</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
+    <value>blob.core.cloudapi.de</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 173</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 21</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>cbAzureStorageEnvironment</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 156</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Text" xml:space="preserve">
+    <value>Environment:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>lblAzureStorageEnvironment</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnAzureStoragePortal.Location" type="System.Drawing.Point, System.Drawing">
+    <value>552, 30</value>
+  </data>
+  <data name="btnAzureStoragePortal.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 24</value>
+  </data>
+  <data name="btnAzureStoragePortal.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="btnAzureStoragePortal.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Name" xml:space="preserve">
+    <value>btnAzureStoragePortal</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="txtAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 128</value>
+  </data>
+  <data name="txtAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Name" xml:space="preserve">
+    <value>txtAzureStorageContainer</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lblAzureStorageContainer.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 112</value>
+  </data>
+  <data name="lblAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 13</value>
+  </data>
+  <data name="lblAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblAzureStorageContainer.Text" xml:space="preserve">
+    <value>Container:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Name" xml:space="preserve">
+    <value>lblAzureStorageContainer</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 80</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Name" xml:space="preserve">
+    <value>txtAzureStorageAccessKey</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 64</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 13</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Text" xml:space="preserve">
+    <value>Access key:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Name" xml:space="preserve">
+    <value>lblAzureStorageAccessKey</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="txtAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 32</value>
+  </data>
+  <data name="txtAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Name" xml:space="preserve">
+    <value>txtAzureStorageAccountName</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblAzureStorageAccountName.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageAccountName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 16</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
+  </data>
+  <data name="lblAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Text" xml:space="preserve">
+    <value>Account name:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Name" xml:space="preserve">
+    <value>lblAzureStorageAccountName</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 273</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>txtAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 257</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
+    <value>Custom Domain:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>lblAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAzureStorage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpAzureStorage.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="tpAzureStorage.Text" xml:space="preserve">
+    <value>Azure Storage</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Name" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <data name="cbGfycatIsPublic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -13059,6 +7752,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oauth2Gfycat.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="tpGfycat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGfycat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGfycat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGfycat.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="tpGfycat.Text" xml:space="preserve">
+    <value>Gfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="btnMegaRefreshFolders.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -13352,6 +8072,30 @@ store.book[0].title</value>
     <value>tpMega</value>
   </data>
   <data name="&gt;&gt;lblMegaPassword.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tpMega.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpMega.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpMega.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="tpMega.Text" xml:space="preserve">
+    <value>Mega</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Name" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.AutoSize" type="System.Boolean, mscorlib">
@@ -13708,6 +8452,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblOwnCloudHost.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
+  <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOwnCloud.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpOwnCloud.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="tpOwnCloud.Text" xml:space="preserve">
+    <value>ownCloud / Nextcloud</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
   <data name="cbMediaFireUseLongLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -13891,6 +8662,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblMediaFireEmail.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="tpMediaFire.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpMediaFire.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpMediaFire.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpMediaFire.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="tpMediaFire.Text" xml:space="preserve">
+    <value>MediaFire</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Name" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
   <data name="lblPushbulletDevices.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -14025,6 +8823,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;txtPushbulletUserKey.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="tpPushbullet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPushbullet.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPushbullet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPushbullet.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="tpPushbullet.Text" xml:space="preserve">
+    <value>Pushbullet</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Name" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
   <data name="btnSendSpaceRegister.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -14175,6 +9000,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;atcSendSpaceAccountType.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="tpSendSpace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSendSpace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSendSpace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSendSpace.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpSendSpace.Text" xml:space="preserve">
+    <value>SendSpace</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Name" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.ZOrder" xml:space="preserve">
+    <value>14</value>
   </data>
   <data name="lblGe_ttStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14335,6 +9187,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtGe_ttEmail.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="tpGe_tt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGe_tt.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGe_tt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGe_tt.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tpGe_tt.Text" xml:space="preserve">
+    <value>Ge.tt</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Name" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
   <data name="cbLocalhostrDirectURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -14467,6 +9346,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtLocalhostrEmail.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="tpHostr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpHostr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpHostr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpHostr.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tpHostr.Text" xml:space="preserve">
+    <value>Hostr</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Name" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
   <data name="txtJiraIssuePrefix.Location" type="System.Drawing.Point, System.Drawing">
     <value>472, 277</value>
   </data>
@@ -14520,66 +9426,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblJiraIssuePrefix.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtJiraConfigHelp.Name" xml:space="preserve">
-    <value>txtJiraConfigHelp</value>
-  </data>
-  <data name="&gt;&gt;txtJiraConfigHelp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtJiraConfigHelp.Parent" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;txtJiraConfigHelp.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtJiraHost.Name" xml:space="preserve">
-    <value>txtJiraHost</value>
-  </data>
-  <data name="&gt;&gt;txtJiraHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtJiraHost.Parent" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;txtJiraHost.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblJiraHost.Name" xml:space="preserve">
-    <value>lblJiraHost</value>
-  </data>
-  <data name="&gt;&gt;lblJiraHost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblJiraHost.Parent" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;lblJiraHost.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="gbJiraServer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="gbJiraServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 358</value>
-  </data>
-  <data name="gbJiraServer.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbJiraServer.Text" xml:space="preserve">
-    <value>Jira server</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="txtJiraConfigHelp.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
@@ -14665,6 +9511,30 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblJiraHost.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="gbJiraServer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="gbJiraServer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 358</value>
+  </data>
+  <data name="gbJiraServer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbJiraServer.Text" xml:space="preserve">
+    <value>Jira server</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="oAuthJira.Location" type="System.Drawing.Point, System.Drawing">
     <value>473, 13</value>
   </data>
@@ -14685,6 +9555,30 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oAuthJira.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="tpJira.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpJira.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpJira.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="tpJira.Text" xml:space="preserve">
+    <value>Atlassian Jira</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Name" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpJira.ZOrder" xml:space="preserve">
+    <value>17</value>
   </data>
   <data name="lblLambdaInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14817,6 +9711,33 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;cbLambdaUploadURL.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="tpLambda.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpLambda.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpLambda.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpLambda.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="tpLambda.Text" xml:space="preserve">
+    <value>Lambda</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Name" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.ZOrder" xml:space="preserve">
+    <value>18</value>
   </data>
   <data name="btnPomfTest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -15001,6 +9922,33 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbPomfUploaders.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="tpPomf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPomf.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPomf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPomf.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="tpPomf.Text" xml:space="preserve">
+    <value>Pomf</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Name" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
   <data name="cbSeafileAPIURL.Items" xml:space="preserve">
     <value>https://seacloud.cc/api2/</value>
   </data>
@@ -15027,78 +9975,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;cbSeafileAPIURL.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileSharePassword.Name" xml:space="preserve">
-    <value>txtSeafileSharePassword</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileSharePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileSharePassword.Parent" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileSharePassword.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSharePassword.Name" xml:space="preserve">
-    <value>lblSeafileSharePassword</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSharePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSharePassword.Parent" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileSharePassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nudSeafileExpireDays.Name" xml:space="preserve">
-    <value>nudSeafileExpireDays</value>
-  </data>
-  <data name="&gt;&gt;nudSeafileExpireDays.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudSeafileExpireDays.Parent" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;nudSeafileExpireDays.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileDaysToExpire.Name" xml:space="preserve">
-    <value>lblSeafileDaysToExpire</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileDaysToExpire.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileDaysToExpire.Parent" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileDaysToExpire.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="grpSeafileShareSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 346</value>
-  </data>
-  <data name="grpSeafileShareSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 115</value>
-  </data>
-  <data name="grpSeafileShareSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="grpSeafileShareSettings.Text" xml:space="preserve">
-    <value>Seafile share settings</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="txtSeafileSharePassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>19, 79</value>
@@ -15202,6 +10078,30 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblSeafileDaysToExpire.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="grpSeafileShareSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 346</value>
+  </data>
+  <data name="grpSeafileShareSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 115</value>
+  </data>
+  <data name="grpSeafileShareSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="grpSeafileShareSettings.Text" xml:space="preserve">
+    <value>Seafile share settings</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="btnSeafileLibraryPasswordValidate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -15280,6 +10180,21 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblSeafileLibraryPassword.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="colSeafileLibraryName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="colSeafileLibraryName.Width" type="System.Int32, mscorlib">
+    <value>217</value>
+  </data>
+  <data name="colSeafileLibrarySize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="colSeafileLibrarySize.Width" type="System.Int32, mscorlib">
+    <value>74</value>
+  </data>
+  <data name="colSeafileLibraryEncrypted.Text" xml:space="preserve">
+    <value>Encrypted</value>
+  </data>
   <data name="lvSeafileLibraries.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 162</value>
   </data>
@@ -15300,21 +10215,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvSeafileLibraries.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="colSeafileLibraryName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="colSeafileLibraryName.Width" type="System.Int32, mscorlib">
-    <value>217</value>
-  </data>
-  <data name="colSeafileLibrarySize.Text" xml:space="preserve">
-    <value>Size</value>
-  </data>
-  <data name="colSeafileLibrarySize.Width" type="System.Int32, mscorlib">
-    <value>74</value>
-  </data>
-  <data name="colSeafileLibraryEncrypted.Text" xml:space="preserve">
-    <value>Encrypted</value>
   </data>
   <data name="btnSeafilePathValidate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -15482,90 +10382,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblSeafileSelectLibrary.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Name" xml:space="preserve">
-    <value>btnRefreshSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Parent" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;btnRefreshSeafileAccInfo.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoUsage.Name" xml:space="preserve">
-    <value>txtSeafileAccInfoUsage</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoUsage.Parent" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoUsage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoEmail.Name" xml:space="preserve">
-    <value>txtSeafileAccInfoEmail</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoEmail.Parent" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileAccInfoEmail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoEmail.Name" xml:space="preserve">
-    <value>lblSeafileAccInfoEmail</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoEmail.Parent" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoEmail.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoUsage.Name" xml:space="preserve">
-    <value>lblSeafileAccInfoUsage</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoUsage.Parent" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileAccInfoUsage.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpSeafileAccInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 181</value>
-  </data>
-  <data name="grpSeafileAccInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 149</value>
-  </data>
-  <data name="grpSeafileAccInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="grpSeafileAccInfo.Text" xml:space="preserve">
-    <value>Account information</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="btnRefreshSeafileAccInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -15695,6 +10511,30 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblSeafileAccInfoUsage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="grpSeafileAccInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 181</value>
+  </data>
+  <data name="grpSeafileAccInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 149</value>
+  </data>
+  <data name="grpSeafileAccInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="grpSeafileAccInfo.Text" xml:space="preserve">
+    <value>Account information</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
   <data name="btnSeafileCheckAuthToken.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -15748,90 +10588,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;btnSeafileCheckAPIURL.ZOrder" xml:space="preserve">
     <value>14</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileGetAuthToken.Name" xml:space="preserve">
-    <value>btnSeafileGetAuthToken</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileGetAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileGetAuthToken.Parent" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;btnSeafileGetAuthToken.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtSeafilePassword.Name" xml:space="preserve">
-    <value>txtSeafilePassword</value>
-  </data>
-  <data name="&gt;&gt;txtSeafilePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafilePassword.Parent" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;txtSeafilePassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUsername.Name" xml:space="preserve">
-    <value>txtSeafileUsername</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUsername.Parent" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;txtSeafileUsername.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileUsername.Name" xml:space="preserve">
-    <value>lblSeafileUsername</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileUsername.Parent" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;lblSeafileUsername.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePassword.Name" xml:space="preserve">
-    <value>lblSeafilePassword</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePassword.Parent" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;lblSeafilePassword.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 16</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 149</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Text" xml:space="preserve">
-    <value>Obtain auth token</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="btnSeafileGetAuthToken.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -15961,6 +10717,30 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lblSeafilePassword.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 16</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 149</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Text" xml:space="preserve">
+    <value>Obtain auth token</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
+    <value>15</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -16101,6 +10881,33 @@ Using an encrypted library disables sharing.</value>
     <value>tpSeafile</value>
   </data>
   <data name="&gt;&gt;lblSeafileAPIURL.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="tpSeafile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSeafile.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSeafile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSeafile.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="tpSeafile.Text" xml:space="preserve">
+    <value>Seafile</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Name" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
   <data name="cbStreamableUseDirectURL.AutoSize" type="System.Boolean, mscorlib">
@@ -16280,6 +11087,30 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cbStreamableAnonymous.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="tpStreamable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpStreamable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpStreamable.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="tpStreamable.Text" xml:space="preserve">
+    <value>Streamable</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Name" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
   <data name="btnSulGetAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -16357,6 +11188,33 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lblSulAPIKey.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="tpSul.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSul.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSul.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSul.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="tpSul.Text" xml:space="preserve">
+    <value>s-ul</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Name" xml:space="preserve">
+    <value>tpSul</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSul.ZOrder" xml:space="preserve">
+    <value>22</value>
   </data>
   <data name="btnLithiioFetchAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -16565,77 +11423,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtLithiioApiKey.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;cbPlikOneShot.Name" xml:space="preserve">
-    <value>cbPlikOneShot</value>
+  <data name="tpLithiio.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
   </data>
-  <data name="&gt;&gt;cbPlikOneShot.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpLithiio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;cbPlikOneShot.Parent" xml:space="preserve">
-    <value>gbPlikSettings</value>
+  <data name="tpLithiio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
   </data>
-  <data name="&gt;&gt;cbPlikOneShot.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="tpLithiio.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
-  <data name="&gt;&gt;txtPlikComment.Name" xml:space="preserve">
-    <value>txtPlikComment</value>
+  <data name="tpLithiio.Text" xml:space="preserve">
+    <value>Lithiio</value>
   </data>
-  <data name="&gt;&gt;txtPlikComment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpLithiio.Name" xml:space="preserve">
+    <value>tpLithiio</value>
   </data>
-  <data name="&gt;&gt;txtPlikComment.Parent" xml:space="preserve">
-    <value>gbPlikSettings</value>
+  <data name="&gt;&gt;tpLithiio.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;txtPlikComment.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpLithiio.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
   </data>
-  <data name="&gt;&gt;cbPlikComment.Name" xml:space="preserve">
-    <value>cbPlikComment</value>
-  </data>
-  <data name="&gt;&gt;cbPlikComment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPlikComment.Parent" xml:space="preserve">
-    <value>gbPlikSettings</value>
-  </data>
-  <data name="&gt;&gt;cbPlikComment.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbPlikRemovable.Name" xml:space="preserve">
-    <value>cbPlikRemovable</value>
-  </data>
-  <data name="&gt;&gt;cbPlikRemovable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPlikRemovable.Parent" xml:space="preserve">
-    <value>gbPlikSettings</value>
-  </data>
-  <data name="&gt;&gt;cbPlikRemovable.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="gbPlikSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>292, 19</value>
-  </data>
-  <data name="gbPlikSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 247</value>
-  </data>
-  <data name="gbPlikSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="gbPlikSettings.Text" xml:space="preserve">
-    <value>Other settings</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
-    <value>gbPlikSettings</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpLithiio.ZOrder" xml:space="preserve">
+    <value>23</value>
   </data>
   <data name="cbPlikOneShot.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -16751,173 +11564,29 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cbPlikRemovable.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;nudPlikTTL.Name" xml:space="preserve">
-    <value>nudPlikTTL</value>
+  <data name="gbPlikSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>292, 19</value>
   </data>
-  <data name="&gt;&gt;nudPlikTTL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gbPlikSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>344, 247</value>
   </data>
-  <data name="&gt;&gt;nudPlikTTL.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
+  <data name="gbPlikSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
   </data>
-  <data name="&gt;&gt;nudPlikTTL.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="gbPlikSettings.Text" xml:space="preserve">
+    <value>Other settings</value>
   </data>
-  <data name="&gt;&gt;cbxPlikTTLUnit.Name" xml:space="preserve">
-    <value>cbxPlikTTLUnit</value>
+  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
+    <value>gbPlikSettings</value>
   </data>
-  <data name="&gt;&gt;cbxPlikTTLUnit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbxPlikTTLUnit.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;cbxPlikTTLUnit.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblPlikTTL.Name" xml:space="preserve">
-    <value>lblPlikTTL</value>
-  </data>
-  <data name="&gt;&gt;lblPlikTTL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlikTTL.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;lblPlikTTL.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtPlikURL.Name" xml:space="preserve">
-    <value>txtPlikURL</value>
-  </data>
-  <data name="&gt;&gt;txtPlikURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPlikURL.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;txtPlikURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblPlikURL.Name" xml:space="preserve">
-    <value>lblPlikURL</value>
-  </data>
-  <data name="&gt;&gt;lblPlikURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlikURL.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;lblPlikURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbPlikIsSecured.Name" xml:space="preserve">
-    <value>cbPlikIsSecured</value>
-  </data>
-  <data name="&gt;&gt;cbPlikIsSecured.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPlikIsSecured.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;cbPlikIsSecured.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblPlikAPIKey.Name" xml:space="preserve">
-    <value>lblPlikAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPlikAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlikAPIKey.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;lblPlikAPIKey.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtPlikAPIKey.Name" xml:space="preserve">
-    <value>txtPlikAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPlikAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPlikAPIKey.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;txtPlikAPIKey.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblPlikPassword.Name" xml:space="preserve">
-    <value>lblPlikPassword</value>
-  </data>
-  <data name="&gt;&gt;lblPlikPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlikPassword.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;lblPlikPassword.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;lblPlikUsername.Name" xml:space="preserve">
-    <value>lblPlikUsername</value>
-  </data>
-  <data name="&gt;&gt;lblPlikUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPlikUsername.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;lblPlikUsername.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;txtPlikPassword.Name" xml:space="preserve">
-    <value>txtPlikPassword</value>
-  </data>
-  <data name="&gt;&gt;txtPlikPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPlikPassword.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;txtPlikPassword.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;txtPlikLogin.Name" xml:space="preserve">
-    <value>txtPlikLogin</value>
-  </data>
-  <data name="&gt;&gt;txtPlikLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPlikLogin.Parent" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;txtPlikLogin.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="gbPlikLoginCredentials.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 19</value>
-  </data>
-  <data name="gbPlikLoginCredentials.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 247</value>
-  </data>
-  <data name="gbPlikLoginCredentials.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="gbPlikLoginCredentials.Text" xml:space="preserve">
-    <value>Login Credentials</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
+  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
     <value>tpPlik</value>
   </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="nudPlikTTL.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 217</value>
@@ -17237,6 +11906,57 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtPlikLogin.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="gbPlikLoginCredentials.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 19</value>
+  </data>
+  <data name="gbPlikLoginCredentials.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 247</value>
+  </data>
+  <data name="gbPlikLoginCredentials.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="gbPlikLoginCredentials.Text" xml:space="preserve">
+    <value>Login Credentials</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpPlik.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPlik.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPlik.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPlik.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="tpPlik.Text" xml:space="preserve">
+    <value>Plik</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Name" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
   <data name="cbYouTubeUseShortenedLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -17338,6 +12058,30 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;oauth2YouTube.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="tpYouTube.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpYouTube.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpYouTube.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="tpYouTube.Text" xml:space="preserve">
+    <value>YouTube</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Name" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.ZOrder" xml:space="preserve">
+    <value>25</value>
   </data>
   <data name="lbSharedFolderAccounts.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -17608,6 +12352,33 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;cboSharedFolderImages.ZOrder" xml:space="preserve">
     <value>10</value>
+  </data>
+  <data name="tpSharedFolder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSharedFolder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSharedFolder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSharedFolder.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="tpSharedFolder.Text" xml:space="preserve">
+    <value>Shared folder</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Name" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.ZOrder" xml:space="preserve">
+    <value>26</value>
   </data>
   <data name="txtEmailAutomaticSendTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 408</value>
@@ -18002,6 +12773,84 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtEmailDefaultSubject.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
+  <data name="tpEmail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpEmail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpEmail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpEmail.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="tpEmail.Text" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Name" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="tcFileUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcFileUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Name" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Parent" xml:space="preserve">
+    <value>tpFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpFileUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
+  </data>
+  <data name="tpFileUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpFileUploaders.Text" xml:space="preserve">
+    <value>File uploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Name" xml:space="preserve">
+    <value>tpFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="btnCopyShowFiles.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -18019,372 +12868,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;btnCopyShowFiles.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
-    <value>tpTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTextUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
-  </data>
-  <data name="tpTextUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpTextUploaders.Text" xml:space="preserve">
-    <value>Text uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTextUploaders.Name" xml:space="preserve">
-    <value>tpTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTextUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTextUploaders.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTextUploaders.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
-    <value>tpPaste_ee</value>
-  </data>
-  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
-    <value>tpUpaste</value>
-  </data>
-  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tpPastie.Name" xml:space="preserve">
-    <value>tpPastie</value>
-  </data>
-  <data name="&gt;&gt;tpPastie.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPastie.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPastie.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tcTextUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
-  </data>
-  <data name="tcTextUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
-    <value>tpTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinRaw.Name" xml:space="preserve">
-    <value>cbPastebinRaw</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinRaw.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinRaw.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinRaw.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinSyntax.Name" xml:space="preserve">
-    <value>cbPastebinSyntax</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinSyntax.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinSyntax.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinSyntax.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinRegister.Name" xml:space="preserve">
-    <value>btnPastebinRegister</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinRegister.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinRegister.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinRegister.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinSyntax.Name" xml:space="preserve">
-    <value>lblPastebinSyntax</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinSyntax.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinSyntax.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinSyntax.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinExpiration.Name" xml:space="preserve">
-    <value>lblPastebinExpiration</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinExpiration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinExpiration.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinExpiration.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPrivacy.Name" xml:space="preserve">
-    <value>lblPastebinPrivacy</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPrivacy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPrivacy.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPrivacy.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinTitle.Name" xml:space="preserve">
-    <value>lblPastebinTitle</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinTitle.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinTitle.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPassword.Name" xml:space="preserve">
-    <value>lblPastebinPassword</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPassword.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinPassword.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinUsername.Name" xml:space="preserve">
-    <value>lblPastebinUsername</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinUsername.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinUsername.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinExpiration.Name" xml:space="preserve">
-    <value>cbPastebinExpiration</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinExpiration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinExpiration.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinExpiration.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinPrivacy.Name" xml:space="preserve">
-    <value>cbPastebinPrivacy</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinPrivacy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinPrivacy.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;cbPastebinPrivacy.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinTitle.Name" xml:space="preserve">
-    <value>txtPastebinTitle</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinTitle.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinTitle.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinPassword.Name" xml:space="preserve">
-    <value>txtPastebinPassword</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinPassword.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinPassword.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinUsername.Name" xml:space="preserve">
-    <value>txtPastebinUsername</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinUsername.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;txtPastebinUsername.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinLoginStatus.Name" xml:space="preserve">
-    <value>lblPastebinLoginStatus</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinLoginStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinLoginStatus.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;lblPastebinLoginStatus.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinLogin.Name" xml:space="preserve">
-    <value>btnPastebinLogin</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinLogin.Parent" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;btnPastebinLogin.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="tpPastebin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpPastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPastebin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
-  </data>
-  <data name="tpPastebin.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpPastebin.Text" xml:space="preserve">
-    <value>Pastebin</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
-    <value>tpPastebin</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="cbPastebinRaw.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -18806,68 +13289,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnPastebinLogin.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
-  <data name="&gt;&gt;btnPaste_eeGetUserKey.Name" xml:space="preserve">
-    <value>btnPaste_eeGetUserKey</value>
-  </data>
-  <data name="&gt;&gt;btnPaste_eeGetUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPaste_eeGetUserKey.Parent" xml:space="preserve">
-    <value>tpPaste_ee</value>
-  </data>
-  <data name="&gt;&gt;btnPaste_eeGetUserKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>lblPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>tpPaste_ee</value>
-  </data>
-  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
-    <value>txtPaste_eeUserAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
-    <value>tpPaste_ee</value>
-  </data>
-  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpPaste_ee.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpPastebin.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPaste_ee.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpPastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpPaste_ee.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="tpPastebin.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
   </data>
-  <data name="tpPaste_ee.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpPastebin.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpPaste_ee.Text" xml:space="preserve">
-    <value>Paste.ee</value>
+  <data name="tpPastebin.Text" xml:space="preserve">
+    <value>Pastebin</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
-    <value>tpPaste_ee</value>
+  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
+    <value>tpPastebin</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnPaste_eeGetUserKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -18947,113 +13394,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;lblGistCustomURLExample.Name" xml:space="preserve">
-    <value>lblGistCustomURLExample</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURLExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURLExample.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURLExample.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblGistOAuthInfo.Name" xml:space="preserve">
-    <value>lblGistOAuthInfo</value>
-  </data>
-  <data name="&gt;&gt;lblGistOAuthInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGistOAuthInfo.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;lblGistOAuthInfo.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURL.Name" xml:space="preserve">
-    <value>lblGistCustomURL</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURL.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;lblGistCustomURL.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtGistCustomURL.Name" xml:space="preserve">
-    <value>txtGistCustomURL</value>
-  </data>
-  <data name="&gt;&gt;txtGistCustomURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtGistCustomURL.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;txtGistCustomURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbGistUseRawURL.Name" xml:space="preserve">
-    <value>cbGistUseRawURL</value>
-  </data>
-  <data name="&gt;&gt;cbGistUseRawURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGistUseRawURL.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;cbGistUseRawURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbGistPublishPublic.Name" xml:space="preserve">
-    <value>cbGistPublishPublic</value>
-  </data>
-  <data name="&gt;&gt;cbGistPublishPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGistPublishPublic.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;cbGistPublishPublic.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;oAuth2Gist.Name" xml:space="preserve">
-    <value>oAuth2Gist</value>
-  </data>
-  <data name="&gt;&gt;oAuth2Gist.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oAuth2Gist.Parent" xml:space="preserve">
-    <value>tpGist</value>
-  </data>
-  <data name="&gt;&gt;oAuth2Gist.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpGist.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpPaste_ee.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpGist.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpPaste_ee.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPaste_ee.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpGist.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpPaste_ee.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpGist.Text" xml:space="preserve">
-    <value>GitHub Gist</value>
+  <data name="tpPaste_ee.Text" xml:space="preserve">
+    <value>Paste.ee</value>
   </data>
-  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
-    <value>tpGist</value>
+  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
+    <value>tpPaste_ee</value>
   </data>
-  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblGistCustomURLExample.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -19247,68 +13613,29 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oAuth2Gist.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;cbUpasteIsPublic.Name" xml:space="preserve">
-    <value>cbUpasteIsPublic</value>
-  </data>
-  <data name="&gt;&gt;cbUpasteIsPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbUpasteIsPublic.Parent" xml:space="preserve">
-    <value>tpUpaste</value>
-  </data>
-  <data name="&gt;&gt;cbUpasteIsPublic.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblUpasteUserKey.Name" xml:space="preserve">
-    <value>lblUpasteUserKey</value>
-  </data>
-  <data name="&gt;&gt;lblUpasteUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblUpasteUserKey.Parent" xml:space="preserve">
-    <value>tpUpaste</value>
-  </data>
-  <data name="&gt;&gt;lblUpasteUserKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtUpasteUserKey.Name" xml:space="preserve">
-    <value>txtUpasteUserKey</value>
-  </data>
-  <data name="&gt;&gt;txtUpasteUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUpasteUserKey.Parent" xml:space="preserve">
-    <value>tpUpaste</value>
-  </data>
-  <data name="&gt;&gt;txtUpasteUserKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpUpaste.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpGist.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUpaste.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpUpaste.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpGist.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpUpaste.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpGist.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpUpaste.Text" xml:space="preserve">
-    <value>uPaste</value>
+  <data name="tpGist.Text" xml:space="preserve">
+    <value>GitHub Gist</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
-    <value>tpUpaste</value>
+  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
+    <value>tpGist</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbUpasteIsPublic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -19391,92 +13718,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtUpasteUserKey.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;cbHastebinUseFileExtension.Name" xml:space="preserve">
-    <value>cbHastebinUseFileExtension</value>
-  </data>
-  <data name="&gt;&gt;cbHastebinUseFileExtension.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbHastebinUseFileExtension.Parent" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;cbHastebinUseFileExtension.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Name" xml:space="preserve">
-    <value>txtHastebinSyntaxHighlighting</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Parent" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinCustomDomain.Name" xml:space="preserve">
-    <value>txtHastebinCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinCustomDomain.Parent" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;txtHastebinCustomDomain.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Name" xml:space="preserve">
-    <value>lblHastebinSyntaxHighlighting</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Parent" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinCustomDomain.Name" xml:space="preserve">
-    <value>lblHastebinCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinCustomDomain.Parent" xml:space="preserve">
-    <value>tpHastebin</value>
-  </data>
-  <data name="&gt;&gt;lblHastebinCustomDomain.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpHastebin.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpUpaste.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpHastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpUpaste.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpHastebin.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpUpaste.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpHastebin.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="tpUpaste.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpHastebin.Text" xml:space="preserve">
-    <value>Hastebin</value>
+  <data name="tpUpaste.Text" xml:space="preserve">
+    <value>uPaste</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
-    <value>tpHastebin</value>
+  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
+    <value>tpUpaste</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="cbHastebinUseFileExtension.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -19610,80 +13877,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblHastebinCustomDomain.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Name" xml:space="preserve">
-    <value>lblOneTimeSecretAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Parent" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretAPIKey.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretEmail.Name" xml:space="preserve">
-    <value>lblOneTimeSecretEmail</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretEmail.Parent" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;lblOneTimeSecretEmail.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Name" xml:space="preserve">
-    <value>txtOneTimeSecretAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Parent" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretAPIKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretEmail.Name" xml:space="preserve">
-    <value>txtOneTimeSecretEmail</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretEmail.Parent" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;txtOneTimeSecretEmail.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpOneTimeSecret.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpHastebin.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpOneTimeSecret.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpHastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpOneTimeSecret.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpHastebin.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpOneTimeSecret.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="tpHastebin.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpOneTimeSecret.Text" xml:space="preserve">
-    <value>OneTimeSecret</value>
+  <data name="tpHastebin.Text" xml:space="preserve">
+    <value>Hastebin</value>
   </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
+  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
+    <value>tpHastebin</value>
   </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="lblOneTimeSecretAPIKey.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -19787,6 +14006,51 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtOneTimeSecretEmail.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="tpOneTimeSecret.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpOneTimeSecret.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOneTimeSecret.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
+  </data>
+  <data name="tpOneTimeSecret.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tpOneTimeSecret.Text" xml:space="preserve">
+    <value>OneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="cbPastieIsPublic.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbPastieIsPublic.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbPastieIsPublic.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 22</value>
+  </data>
+  <data name="cbPastieIsPublic.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 17</value>
+  </data>
+  <data name="cbPastieIsPublic.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbPastieIsPublic.Text" xml:space="preserve">
+    <value>Is public upload?</value>
+  </data>
   <data name="&gt;&gt;cbPastieIsPublic.Name" xml:space="preserve">
     <value>cbPastieIsPublic</value>
   </data>
@@ -19826,332 +14090,56 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;tpPastie.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="cbPastieIsPublic.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbPastieIsPublic.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbPastieIsPublic.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 22</value>
-  </data>
-  <data name="cbPastieIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
-  </data>
-  <data name="cbPastieIsPublic.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="cbPastieIsPublic.Text" xml:space="preserve">
-    <value>Is public upload?</value>
-  </data>
-  <data name="&gt;&gt;cbPastieIsPublic.Name" xml:space="preserve">
-    <value>cbPastieIsPublic</value>
-  </data>
-  <data name="&gt;&gt;cbPastieIsPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPastieIsPublic.Parent" xml:space="preserve">
-    <value>tpPastie</value>
-  </data>
-  <data name="&gt;&gt;cbPastieIsPublic.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
-    <value>tpImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpImageUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
-  </data>
-  <data name="tpImageUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpImageUploaders.Text" xml:space="preserve">
-    <value>Image uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Name" xml:space="preserve">
-    <value>tpImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
-    <value>tpFlickr</value>
-  </data>
-  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
-    <value>tpPhotobucket</value>
-  </data>
-  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
-    <value>tpGooglePhotos</value>
-  </data>
-  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
-    <value>tpVgyme</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tcImageUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tcTextUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tcImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tcTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="tcImageUploaders.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>780, 480</value>
-  </data>
-  <data name="tcImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tcTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
     <value>980, 563</value>
   </data>
-  <data name="tcImageUploaders.TabIndex" type="System.Int32, mscorlib">
+  <data name="tcTextUploaders.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
-    <value>tcImageUploaders</value>
+  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
+    <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
-    <value>tpImageUploaders</value>
+  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
+    <value>tpTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;cbImgurUseGIFV.Name" xml:space="preserve">
-    <value>cbImgurUseGIFV</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUseGIFV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUseGIFV.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUseGIFV.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Name" xml:space="preserve">
-    <value>cbImgurUploadSelectedAlbum</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbImgurDirectLink.Name" xml:space="preserve">
-    <value>cbImgurDirectLink</value>
-  </data>
-  <data name="&gt;&gt;cbImgurDirectLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImgurDirectLink.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;cbImgurDirectLink.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;atcImgurAccountType.Name" xml:space="preserve">
-    <value>atcImgurAccountType</value>
-  </data>
-  <data name="&gt;&gt;atcImgurAccountType.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;atcImgurAccountType.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;atcImgurAccountType.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;oauth2Imgur.Name" xml:space="preserve">
-    <value>oauth2Imgur</value>
-  </data>
-  <data name="&gt;&gt;oauth2Imgur.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Imgur.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;oauth2Imgur.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvImgurAlbumList.Name" xml:space="preserve">
-    <value>lvImgurAlbumList</value>
-  </data>
-  <data name="&gt;&gt;lvImgurAlbumList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvImgurAlbumList.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;lvImgurAlbumList.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnImgurRefreshAlbumList.Name" xml:space="preserve">
-    <value>btnImgurRefreshAlbumList</value>
-  </data>
-  <data name="&gt;&gt;btnImgurRefreshAlbumList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnImgurRefreshAlbumList.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;btnImgurRefreshAlbumList.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbImgurThumbnailType.Name" xml:space="preserve">
-    <value>cbImgurThumbnailType</value>
-  </data>
-  <data name="&gt;&gt;cbImgurThumbnailType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImgurThumbnailType.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;cbImgurThumbnailType.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblImgurThumbnailType.Name" xml:space="preserve">
-    <value>lblImgurThumbnailType</value>
-  </data>
-  <data name="&gt;&gt;lblImgurThumbnailType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImgurThumbnailType.Parent" xml:space="preserve">
-    <value>tpImgur</value>
-  </data>
-  <data name="&gt;&gt;lblImgurThumbnailType.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpImgur.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpImgur.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpTextUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpImgur.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="tpTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
   </data>
-  <data name="tpImgur.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpTextUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpImgur.Text" xml:space="preserve">
-    <value>Imgur</value>
+  <data name="tpTextUploaders.Text" xml:space="preserve">
+    <value>Text uploaders</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
-    <value>tpImgur</value>
+  <data name="&gt;&gt;tpTextUploaders.Name" xml:space="preserve">
+    <value>tpTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpTextUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
+  <data name="&gt;&gt;tpTextUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpTextUploaders.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="cbImgurUseGIFV.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -20285,6 +14273,21 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauth2Imgur.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="chImgurID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="chImgurTitle.Text" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="chImgurTitle.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="chImgurDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chImgurDescription.Width" type="System.Int32, mscorlib">
+    <value>226</value>
+  </data>
   <data name="lvImgurAlbumList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 48</value>
   </data>
@@ -20305,21 +14308,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvImgurAlbumList.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="chImgurID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="chImgurTitle.Text" xml:space="preserve">
-    <value>Title</value>
-  </data>
-  <data name="chImgurTitle.Width" type="System.Int32, mscorlib">
-    <value>150</value>
-  </data>
-  <data name="chImgurDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chImgurDescription.Width" type="System.Int32, mscorlib">
-    <value>226</value>
   </data>
   <data name="btnImgurRefreshAlbumList.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -20402,128 +14390,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblImgurThumbnailType.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;btnImageShackLogin.Name" xml:space="preserve">
-    <value>btnImageShackLogin</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackLogin.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackLogin.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Name" xml:space="preserve">
-    <value>btnImageShackOpenPublicProfile</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenPublicProfile.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbImageShackIsPublic.Name" xml:space="preserve">
-    <value>cbImageShackIsPublic</value>
-  </data>
-  <data name="&gt;&gt;cbImageShackIsPublic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageShackIsPublic.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;cbImageShackIsPublic.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenMyImages.Name" xml:space="preserve">
-    <value>btnImageShackOpenMyImages</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenMyImages.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenMyImages.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;btnImageShackOpenMyImages.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackUsername.Name" xml:space="preserve">
-    <value>lblImageShackUsername</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackUsername.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackUsername.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackUsername.Name" xml:space="preserve">
-    <value>txtImageShackUsername</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackUsername.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackUsername.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackPassword.Name" xml:space="preserve">
-    <value>txtImageShackPassword</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackPassword.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;txtImageShackPassword.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackPassword.Name" xml:space="preserve">
-    <value>lblImageShackPassword</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackPassword.Parent" xml:space="preserve">
-    <value>tpImageShack</value>
-  </data>
-  <data name="&gt;&gt;lblImageShackPassword.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpImageShack.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpImgur.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpImageShack.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpImgur.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpImageShack.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpImgur.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpImageShack.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpImgur.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpImageShack.Text" xml:space="preserve">
-    <value>ImageShack</value>
+  <data name="tpImgur.Text" xml:space="preserve">
+    <value>Imgur</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
-    <value>tpImageShack</value>
+  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
+    <value>tpImgur</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnImageShackLogin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -20738,116 +14630,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblImageShackPassword.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;atcTinyPicAccountType.Name" xml:space="preserve">
-    <value>atcTinyPicAccountType</value>
-  </data>
-  <data name="&gt;&gt;atcTinyPicAccountType.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;atcTinyPicAccountType.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;atcTinyPicAccountType.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicLogin.Name" xml:space="preserve">
-    <value>btnTinyPicLogin</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicLogin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicLogin.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicLogin.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicPassword.Name" xml:space="preserve">
-    <value>txtTinyPicPassword</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicPassword.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicPassword.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicPassword.Name" xml:space="preserve">
-    <value>lblTinyPicPassword</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicPassword.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicUsername.Name" xml:space="preserve">
-    <value>txtTinyPicUsername</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicUsername.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;txtTinyPicUsername.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicUsername.Name" xml:space="preserve">
-    <value>lblTinyPicUsername</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicUsername.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;lblTinyPicUsername.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicOpenMyImages.Name" xml:space="preserve">
-    <value>btnTinyPicOpenMyImages</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicOpenMyImages.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicOpenMyImages.Parent" xml:space="preserve">
-    <value>tpTinyPic</value>
-  </data>
-  <data name="&gt;&gt;btnTinyPicOpenMyImages.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpTinyPic.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpImageShack.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpTinyPic.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpImageShack.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpTinyPic.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpImageShack.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpTinyPic.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpImageShack.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpTinyPic.Text" xml:space="preserve">
-    <value>TinyPic</value>
+  <data name="tpImageShack.Text" xml:space="preserve">
+    <value>ImageShack</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
-    <value>tpTinyPic</value>
+  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
+    <value>tpImageShack</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="atcTinyPicAccountType.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 16</value>
@@ -21026,56 +14834,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnTinyPicOpenMyImages.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;cbFlickrDirectLink.Name" xml:space="preserve">
-    <value>cbFlickrDirectLink</value>
-  </data>
-  <data name="&gt;&gt;cbFlickrDirectLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFlickrDirectLink.Parent" xml:space="preserve">
-    <value>tpFlickr</value>
-  </data>
-  <data name="&gt;&gt;cbFlickrDirectLink.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;oauthFlickr.Name" xml:space="preserve">
-    <value>oauthFlickr</value>
-  </data>
-  <data name="&gt;&gt;oauthFlickr.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauthFlickr.Parent" xml:space="preserve">
-    <value>tpFlickr</value>
-  </data>
-  <data name="&gt;&gt;oauthFlickr.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpFlickr.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpTinyPic.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpFlickr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpTinyPic.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpFlickr.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpTinyPic.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpFlickr.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpTinyPic.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpFlickr.Text" xml:space="preserve">
-    <value>Flickr</value>
+  <data name="tpTinyPic.Text" xml:space="preserve">
+    <value>TinyPic</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
-    <value>tpFlickr</value>
+  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
+    <value>tpTinyPic</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbFlickrDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -21128,128 +14912,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauthFlickr.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
-    <value>tpPhotobucket</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
-    <value>tpPhotobucket</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
-    <value>tpPhotobucket</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpPhotobucket.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpFlickr.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPhotobucket.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpFlickr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpPhotobucket.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpFlickr.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpPhotobucket.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="tpFlickr.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpPhotobucket.Text" xml:space="preserve">
-    <value>Photobucket</value>
+  <data name="tpFlickr.Text" xml:space="preserve">
+    <value>Flickr</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
-    <value>tpPhotobucket</value>
+  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
+    <value>tpFlickr</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAddAlbum.Name" xml:space="preserve">
-    <value>btnPhotobucketAddAlbum</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAddAlbum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAddAlbum.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAddAlbum.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Name" xml:space="preserve">
-    <value>btnPhotobucketRemoveAlbum</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Name" xml:space="preserve">
-    <value>cboPhotobucketAlbumPaths</value>
-  </data>
-  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;cboPhotobucketAlbumPaths.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="gbPhotobucketAlbumPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 208</value>
-  </data>
-  <data name="gbPhotobucketAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 64</value>
-  </data>
-  <data name="gbPhotobucketAlbumPath.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="gbPhotobucketAlbumPath.Text" xml:space="preserve">
-    <value>Upload images to</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
-    <value>tpPhotobucket</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="btnPhotobucketAddAlbum.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -21329,89 +15017,29 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cboPhotobucketAlbumPaths.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Name" xml:space="preserve">
-    <value>lblPhotobucketNewAlbumName</value>
+  <data name="gbPhotobucketAlbumPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 208</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gbPhotobucketAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 64</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketNewAlbumName.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Name" xml:space="preserve">
-    <value>lblPhotobucketParentAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.ZOrder" xml:space="preserve">
+  <data name="gbPhotobucketAlbumPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Name" xml:space="preserve">
-    <value>txtPhotobucketNewAlbumName</value>
+  <data name="gbPhotobucketAlbumPath.Text" xml:space="preserve">
+    <value>Upload images to</value>
   </data>
-  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
   </data>
-  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketNewAlbumName.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Name" xml:space="preserve">
-    <value>txtPhotobucketParentAlbumPath</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Name" xml:space="preserve">
-    <value>btnPhotobucketCreateAlbum</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Parent" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketCreateAlbum.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="gbPhotobucketAlbums.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 280</value>
-  </data>
-  <data name="gbPhotobucketAlbums.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 128</value>
-  </data>
-  <data name="gbPhotobucketAlbums.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="gbPhotobucketAlbums.Text" xml:space="preserve">
-    <value>Create new album</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
     <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblPhotobucketNewAlbumName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -21542,113 +15170,29 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnPhotobucketCreateAlbum.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Name" xml:space="preserve">
-    <value>lblPhotobucketDefaultAlbumName</value>
+  <data name="gbPhotobucketAlbums.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 280</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gbPhotobucketAlbums.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 128</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthOpen.Name" xml:space="preserve">
-    <value>btnPhotobucketAuthOpen</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthOpen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthOpen.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthOpen.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Name" xml:space="preserve">
-    <value>txtPhotobucketDefaultAlbumName</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.ZOrder" xml:space="preserve">
+  <data name="gbPhotobucketAlbums.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketVerificationCode.Name" xml:space="preserve">
-    <value>lblPhotobucketVerificationCode</value>
+  <data name="gbPhotobucketAlbums.Text" xml:space="preserve">
+    <value>Create new album</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketVerificationCode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
   </data>
-  <data name="&gt;&gt;lblPhotobucketVerificationCode.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketVerificationCode.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthComplete.Name" xml:space="preserve">
-    <value>btnPhotobucketAuthComplete</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthComplete.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthComplete.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;btnPhotobucketAuthComplete.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketVerificationCode.Name" xml:space="preserve">
-    <value>txtPhotobucketVerificationCode</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketVerificationCode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketVerificationCode.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;txtPhotobucketVerificationCode.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketAccountStatus.Name" xml:space="preserve">
-    <value>lblPhotobucketAccountStatus</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketAccountStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketAccountStatus.Parent" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;lblPhotobucketAccountStatus.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="gbPhotobucketUserAccount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="gbPhotobucketUserAccount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 184</value>
-  </data>
-  <data name="gbPhotobucketUserAccount.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbPhotobucketUserAccount.Text" xml:space="preserve">
-    <value>User account</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
-  </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
     <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblPhotobucketDefaultAlbumName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -21836,92 +15380,56 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblPhotobucketAccountStatus.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="&gt;&gt;txtPicasaAlbumID.Name" xml:space="preserve">
-    <value>txtPicasaAlbumID</value>
+  <data name="gbPhotobucketUserAccount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 16</value>
   </data>
-  <data name="&gt;&gt;txtPicasaAlbumID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gbPhotobucketUserAccount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 184</value>
   </data>
-  <data name="&gt;&gt;txtPicasaAlbumID.Parent" xml:space="preserve">
-    <value>tpGooglePhotos</value>
-  </data>
-  <data name="&gt;&gt;txtPicasaAlbumID.ZOrder" xml:space="preserve">
+  <data name="gbPhotobucketUserAccount.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lblPicasaAlbumID.Name" xml:space="preserve">
-    <value>lblPicasaAlbumID</value>
+  <data name="gbPhotobucketUserAccount.Text" xml:space="preserve">
+    <value>User account</value>
   </data>
-  <data name="&gt;&gt;lblPicasaAlbumID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
   </data>
-  <data name="&gt;&gt;lblPicasaAlbumID.Parent" xml:space="preserve">
-    <value>tpGooglePhotos</value>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblPicasaAlbumID.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
+    <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;lvPicasaAlbumList.Name" xml:space="preserve">
-    <value>lvPicasaAlbumList</value>
-  </data>
-  <data name="&gt;&gt;lvPicasaAlbumList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvPicasaAlbumList.Parent" xml:space="preserve">
-    <value>tpGooglePhotos</value>
-  </data>
-  <data name="&gt;&gt;lvPicasaAlbumList.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Name" xml:space="preserve">
-    <value>btnPicasaRefreshAlbumList</value>
-  </data>
-  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Parent" xml:space="preserve">
-    <value>tpGooglePhotos</value>
-  </data>
-  <data name="&gt;&gt;btnPicasaRefreshAlbumList.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;oauth2Picasa.Name" xml:space="preserve">
-    <value>oauth2Picasa</value>
-  </data>
-  <data name="&gt;&gt;oauth2Picasa.Type" xml:space="preserve">
-    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;oauth2Picasa.Parent" xml:space="preserve">
-    <value>tpGooglePhotos</value>
-  </data>
-  <data name="&gt;&gt;oauth2Picasa.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpGooglePhotos.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpPhotobucket.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpGooglePhotos.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpPhotobucket.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpGooglePhotos.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpPhotobucket.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpGooglePhotos.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="tpPhotobucket.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpGooglePhotos.Text" xml:space="preserve">
-    <value>Google Photos</value>
+  <data name="tpPhotobucket.Text" xml:space="preserve">
+    <value>Photobucket</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
-    <value>tpGooglePhotos</value>
+  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
+    <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="txtPicasaAlbumID.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 64</value>
@@ -21974,6 +15482,24 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblPicasaAlbumID.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="chPicasaID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="chPicasaID.Width" type="System.Int32, mscorlib">
+    <value>135</value>
+  </data>
+  <data name="chPicasaName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="chPicasaName.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="chPicasaDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chPicasaDescription.Width" type="System.Int32, mscorlib">
+    <value>143</value>
+  </data>
   <data name="lvPicasaAlbumList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 88</value>
   </data>
@@ -21994,24 +15520,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvPicasaAlbumList.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="chPicasaID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="chPicasaID.Width" type="System.Int32, mscorlib">
-    <value>135</value>
-  </data>
-  <data name="chPicasaName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="chPicasaName.Width" type="System.Int32, mscorlib">
-    <value>150</value>
-  </data>
-  <data name="chPicasaDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chPicasaDescription.Width" type="System.Int32, mscorlib">
-    <value>143</value>
   </data>
   <data name="btnPicasaRefreshAlbumList.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -22064,140 +15572,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauth2Picasa.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;btnCheveretoTestAll.Name" xml:space="preserve">
-    <value>btnCheveretoTestAll</value>
-  </data>
-  <data name="&gt;&gt;btnCheveretoTestAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCheveretoTestAll.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;btnCheveretoTestAll.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURLExample.Name" xml:space="preserve">
-    <value>lblCheveretoUploadURLExample</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURLExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURLExample.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURLExample.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploaders.Name" xml:space="preserve">
-    <value>lblCheveretoUploaders</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploaders.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploaders.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoUploaders.Name" xml:space="preserve">
-    <value>cbCheveretoUploaders</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoUploaders.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoUploaders.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoDirectURL.Name" xml:space="preserve">
-    <value>cbCheveretoDirectURL</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoDirectURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoDirectURL.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;cbCheveretoDirectURL.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURL.Name" xml:space="preserve">
-    <value>lblCheveretoUploadURL</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURL.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoUploadURL.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoUploadURL.Name" xml:space="preserve">
-    <value>txtCheveretoUploadURL</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoUploadURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoUploadURL.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoUploadURL.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoAPIKey.Name" xml:space="preserve">
-    <value>txtCheveretoAPIKey</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoAPIKey.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;txtCheveretoAPIKey.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoAPIKey.Name" xml:space="preserve">
-    <value>lblCheveretoAPIKey</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoAPIKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoAPIKey.Parent" xml:space="preserve">
-    <value>tpChevereto</value>
-  </data>
-  <data name="&gt;&gt;lblCheveretoAPIKey.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpChevereto.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpGooglePhotos.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpChevereto.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpGooglePhotos.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpChevereto.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpGooglePhotos.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpChevereto.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="tpGooglePhotos.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="tpChevereto.Text" xml:space="preserve">
-    <value>Chevereto</value>
+  <data name="tpGooglePhotos.Text" xml:space="preserve">
+    <value>Google Photos</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
-    <value>tpChevereto</value>
+  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
+    <value>tpGooglePhotos</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="btnCheveretoTestAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -22442,68 +15842,32 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblCheveretoAPIKey.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;llVgymeAccountDetailsPage.Name" xml:space="preserve">
-    <value>llVgymeAccountDetailsPage</value>
-  </data>
-  <data name="&gt;&gt;llVgymeAccountDetailsPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;llVgymeAccountDetailsPage.Parent" xml:space="preserve">
-    <value>tpVgyme</value>
-  </data>
-  <data name="&gt;&gt;llVgymeAccountDetailsPage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtVgymeUserKey.Name" xml:space="preserve">
-    <value>txtVgymeUserKey</value>
-  </data>
-  <data name="&gt;&gt;txtVgymeUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtVgymeUserKey.Parent" xml:space="preserve">
-    <value>tpVgyme</value>
-  </data>
-  <data name="&gt;&gt;txtVgymeUserKey.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lvlVgymeUserKey.Name" xml:space="preserve">
-    <value>lvlVgymeUserKey</value>
-  </data>
-  <data name="&gt;&gt;lvlVgymeUserKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvlVgymeUserKey.Parent" xml:space="preserve">
-    <value>tpVgyme</value>
-  </data>
-  <data name="&gt;&gt;lvlVgymeUserKey.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpVgyme.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpChevereto.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpVgyme.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpChevereto.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpVgyme.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpChevereto.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpVgyme.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+  <data name="tpChevereto.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
   </data>
-  <data name="tpVgyme.Text" xml:space="preserve">
-    <value>vgy.me</value>
+  <data name="tpChevereto.Text" xml:space="preserve">
+    <value>Chevereto</value>
   </data>
-  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
-    <value>tpVgyme</value>
+  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
+    <value>tpChevereto</value>
   </data>
-  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
-    <value>7</value>
+  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="llVgymeAccountDetailsPage.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -22585,6 +15949,87 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvlVgymeUserKey.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="tpVgyme.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpVgyme.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpVgyme.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpVgyme.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="tpVgyme.Text" xml:space="preserve">
+    <value>vgy.me</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
+    <value>tpVgyme</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tcImageUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcImageUploaders.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>780, 480</value>
+  </data>
+  <data name="tcImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcImageUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
+    <value>tpImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpImageUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
+  </data>
+  <data name="tpImageUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpImageUploaders.Text" xml:space="preserve">
+    <value>Image uploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImageUploaders.Name" xml:space="preserve">
+    <value>tpImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImageUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpImageUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImageUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="tcUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -218,6 +218,237 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;mbCustomUploaderDestinationType.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
+    <value>tcOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
+    <value>tpOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpOtherUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
+  </data>
+  <data name="tpOtherUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpOtherUploaders.Text" xml:space="preserve">
+    <value>Other uploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOtherUploaders.Name" xml:space="preserve">
+    <value>tpOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOtherUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOtherUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOtherUploaders.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
+    <value>tcOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
+    <value>tcOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tcOtherUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcOtherUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
+    <value>tcOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
+    <value>tpOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterNameUpdate.Name" xml:space="preserve">
+    <value>btnTwitterNameUpdate</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterNameUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterNameUpdate.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterNameUpdate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lbTwitterAccounts.Name" xml:space="preserve">
+    <value>lbTwitterAccounts</value>
+  </data>
+  <data name="&gt;&gt;lbTwitterAccounts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbTwitterAccounts.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;lbTwitterAccounts.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDefaultMessage.Name" xml:space="preserve">
+    <value>lblTwitterDefaultMessage</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDefaultMessage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDefaultMessage.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDefaultMessage.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDefaultMessage.Name" xml:space="preserve">
+    <value>txtTwitterDefaultMessage</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDefaultMessage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDefaultMessage.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDefaultMessage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbTwitterSkipMessageBox.Name" xml:space="preserve">
+    <value>cbTwitterSkipMessageBox</value>
+  </data>
+  <data name="&gt;&gt;cbTwitterSkipMessageBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbTwitterSkipMessageBox.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;cbTwitterSkipMessageBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;oauthTwitter.Name" xml:space="preserve">
+    <value>oauthTwitter</value>
+  </data>
+  <data name="&gt;&gt;oauthTwitter.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauthTwitter.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;oauthTwitter.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDescription.Name" xml:space="preserve">
+    <value>txtTwitterDescription</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDescription.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;txtTwitterDescription.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDescription.Name" xml:space="preserve">
+    <value>lblTwitterDescription</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDescription.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;lblTwitterDescription.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterRemove.Name" xml:space="preserve">
+    <value>btnTwitterRemove</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterRemove.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterRemove.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterAdd.Name" xml:space="preserve">
+    <value>btnTwitterAdd</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterAdd.Parent" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;btnTwitterAdd.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="tpTwitter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTwitter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpTwitter.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpTwitter.Text" xml:space="preserve">
+    <value>Twitter</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
+    <value>tpTwitter</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
+    <value>tcOtherUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="btnTwitterNameUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -485,29 +716,296 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;btnTwitterAdd.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="tpTwitter.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Name" xml:space="preserve">
+    <value>btnCustomUploaderURLSharingServiceTest</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLSharingServiceTest.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Name" xml:space="preserve">
+    <value>cbCustomUploaderURLSharingService</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLSharingService.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Name" xml:space="preserve">
+    <value>lblCustomUploaderURLSharingService</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLSharingService.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderExamples.Name" xml:space="preserve">
+    <value>btnCustomUploaderExamples</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderExamples.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderExamples.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderExamples.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHelp.Name" xml:space="preserve">
+    <value>btnCustomUploaderHelp</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHelp.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHelp.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderImageUploader.Name" xml:space="preserve">
+    <value>lblCustomUploaderImageUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderImageUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderImageUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderImageUploader.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Name" xml:space="preserve">
+    <value>btnCustomUploaderFileUploaderTest</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderFileUploaderTest.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileUploader.Name" xml:space="preserve">
+    <value>lblCustomUploaderFileUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileUploader.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Name" xml:space="preserve">
+    <value>btnCustomUploaderImageUploaderTest</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderImageUploaderTest.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTestResult.Name" xml:space="preserve">
+    <value>lblCustomUploaderTestResult</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTestResult.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTestResult.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTestResult.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderFileUploader.Name" xml:space="preserve">
+    <value>cbCustomUploaderFileUploader</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderFileUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderFileUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderFileUploader.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Name" xml:space="preserve">
+    <value>btnCustomUploaderShowLastResponse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderShowLastResponse.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLShortener.Name" xml:space="preserve">
+    <value>cbCustomUploaderURLShortener</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLShortener.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLShortener.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderURLShortener.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTextUploader.Name" xml:space="preserve">
+    <value>lblCustomUploaderTextUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTextUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTextUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderTextUploader.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Name" xml:space="preserve">
+    <value>btnCustomUploaderURLShortenerTest</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderURLShortenerTest.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderTextUploader.Name" xml:space="preserve">
+    <value>cbCustomUploaderTextUploader</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderTextUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderTextUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderTextUploader.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLShortener.Name" xml:space="preserve">
+    <value>lblCustomUploaderURLShortener</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLShortener.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLShortener.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURLShortener.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Name" xml:space="preserve">
+    <value>btnCustomUploaderTextUploaderTest</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderTextUploaderTest.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderImageUploader.Name" xml:space="preserve">
+    <value>cbCustomUploaderImageUploader</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderImageUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderImageUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderImageUploader.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderLog.Name" xml:space="preserve">
+    <value>txtCustomUploaderLog</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderLog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderLog.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderLog.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="tpCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpTwitter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="tpCustomUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpTwitter.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
   </data>
-  <data name="tpTwitter.Text" xml:space="preserve">
-    <value>Twitter</value>
+  <data name="tpCustomUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;tpTwitter.Name" xml:space="preserve">
-    <value>tpTwitter</value>
+  <data name="tpCustomUploaders.Text" xml:space="preserve">
+    <value>Custom uploaders</value>
   </data>
-  <data name="&gt;&gt;tpTwitter.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpTwitter.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
     <value>tcOtherUploaders</value>
   </data>
-  <data name="&gt;&gt;tpTwitter.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnCustomUploaderURLSharingServiceTest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -587,6 +1085,243 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   <data name="&gt;&gt;lblCustomUploaderURLSharingService.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="&gt;&gt;lblCustomUploaderName.Name" xml:space="preserve">
+    <value>lblCustomUploaderName</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderName.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderName.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderRequestType.Name" xml:space="preserve">
+    <value>cbCustomUploaderRequestType</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderRequestType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderRequestType.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderRequestType.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURL.Name" xml:space="preserve">
+    <value>lblCustomUploaderURL</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderFileForm.Name" xml:space="preserve">
+    <value>txtCustomUploaderFileForm</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderFileForm.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderFileForm.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderFileForm.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestType.Name" xml:space="preserve">
+    <value>lblCustomUploaderRequestType</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestType.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestType.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileForm.Name" xml:space="preserve">
+    <value>lblCustomUploaderFileForm</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileForm.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileForm.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderFileForm.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderName.Name" xml:space="preserve">
+    <value>txtCustomUploaderName</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderName.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderName.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Name" xml:space="preserve">
+    <value>lblCustomUploaderThumbnailURL</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderThumbnailURL.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRequestURL.Name" xml:space="preserve">
+    <value>txtCustomUploaderRequestURL</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRequestURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRequestURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRequestURL.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderURL.Name" xml:space="preserve">
+    <value>txtCustomUploaderURL</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderURL.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderResponseType.Name" xml:space="preserve">
+    <value>cbCustomUploaderResponseType</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderResponseType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderResponseType.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;cbCustomUploaderResponseType.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Name" xml:space="preserve">
+    <value>txtCustomUploaderThumbnailURL</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderThumbnailURL.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Name" xml:space="preserve">
+    <value>txtCustomUploaderDeletionURL</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderDeletionURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestURL.Name" xml:space="preserve">
+    <value>lblCustomUploaderRequestURL</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderRequestURL.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderResponseType.Name" xml:space="preserve">
+    <value>lblCustomUploaderResponseType</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderResponseType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderResponseType.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderResponseType.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Name" xml:space="preserve">
+    <value>lblCustomUploaderDeletionURL</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderDeletionURL.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="pCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
+    <value>272, 8</value>
+  </data>
+  <data name="pCustomUploader.Size" type="System.Drawing.Size, System.Drawing">
+    <value>528, 432</value>
+  </data>
+  <data name="pCustomUploader.TabIndex" type="System.Int32, mscorlib">
+    <value>37</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="lblCustomUploaderName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -637,6 +1372,150 @@ For example, if your bucket is called bucket.example.com then URL will be http:/
   </data>
   <data name="&gt;&gt;cbCustomUploaderRequestType.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 48</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 184</value>
+  </data>
+  <data name="tcCustomUploaderResponseParse.TabIndex" type="System.Int32, mscorlib">
+    <value>36</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Name" xml:space="preserve">
+    <value>btnCustomUploaderJsonAddSyntax</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.Parent" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderJsonAddSyntax.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Name" xml:space="preserve">
+    <value>btnCustomUploadJsonPathHelp</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.Parent" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadJsonPathHelp.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Name" xml:space="preserve">
+    <value>lblCustomUploaderJsonPathExample</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.Parent" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPathExample.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPath.Name" xml:space="preserve">
+    <value>lblCustomUploaderJsonPath</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPath.Parent" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderJsonPath.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderJsonPath.Name" xml:space="preserve">
+    <value>txtCustomUploaderJsonPath</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderJsonPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderJsonPath.Parent" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderJsonPath.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpCustomUploaderJsonParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCustomUploaderJsonParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCustomUploaderJsonParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 158</value>
+  </data>
+  <data name="tpCustomUploaderJsonParse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpCustomUploaderJsonParse.Text" xml:space="preserve">
+    <value>JSON</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderJsonParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
+    <value>tcCustomUploaderResponseParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCustomUploaderJsonAddSyntax.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -776,32 +1655,92 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderJsonPath.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpCustomUploaderJsonParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Name" xml:space="preserve">
+    <value>btnCustomUploaderXmlSyntaxAdd</value>
   </data>
-  <data name="tpCustomUploaderJsonParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpCustomUploaderJsonParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 158</value>
+  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.Parent" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
   </data>
-  <data name="tpCustomUploaderJsonParse.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnCustomUploaderXmlSyntaxAdd.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Name" xml:space="preserve">
+    <value>btnCustomUploaderXPathHelp</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderXPathHelp.Parent" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderXPathHelp.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpCustomUploaderJsonParse.Text" xml:space="preserve">
-    <value>JSON</value>
+  <data name="&gt;&gt;lblCustomUploaderXPathExample.Name" xml:space="preserve">
+    <value>lblCustomUploaderXPathExample</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderJsonParse</value>
+  <data name="&gt;&gt;lblCustomUploaderXPathExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblCustomUploaderXPathExample.Parent" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderXPathExample.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderXPath.Name" xml:space="preserve">
+    <value>lblCustomUploaderXPath</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderXPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderXPath.Parent" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;lblCustomUploaderXPath.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderXPath.Name" xml:space="preserve">
+    <value>txtCustomUploaderXPath</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderXPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderXPath.Parent" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderXPath.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpCustomUploaderXmlParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCustomUploaderXmlParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCustomUploaderXmlParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 158</value>
+  </data>
+  <data name="tpCustomUploaderXmlParse.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpCustomUploaderXmlParse.Text" xml:space="preserve">
+    <value>XML</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderXmlParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
     <value>tcCustomUploaderResponseParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderJsonParse.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnCustomUploaderXmlSyntaxAdd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -941,32 +1880,116 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderXPath.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Name" xml:space="preserve">
+    <value>btnCustomUploaderRegexHelp</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 158</value>
+  <data name="&gt;&gt;btnCustomUploaderRegexHelp.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnCustomUploaderRegexHelp.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Name" xml:space="preserve">
+    <value>btnCustomUploaderRegexAddSyntax</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexAddSyntax.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRegexp.Name" xml:space="preserve">
+    <value>txtCustomUploaderRegexp</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRegexp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRegexp.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderRegexp.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpCustomUploaderXmlParse.Text" xml:space="preserve">
-    <value>XML</value>
+  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Name" xml:space="preserve">
+    <value>btnCustomUploaderRegexpUpdate</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderXmlParse</value>
+  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpUpdate.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Name" xml:space="preserve">
+    <value>btnCustomUploaderRegexpAdd</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpAdd.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Name" xml:space="preserve">
+    <value>btnCustomUploaderRegexpRemove</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRegexpRemove.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderRegexps.Name" xml:space="preserve">
+    <value>lvCustomUploaderRegexps</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderRegexps.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderRegexps.Parent" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderRegexps.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 158</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpCustomUploaderRegexParse.Text" xml:space="preserve">
+    <value>Regex</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
+    <value>tpCustomUploaderRegexParse</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
     <value>tcCustomUploaderResponseParse</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderXmlParse.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="btnCustomUploaderRegexHelp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1124,9 +2147,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderRegexpRemove.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="lvRegexpsColumn.Width" type="System.Int32, mscorlib">
-    <value>227</value>
-  </data>
   <data name="lvCustomUploaderRegexps.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -1148,53 +2168,8 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderRegexps.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tpCustomUploaderRegexParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCustomUploaderRegexParse.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCustomUploaderRegexParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 158</value>
-  </data>
-  <data name="tpCustomUploaderRegexParse.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpCustomUploaderRegexParse.Text" xml:space="preserve">
-    <value>Regex</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Name" xml:space="preserve">
-    <value>tpCustomUploaderRegexParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.Parent" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderRegexParse.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>264, 48</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 184</value>
-  </data>
-  <data name="tcCustomUploaderResponseParse.TabIndex" type="System.Int32, mscorlib">
-    <value>36</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Name" xml:space="preserve">
-    <value>tcCustomUploaderResponseParse</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderResponseParse.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="lvRegexpsColumn.Width" type="System.Int32, mscorlib">
+    <value>227</value>
   </data>
   <data name="lblCustomUploaderURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1225,6 +2200,150 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblCustomUploaderURL.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tcCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 186</value>
+  </data>
+  <data name="tcCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 240</value>
+  </data>
+  <data name="tcCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>pCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Name" xml:space="preserve">
+    <value>btnCustomUploaderArgUpdate</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgUpdate.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgUpdate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgName.Name" xml:space="preserve">
+    <value>txtCustomUploaderArgName</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgName.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgName.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgValue.Name" xml:space="preserve">
+    <value>txtCustomUploaderArgValue</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgValue.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderArgValue.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgAdd.Name" xml:space="preserve">
+    <value>btnCustomUploaderArgAdd</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgAdd.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgAdd.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgRemove.Name" xml:space="preserve">
+    <value>btnCustomUploaderArgRemove</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgRemove.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderArgRemove.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderArguments.Name" xml:space="preserve">
+    <value>lvCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderArguments.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCustomUploaderArguments.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 214</value>
+  </data>
+  <data name="tpCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpCustomUploaderArguments.Text" xml:space="preserve">
+    <value>Arguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
+    <value>tpCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
+    <value>tcCustomUploaderArguments</value>
+  </data>
+  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCustomUploaderArgUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1349,18 +2468,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderArgRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="chCustomUploaderArgumentsName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="chCustomUploaderArgumentsName.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
-  <data name="chCustomUploaderArgumentsValue.Text" xml:space="preserve">
-    <value>Value</value>
-  </data>
-  <data name="chCustomUploaderArgumentsValue.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
   <data name="lvCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -1382,32 +2489,116 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderArguments.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="chCustomUploaderArgumentsName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="chCustomUploaderArgumentsName.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
+  <data name="chCustomUploaderArgumentsValue.Text" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="chCustomUploaderArgumentsValue.Width" type="System.Int32, mscorlib">
+    <value>114</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Name" xml:space="preserve">
+    <value>btnCustomUploaderHeaderUpdate</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderUpdate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderName.Name" xml:space="preserve">
+    <value>txtCustomUploaderHeaderName</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderName.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderName.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Name" xml:space="preserve">
+    <value>txtCustomUploaderHeaderValue</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderValue.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;txtCustomUploaderHeaderValue.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Name" xml:space="preserve">
+    <value>btnCustomUploaderHeaderAdd</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderAdd.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Name" xml:space="preserve">
+    <value>btnCustomUploaderHeaderRemove</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderHeaderRemove.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderHeaders.Name" xml:space="preserve">
+    <value>lvCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderHeaders.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderHeaders.Parent" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
+  </data>
+  <data name="&gt;&gt;lvCustomUploaderHeaders.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCustomUploaderArguments.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpCustomUploaderHeaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpCustomUploaderHeaders.Size" type="System.Drawing.Size, System.Drawing">
     <value>248, 214</value>
   </data>
-  <data name="tpCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpCustomUploaderHeaders.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpCustomUploaderArguments.Text" xml:space="preserve">
-    <value>Arguments</value>
+  <data name="tpCustomUploaderHeaders.Text" xml:space="preserve">
+    <value>Headers</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tpCustomUploaderArguments</value>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
+    <value>tpCustomUploaderHeaders</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
     <value>tcCustomUploaderArguments</value>
   </data>
-  <data name="&gt;&gt;tpCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnCustomUploaderHeaderUpdate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1532,18 +2723,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderHeaderRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="chCustomUploaderHeadersName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="chCustomUploaderHeadersName.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
-  <data name="chCustomUploaderHeadersValue.Text" xml:space="preserve">
-    <value>Value</value>
-  </data>
-  <data name="chCustomUploaderHeadersValue.Width" type="System.Int32, mscorlib">
-    <value>114</value>
-  </data>
   <data name="lvCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -1565,53 +2744,17 @@ store.book[0].title</value>
   <data name="&gt;&gt;lvCustomUploaderHeaders.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="chCustomUploaderHeadersName.Text" xml:space="preserve">
+    <value>Name</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="chCustomUploaderHeadersName.Width" type="System.Int32, mscorlib">
+    <value>114</value>
   </data>
-  <data name="tpCustomUploaderHeaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 214</value>
+  <data name="chCustomUploaderHeadersValue.Text" xml:space="preserve">
+    <value>Value</value>
   </data>
-  <data name="tpCustomUploaderHeaders.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpCustomUploaderHeaders.Text" xml:space="preserve">
-    <value>Headers</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Name" xml:space="preserve">
-    <value>tpCustomUploaderHeaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.Parent" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaderHeaders.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tcCustomUploaderArguments.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 186</value>
-  </data>
-  <data name="tcCustomUploaderArguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 240</value>
-  </data>
-  <data name="tcCustomUploaderArguments.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Name" xml:space="preserve">
-    <value>tcCustomUploaderArguments</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.Parent" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;tcCustomUploaderArguments.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="chCustomUploaderHeadersValue.Width" type="System.Int32, mscorlib">
+    <value>114</value>
   </data>
   <data name="txtCustomUploaderFileForm.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 162</value>
@@ -1940,27 +3083,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblCustomUploaderDeletionURL.ZOrder" xml:space="preserve">
     <value>18</value>
   </data>
-  <data name="pCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 8</value>
-  </data>
-  <data name="pCustomUploader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>528, 432</value>
-  </data>
-  <data name="pCustomUploader.TabIndex" type="System.Int32, mscorlib">
-    <value>37</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Name" xml:space="preserve">
-    <value>pCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;pCustomUploader.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="btnCustomUploaderExamples.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -2231,6 +3353,114 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbCustomUploaderURLShortener.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
+  <data name="&gt;&gt;btnCustomUploaderDuplicate.Name" xml:space="preserve">
+    <value>btnCustomUploaderDuplicate</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderDuplicate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderDuplicate.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderDuplicate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadersExportAll.Name" xml:space="preserve">
+    <value>btnCustomUploadersExportAll</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadersExportAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadersExportAll.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploadersExportAll.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Name" xml:space="preserve">
+    <value>btnCustomUploaderClearUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderClearUploaders.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderClearUploaders.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;eiCustomUploaders.Name" xml:space="preserve">
+    <value>eiCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;eiCustomUploaders.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;eiCustomUploaders.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;eiCustomUploaders.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lbCustomUploaderList.Name" xml:space="preserve">
+    <value>lbCustomUploaderList</value>
+  </data>
+  <data name="&gt;&gt;lbCustomUploaderList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbCustomUploaderList.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;lbCustomUploaderList.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRemove.Name" xml:space="preserve">
+    <value>btnCustomUploaderRemove</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRemove.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderRemove.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderAdd.Name" xml:space="preserve">
+    <value>btnCustomUploaderAdd</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderAdd.Parent" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;btnCustomUploaderAdd.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="gbCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="gbCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>248, 344</value>
+  </data>
+  <data name="gbCustomUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbCustomUploaders.Text" xml:space="preserve">
+    <value>Uploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
+    <value>gbCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
+    <value>tpCustomUploaders</value>
+  </data>
+  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
   <data name="btnCustomUploaderDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -2414,30 +3644,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;btnCustomUploaderAdd.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="gbCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="gbCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 344</value>
-  </data>
-  <data name="gbCustomUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbCustomUploaders.Text" xml:space="preserve">
-    <value>Uploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Name" xml:space="preserve">
-    <value>gbCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.Parent" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;gbCustomUploaders.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="lblCustomUploaderTextUploader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2618,83 +3824,191 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtCustomUploaderLog.ZOrder" xml:space="preserve">
     <value>21</value>
   </data>
-  <data name="tpCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
+    <value>tcURLShorteners</value>
   </data>
-  <data name="tpCustomUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
-  </data>
-  <data name="tpCustomUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="tpCustomUploaders.Text" xml:space="preserve">
-    <value>Custom uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Name" xml:space="preserve">
-    <value>tpCustomUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.Parent" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpCustomUploaders.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tcOtherUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
-  </data>
-  <data name="tcOtherUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Name" xml:space="preserve">
-    <value>tcOtherUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcOtherUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcOtherUploaders.Parent" xml:space="preserve">
-    <value>tpOtherUploaders</value>
+  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
+    <value>tpURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tcOtherUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpOtherUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpOtherUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpURLShorteners.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpOtherUploaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
     <value>986, 569</value>
   </data>
-  <data name="tpOtherUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="tpURLShorteners.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpOtherUploaders.Text" xml:space="preserve">
-    <value>Other uploaders</value>
+  <data name="tpURLShorteners.Text" xml:space="preserve">
+    <value>URL shorteners</value>
   </data>
-  <data name="&gt;&gt;tpOtherUploaders.Name" xml:space="preserve">
-    <value>tpOtherUploaders</value>
+  <data name="&gt;&gt;tpURLShorteners.Name" xml:space="preserve">
+    <value>tpURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpOtherUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpOtherUploaders.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.Parent" xml:space="preserve">
     <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpOtherUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpURLShorteners.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
+    <value>tpBitly</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="tcURLShorteners.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcURLShorteners.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
+    <value>tpURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtBitlyDomain.Name" xml:space="preserve">
+    <value>txtBitlyDomain</value>
+  </data>
+  <data name="&gt;&gt;txtBitlyDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtBitlyDomain.Parent" xml:space="preserve">
+    <value>tpBitly</value>
+  </data>
+  <data name="&gt;&gt;txtBitlyDomain.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblBitlyDomain.Name" xml:space="preserve">
+    <value>lblBitlyDomain</value>
+  </data>
+  <data name="&gt;&gt;lblBitlyDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBitlyDomain.Parent" xml:space="preserve">
+    <value>tpBitly</value>
+  </data>
+  <data name="&gt;&gt;lblBitlyDomain.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;oauth2Bitly.Name" xml:space="preserve">
+    <value>oauth2Bitly</value>
+  </data>
+  <data name="&gt;&gt;oauth2Bitly.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Bitly.Parent" xml:space="preserve">
+    <value>tpBitly</value>
+  </data>
+  <data name="&gt;&gt;oauth2Bitly.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpBitly.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpBitly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpBitly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpBitly.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpBitly.Text" xml:space="preserve">
+    <value>bit.ly</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
+    <value>tpBitly</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
+    <value>tcURLShorteners</value>
+  </data>
+  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="txtBitlyDomain.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 248</value>
@@ -2768,32 +4082,140 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Bitly.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpBitly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;txtYourlsPassword.Name" xml:space="preserve">
+    <value>txtYourlsPassword</value>
   </data>
-  <data name="tpBitly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;txtYourlsPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpBitly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="&gt;&gt;txtYourlsPassword.Parent" xml:space="preserve">
+    <value>tpYourls</value>
   </data>
-  <data name="tpBitly.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;txtYourlsPassword.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsUsername.Name" xml:space="preserve">
+    <value>txtYourlsUsername</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsUsername.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsUsername.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpBitly.Text" xml:space="preserve">
-    <value>bit.ly</value>
+  <data name="&gt;&gt;txtYourlsSignature.Name" xml:space="preserve">
+    <value>txtYourlsSignature</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Name" xml:space="preserve">
-    <value>tpBitly</value>
+  <data name="&gt;&gt;txtYourlsSignature.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Type" xml:space="preserve">
+  <data name="&gt;&gt;txtYourlsSignature.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsSignature.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsNote.Name" xml:space="preserve">
+    <value>lblYourlsNote</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsNote.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsNote.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsNote.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsPassword.Name" xml:space="preserve">
+    <value>lblYourlsPassword</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsPassword.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsPassword.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsUsername.Name" xml:space="preserve">
+    <value>lblYourlsUsername</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsUsername.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsUsername.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsSignature.Name" xml:space="preserve">
+    <value>lblYourlsSignature</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsSignature.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsSignature.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsSignature.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsAPIURL.Name" xml:space="preserve">
+    <value>txtYourlsAPIURL</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsAPIURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsAPIURL.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;txtYourlsAPIURL.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsAPIURL.Name" xml:space="preserve">
+    <value>lblYourlsAPIURL</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsAPIURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsAPIURL.Parent" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;lblYourlsAPIURL.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tpYourls.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpYourls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpYourls.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
+  </data>
+  <data name="tpYourls.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpYourls.Text" xml:space="preserve">
+    <value>YOURLS</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
+    <value>tpYourls</value>
+  </data>
+  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpBitly.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpBitly.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="txtYourlsPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 200</value>
@@ -3029,32 +4451,92 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblYourlsAPIURL.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpYourls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;llAdflyLink.Name" xml:space="preserve">
+    <value>llAdflyLink</value>
   </data>
-  <data name="tpYourls.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;llAdflyLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpYourls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="&gt;&gt;llAdflyLink.Parent" xml:space="preserve">
+    <value>tpAdFly</value>
   </data>
-  <data name="tpYourls.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;llAdflyLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtAdflyAPIUID.Name" xml:space="preserve">
+    <value>txtAdflyAPIUID</value>
+  </data>
+  <data name="&gt;&gt;txtAdflyAPIUID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAdflyAPIUID.Parent" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;txtAdflyAPIUID.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIUID.Name" xml:space="preserve">
+    <value>lblAdflyAPIUID</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIUID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIUID.Parent" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIUID.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpYourls.Text" xml:space="preserve">
-    <value>YOURLS</value>
+  <data name="&gt;&gt;txtAdflyAPIKEY.Name" xml:space="preserve">
+    <value>txtAdflyAPIKEY</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Name" xml:space="preserve">
-    <value>tpYourls</value>
+  <data name="&gt;&gt;txtAdflyAPIKEY.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Type" xml:space="preserve">
+  <data name="&gt;&gt;txtAdflyAPIKEY.Parent" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;txtAdflyAPIKEY.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIKEY.Name" xml:space="preserve">
+    <value>lblAdflyAPIKEY</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIKEY.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIKEY.Parent" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;lblAdflyAPIKEY.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpAdFly.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpAdFly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAdFly.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
+  </data>
+  <data name="tpAdFly.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpAdFly.Text" xml:space="preserve">
+    <value>adf.ly</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
+    <value>tpAdFly</value>
+  </data>
+  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpYourls.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpYourls.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="llAdflyLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3188,32 +4670,101 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblAdflyAPIKEY.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpAdFly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;cbPolrUseAPIv1.Name" xml:space="preserve">
+    <value>cbPolrUseAPIv1</value>
   </data>
-  <data name="tpAdFly.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;cbPolrUseAPIv1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpAdFly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="&gt;&gt;cbPolrUseAPIv1.Parent" xml:space="preserve">
+    <value>tpPolr</value>
   </data>
-  <data name="tpAdFly.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cbPolrUseAPIv1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbPolrIsSecret.Name" xml:space="preserve">
+    <value>cbPolrIsSecret</value>
+  </data>
+  <data name="&gt;&gt;cbPolrIsSecret.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPolrIsSecret.Parent" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;cbPolrIsSecret.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtPolrAPIKey.Name" xml:space="preserve">
+    <value>txtPolrAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtPolrAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPolrAPIKey.Parent" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;txtPolrAPIKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIKey.Name" xml:space="preserve">
+    <value>lblPolrAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIKey.Parent" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIKey.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tpAdFly.Text" xml:space="preserve">
-    <value>adf.ly</value>
+  <data name="&gt;&gt;txtPolrAPIHostname.Name" xml:space="preserve">
+    <value>txtPolrAPIHostname</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Name" xml:space="preserve">
-    <value>tpAdFly</value>
+  <data name="&gt;&gt;txtPolrAPIHostname.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Type" xml:space="preserve">
+  <data name="&gt;&gt;txtPolrAPIHostname.Parent" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;txtPolrAPIHostname.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIHostname.Name" xml:space="preserve">
+    <value>lblPolrAPIHostname</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIHostname.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIHostname.Parent" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;lblPolrAPIHostname.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpPolr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpPolr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
+  </data>
+  <data name="tpPolr.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpPolr.Text" xml:space="preserve">
+    <value>Polr</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
+    <value>tpPolr</value>
+  </data>
+  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpAdFly.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="cbPolrUseAPIv1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3377,29 +4928,92 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblPolrAPIHostname.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpPolr.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;cbFirebaseIsShort.Name" xml:space="preserve">
+    <value>cbFirebaseIsShort</value>
+  </data>
+  <data name="&gt;&gt;cbFirebaseIsShort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFirebaseIsShort.Parent" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;cbFirebaseIsShort.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseDomain.Name" xml:space="preserve">
+    <value>lblFirebaseDomain</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseDomain.Parent" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseDomain.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseDomain.Name" xml:space="preserve">
+    <value>txtFirebaseDomain</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseDomain.Parent" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseDomain.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseWebAPIKey.Name" xml:space="preserve">
+    <value>txtFirebaseWebAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseWebAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseWebAPIKey.Parent" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;txtFirebaseWebAPIKey.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseWebAPIKey.Name" xml:space="preserve">
+    <value>lblFirebaseWebAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseWebAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseWebAPIKey.Parent" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
+  </data>
+  <data name="&gt;&gt;lblFirebaseWebAPIKey.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpFirebaseDynamicLinks.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPolr.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpFirebaseDynamicLinks.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpFirebaseDynamicLinks.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpPolr.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="tpFirebaseDynamicLinks.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
   </data>
-  <data name="tpPolr.Text" xml:space="preserve">
-    <value>Polr</value>
+  <data name="tpFirebaseDynamicLinks.Text" xml:space="preserve">
+    <value>Firebase Dynamic Links</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Name" xml:space="preserve">
-    <value>tpPolr</value>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
+    <value>tpFirebaseDynamicLinks</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPolr.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
     <value>tcURLShorteners</value>
   </data>
-  <data name="&gt;&gt;tpPolr.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="cbFirebaseIsShort.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3533,83 +5147,4211 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblFirebaseWebAPIKey.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
+    <value>gbFTPAccount</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
+  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
+    <value>tpFTP</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="tpFirebaseDynamicLinks.Text" xml:space="preserve">
-    <value>Firebase Dynamic Links</value>
+  <data name="&gt;&gt;btnFTPDuplicate.Name" xml:space="preserve">
+    <value>btnFTPDuplicate</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Name" xml:space="preserve">
-    <value>tpFirebaseDynamicLinks</value>
+  <data name="&gt;&gt;btnFTPDuplicate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;btnFTPDuplicate.Parent" xml:space="preserve">
+    <value>tpFTP</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.Parent" xml:space="preserve">
-    <value>tcURLShorteners</value>
+  <data name="&gt;&gt;btnFTPDuplicate.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tpFirebaseDynamicLinks.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;btnFTPRemove.Name" xml:space="preserve">
+    <value>btnFTPRemove</value>
+  </data>
+  <data name="&gt;&gt;btnFTPRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFTPRemove.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;btnFTPRemove.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnFTPAdd.Name" xml:space="preserve">
+    <value>btnFTPAdd</value>
+  </data>
+  <data name="&gt;&gt;btnFTPAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFTPAdd.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;btnFTPAdd.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAccounts.Name" xml:space="preserve">
+    <value>cbFTPAccounts</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAccounts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAccounts.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAccounts.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tcURLShorteners.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="&gt;&gt;lblFTPAccounts.Name" xml:space="preserve">
+    <value>lblFTPAccounts</value>
   </data>
-  <data name="tcURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+  <data name="&gt;&gt;lblFTPAccounts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tcURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
+  <data name="&gt;&gt;lblFTPAccounts.Parent" xml:space="preserve">
+    <value>tpFTP</value>
   </data>
-  <data name="tcURLShorteners.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;lblFTPAccounts.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Name" xml:space="preserve">
-    <value>tcURLShorteners</value>
+  <data name="&gt;&gt;lblFTPFile.Name" xml:space="preserve">
+    <value>lblFTPFile</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblFTPFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.Parent" xml:space="preserve">
-    <value>tpURLShorteners</value>
+  <data name="&gt;&gt;lblFTPFile.Parent" xml:space="preserve">
+    <value>tpFTP</value>
   </data>
-  <data name="&gt;&gt;tcURLShorteners.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;lblFTPFile.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="tpURLShorteners.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;lblFTPText.Name" xml:space="preserve">
+    <value>lblFTPText</value>
   </data>
-  <data name="tpURLShorteners.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="&gt;&gt;lblFTPText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPText.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;lblFTPText.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblFTPImage.Name" xml:space="preserve">
+    <value>lblFTPImage</value>
+  </data>
+  <data name="&gt;&gt;lblFTPImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPImage.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;lblFTPImage.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbFTPImage.Name" xml:space="preserve">
+    <value>cbFTPImage</value>
+  </data>
+  <data name="&gt;&gt;cbFTPImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPImage.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;cbFTPImage.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cbFTPFile.Name" xml:space="preserve">
+    <value>cbFTPFile</value>
+  </data>
+  <data name="&gt;&gt;cbFTPFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPFile.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;cbFTPFile.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;cbFTPText.Name" xml:space="preserve">
+    <value>cbFTPText</value>
+  </data>
+  <data name="&gt;&gt;cbFTPText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPText.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;cbFTPText.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="tpFTP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpFTP.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
+  <data name="tpFTP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 519</value>
   </data>
-  <data name="tpURLShorteners.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpFTP.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpURLShorteners.Text" xml:space="preserve">
-    <value>URL shorteners</value>
+  <data name="tpFTP.Text" xml:space="preserve">
+    <value>FTP / FTPS / SFTP</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Name" xml:space="preserve">
-    <value>tpURLShorteners</value>
+  <data name="&gt;&gt;tpFTP.Name" xml:space="preserve">
+    <value>tpFTP</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFTP.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFTP.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxUseDirectLink.Name" xml:space="preserve">
+    <value>cbDropboxUseDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxUseDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxUseDirectLink.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxUseDirectLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Name" xml:space="preserve">
+    <value>cbDropboxAutoCreateShareableLink</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;cbDropboxAutoCreateShareableLink.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pbDropboxLogo.Name" xml:space="preserve">
+    <value>pbDropboxLogo</value>
+  </data>
+  <data name="&gt;&gt;pbDropboxLogo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pbDropboxLogo.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;pbDropboxLogo.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblDropboxPath.Name" xml:space="preserve">
+    <value>lblDropboxPath</value>
+  </data>
+  <data name="&gt;&gt;lblDropboxPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDropboxPath.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;lblDropboxPath.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtDropboxPath.Name" xml:space="preserve">
+    <value>txtDropboxPath</value>
+  </data>
+  <data name="&gt;&gt;txtDropboxPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtDropboxPath.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;txtDropboxPath.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;oauth2Dropbox.Name" xml:space="preserve">
+    <value>oauth2Dropbox</value>
+  </data>
+  <data name="&gt;&gt;oauth2Dropbox.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Dropbox.Parent" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;oauth2Dropbox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpDropbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpDropbox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpDropbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpDropbox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpDropbox.Text" xml:space="preserve">
+    <value>Dropbox</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Name" xml:space="preserve">
+    <value>tpDropbox</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpDropbox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tvOneDrive.Name" xml:space="preserve">
+    <value>tvOneDrive</value>
+  </data>
+  <data name="&gt;&gt;tvOneDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tvOneDrive.Parent" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;tvOneDrive.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblOneDriveFolderID.Name" xml:space="preserve">
+    <value>lblOneDriveFolderID</value>
+  </data>
+  <data name="&gt;&gt;lblOneDriveFolderID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOneDriveFolderID.Parent" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;lblOneDriveFolderID.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Name" xml:space="preserve">
+    <value>cbOneDriveCreateShareableLink</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveCreateShareableLink.Parent" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveCreateShareableLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;oAuth2OneDrive.Name" xml:space="preserve">
+    <value>oAuth2OneDrive</value>
+  </data>
+  <data name="&gt;&gt;oAuth2OneDrive.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oAuth2OneDrive.Parent" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;oAuth2OneDrive.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpOneDrive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpOneDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOneDrive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpOneDrive.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="tpOneDrive.Text" xml:space="preserve">
+    <value>OneDrive</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Name" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Name" xml:space="preserve">
+    <value>cbGoogleDriveDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveDirectLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveUseFolder.Name" xml:space="preserve">
+    <value>cbGoogleDriveUseFolder</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveUseFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveUseFolder.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveUseFolder.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleDriveFolderID.Name" xml:space="preserve">
+    <value>txtGoogleDriveFolderID</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleDriveFolderID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleDriveFolderID.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleDriveFolderID.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleDriveFolderID.Name" xml:space="preserve">
+    <value>lblGoogleDriveFolderID</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleDriveFolderID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleDriveFolderID.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleDriveFolderID.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lvGoogleDriveFoldersList.Name" xml:space="preserve">
+    <value>lvGoogleDriveFoldersList</value>
+  </data>
+  <data name="&gt;&gt;lvGoogleDriveFoldersList.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvGoogleDriveFoldersList.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;lvGoogleDriveFoldersList.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Name" xml:space="preserve">
+    <value>btnGoogleDriveRefreshFolders</value>
+  </data>
+  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;btnGoogleDriveRefreshFolders.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveIsPublic.Name" xml:space="preserve">
+    <value>cbGoogleDriveIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveIsPublic.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveIsPublic.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleDrive.Name" xml:space="preserve">
+    <value>oauth2GoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleDrive.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleDrive.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleDrive.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGoogleDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGoogleDrive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGoogleDrive.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpGoogleDrive.Text" xml:space="preserve">
+    <value>Google Drive</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Name" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleDrive.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;pbPuush.Name" xml:space="preserve">
+    <value>pbPuush</value>
+  </data>
+  <data name="&gt;&gt;pbPuush.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pbPuush.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;pbPuush.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblPuushAPIKey.Name" xml:space="preserve">
+    <value>lblPuushAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblPuushAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPuushAPIKey.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;lblPuushAPIKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtPuushAPIKey.Name" xml:space="preserve">
+    <value>txtPuushAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtPuushAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPuushAPIKey.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;txtPuushAPIKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;llPuushForgottenPassword.Name" xml:space="preserve">
+    <value>llPuushForgottenPassword</value>
+  </data>
+  <data name="&gt;&gt;llPuushForgottenPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;llPuushForgottenPassword.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;llPuushForgottenPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnPuushLogin.Name" xml:space="preserve">
+    <value>btnPuushLogin</value>
+  </data>
+  <data name="&gt;&gt;btnPuushLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPuushLogin.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;btnPuushLogin.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtPuushPassword.Name" xml:space="preserve">
+    <value>txtPuushPassword</value>
+  </data>
+  <data name="&gt;&gt;txtPuushPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPuushPassword.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;txtPuushPassword.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtPuushEmail.Name" xml:space="preserve">
+    <value>txtPuushEmail</value>
+  </data>
+  <data name="&gt;&gt;txtPuushEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPuushEmail.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;txtPuushEmail.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblPuushEmail.Name" xml:space="preserve">
+    <value>lblPuushEmail</value>
+  </data>
+  <data name="&gt;&gt;lblPuushEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPuushEmail.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;lblPuushEmail.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblPuushPassword.Name" xml:space="preserve">
+    <value>lblPuushPassword</value>
+  </data>
+  <data name="&gt;&gt;lblPuushPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPuushPassword.Parent" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;lblPuushPassword.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tpPuush.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPuush.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPuush.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPuush.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="tpPuush.Text" xml:space="preserve">
+    <value>puush</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Name" xml:space="preserve">
+    <value>tpPuush</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPuush.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderTip.Name" xml:space="preserve">
+    <value>lblBoxFolderTip</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderTip.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderTip.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShare.Name" xml:space="preserve">
+    <value>cbBoxShare</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShare.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShare.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShare.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lvBoxFolders.Name" xml:space="preserve">
+    <value>lvBoxFolders</value>
+  </data>
+  <data name="&gt;&gt;lvBoxFolders.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvBoxFolders.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;lvBoxFolders.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderID.Name" xml:space="preserve">
+    <value>lblBoxFolderID</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderID.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;lblBoxFolderID.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnBoxRefreshFolders.Name" xml:space="preserve">
+    <value>btnBoxRefreshFolders</value>
+  </data>
+  <data name="&gt;&gt;btnBoxRefreshFolders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnBoxRefreshFolders.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;btnBoxRefreshFolders.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;oauth2Box.Name" xml:space="preserve">
+    <value>oauth2Box</value>
+  </data>
+  <data name="&gt;&gt;oauth2Box.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Box.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;oauth2Box.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpBox.Text" xml:space="preserve">
+    <value>Box</value>
+  </data>
+  <data name="&gt;&gt;tpBox.Name" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;tpBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpBox.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoint.Name" xml:space="preserve">
+    <value>lblAmazonS3Endpoint</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoint.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoint.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Endpoint.Name" xml:space="preserve">
+    <value>txtAmazonS3Endpoint</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Endpoint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Endpoint.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Endpoint.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Region.Name" xml:space="preserve">
+    <value>lblAmazonS3Region</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Region.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Region.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Region.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Region.Name" xml:space="preserve">
+    <value>txtAmazonS3Region</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Region.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Region.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3Region.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3CustomDomain.Name" xml:space="preserve">
+    <value>txtAmazonS3CustomDomain</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3CustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3CustomDomain.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3CustomDomain.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Name" xml:space="preserve">
+    <value>lblAmazonS3PathPreviewLabel</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreviewLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreview.Name" xml:space="preserve">
+    <value>lblAmazonS3PathPreview</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreview.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreview.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3PathPreview.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Name" xml:space="preserve">
+    <value>btnAmazonS3BucketNameOpen</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3BucketNameOpen.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Name" xml:space="preserve">
+    <value>btnAmazonS3AccessKeyOpen</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3AccessKeyOpen.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3Endpoints.Name" xml:space="preserve">
+    <value>cbAmazonS3Endpoints</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3Endpoints.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3Endpoints.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3Endpoints.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3BucketName.Name" xml:space="preserve">
+    <value>lblAmazonS3BucketName</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3BucketName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3BucketName.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3BucketName.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3BucketName.Name" xml:space="preserve">
+    <value>txtAmazonS3BucketName</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3BucketName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3BucketName.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3BucketName.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoints.Name" xml:space="preserve">
+    <value>lblAmazonS3Endpoints</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoints.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoints.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3Endpoints.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Name" xml:space="preserve">
+    <value>txtAmazonS3ObjectPrefix</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3ObjectPrefix.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Name" xml:space="preserve">
+    <value>lblAmazonS3ObjectPrefix</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3ObjectPrefix.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3SecretKey.Name" xml:space="preserve">
+    <value>txtAmazonS3SecretKey</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3SecretKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3SecretKey.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3SecretKey.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3SecretKey.Name" xml:space="preserve">
+    <value>lblAmazonS3SecretKey</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3SecretKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3SecretKey.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3SecretKey.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3AccessKey.Name" xml:space="preserve">
+    <value>lblAmazonS3AccessKey</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3AccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3AccessKey.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3AccessKey.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3AccessKey.Name" xml:space="preserve">
+    <value>txtAmazonS3AccessKey</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3AccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3AccessKey.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;txtAmazonS3AccessKey.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="tpAmazonS3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpAmazonS3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAmazonS3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpAmazonS3.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="tpAmazonS3.Text" xml:space="preserve">
+    <value>Amazon S3</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Name" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpAmazonS3.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Name" xml:space="preserve">
+    <value>lblGoogleCloudStoragePathPreview</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreview.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Name" xml:space="preserve">
+    <value>lblGoogleCloudStoragePathPreviewLabel</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStoragePathPreviewLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Name" xml:space="preserve">
+    <value>txtGoogleCloudStorageObjectPrefix</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageObjectPrefix.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Name" xml:space="preserve">
+    <value>lblGoogleCloudStorageObjectPrefix</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageObjectPrefix.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Name" xml:space="preserve">
+    <value>lblGoogleCloudStorageDomain</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageDomain.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageDomain.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Name" xml:space="preserve">
+    <value>txtGoogleCloudStorageDomain</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageDomain.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageDomain.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Name" xml:space="preserve">
+    <value>lblGoogleCloudStorageBucket</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageBucket.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;lblGoogleCloudStorageBucket.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Name" xml:space="preserve">
+    <value>txtGoogleCloudStorageBucket</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageBucket.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;txtGoogleCloudStorageBucket.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleCloudStorage.Name" xml:space="preserve">
+    <value>oauth2GoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleCloudStorage.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleCloudStorage.Parent" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;oauth2GoogleCloudStorage.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGoogleCloudStorage.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="tpGoogleCloudStorage.Text" xml:space="preserve">
+    <value>Google Cloud Storage</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Name" xml:space="preserve">
+    <value>tpGoogleCloudStorage</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGoogleCloudStorage.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 299</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>230, 17</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="cbAzureStorageExcludeContainer.Text" xml:space="preserve">
+    <value>Exclude container name from returned URL</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Name" xml:space="preserve">
+    <value>cbAzureStorageExcludeContainer</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageExcludeContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 223</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Name" xml:space="preserve">
+    <value>txtAzureStorageUploadPath</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageUploadPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 207</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblAzureStorageUploadPath.Text" xml:space="preserve">
+    <value>Upload Path:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Name" xml:space="preserve">
+    <value>lblAzureStorageUploadPath</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageUploadPath.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
+    <value>blob.core.windows.net</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
+    <value>blob.core.usgovcloudapi.net</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
+    <value>blob.core.chinacloudapi.cn</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
+    <value>blob.core.cloudapi.de</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 173</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 21</value>
+  </data>
+  <data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>cbAzureStorageEnvironment</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 156</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 13</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="lblAzureStorageEnvironment.Text" xml:space="preserve">
+    <value>Environment:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Name" xml:space="preserve">
+    <value>lblAzureStorageEnvironment</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnAzureStoragePortal.Location" type="System.Drawing.Point, System.Drawing">
+    <value>552, 30</value>
+  </data>
+  <data name="btnAzureStoragePortal.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 24</value>
+  </data>
+  <data name="btnAzureStoragePortal.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="btnAzureStoragePortal.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Name" xml:space="preserve">
+    <value>btnAzureStoragePortal</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;btnAzureStoragePortal.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="txtAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 128</value>
+  </data>
+  <data name="txtAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Name" xml:space="preserve">
+    <value>txtAzureStorageContainer</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageContainer.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lblAzureStorageContainer.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 112</value>
+  </data>
+  <data name="lblAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 13</value>
+  </data>
+  <data name="lblAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblAzureStorageContainer.Text" xml:space="preserve">
+    <value>Container:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Name" xml:space="preserve">
+    <value>lblAzureStorageContainer</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageContainer.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 80</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Name" xml:space="preserve">
+    <value>txtAzureStorageAccessKey</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccessKey.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 64</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 13</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblAzureStorageAccessKey.Text" xml:space="preserve">
+    <value>Access key:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Name" xml:space="preserve">
+    <value>lblAzureStorageAccessKey</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccessKey.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="txtAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 32</value>
+  </data>
+  <data name="txtAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Name" xml:space="preserve">
+    <value>txtAzureStorageAccountName</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageAccountName.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblAzureStorageAccountName.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageAccountName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 16</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 13</value>
+  </data>
+  <data name="lblAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblAzureStorageAccountName.Text" xml:space="preserve">
+    <value>Account name:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Name" xml:space="preserve">
+    <value>lblAzureStorageAccountName</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 273</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>txtAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 257</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
+    <value>Custom Domain:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Name" xml:space="preserve">
+    <value>lblAzureStorageCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAzureStorage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 519</value>
+  </data>
+  <data name="tpAzureStorage.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="tpAzureStorage.Text" xml:space="preserve">
+    <value>Azure Storage</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Name" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpAzureStorage.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Name" xml:space="preserve">
+    <value>cbGfycatIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;cbGfycatIsPublic.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Name" xml:space="preserve">
+    <value>atcGfycatAccountType</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;atcGfycatAccountType.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Name" xml:space="preserve">
+    <value>oauth2Gfycat</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.Parent" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;oauth2Gfycat.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpGfycat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGfycat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGfycat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGfycat.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="tpGfycat.Text" xml:space="preserve">
+    <value>Gfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
+    <value>tpGfycat</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGfycat.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRefreshFolders.Name" xml:space="preserve">
+    <value>btnMegaRefreshFolders</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRefreshFolders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRefreshFolders.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRefreshFolders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatus.Name" xml:space="preserve">
+    <value>lblMegaStatus</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatus.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatus.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRegister.Name" xml:space="preserve">
+    <value>btnMegaRegister</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRegister.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRegister.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;btnMegaRegister.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblMegaFolder.Name" xml:space="preserve">
+    <value>lblMegaFolder</value>
+  </data>
+  <data name="&gt;&gt;lblMegaFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMegaFolder.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;lblMegaFolder.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatusTitle.Name" xml:space="preserve">
+    <value>lblMegaStatusTitle</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatusTitle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatusTitle.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;lblMegaStatusTitle.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbMegaFolder.Name" xml:space="preserve">
+    <value>cbMegaFolder</value>
+  </data>
+  <data name="&gt;&gt;cbMegaFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbMegaFolder.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;cbMegaFolder.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblMegaEmail.Name" xml:space="preserve">
+    <value>lblMegaEmail</value>
+  </data>
+  <data name="&gt;&gt;lblMegaEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMegaEmail.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;lblMegaEmail.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;btnMegaLogin.Name" xml:space="preserve">
+    <value>btnMegaLogin</value>
+  </data>
+  <data name="&gt;&gt;btnMegaLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnMegaLogin.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;btnMegaLogin.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;txtMegaEmail.Name" xml:space="preserve">
+    <value>txtMegaEmail</value>
+  </data>
+  <data name="&gt;&gt;txtMegaEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMegaEmail.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;txtMegaEmail.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;txtMegaPassword.Name" xml:space="preserve">
+    <value>txtMegaPassword</value>
+  </data>
+  <data name="&gt;&gt;txtMegaPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMegaPassword.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;txtMegaPassword.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblMegaPassword.Name" xml:space="preserve">
+    <value>lblMegaPassword</value>
+  </data>
+  <data name="&gt;&gt;lblMegaPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMegaPassword.Parent" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;lblMegaPassword.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tpMega.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpMega.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpMega.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="tpMega.Text" xml:space="preserve">
+    <value>Mega</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Name" xml:space="preserve">
+    <value>tpMega</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpMega.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Name" xml:space="preserve">
+    <value>cbOwnCloudUsePreviewLinks</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHostExample.Name" xml:space="preserve">
+    <value>lblOwnCloudHostExample</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHostExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHostExample.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHostExample.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloud81Compatibility.Name" xml:space="preserve">
+    <value>cbOwnCloud81Compatibility</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloud81Compatibility.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloud81Compatibility.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloud81Compatibility.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudDirectLink.Name" xml:space="preserve">
+    <value>cbOwnCloudDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudDirectLink.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudDirectLink.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateShare.Name" xml:space="preserve">
+    <value>cbOwnCloudCreateShare</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateShare.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateShare.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateShare.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPath.Name" xml:space="preserve">
+    <value>txtOwnCloudPath</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPath.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPath.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPassword.Name" xml:space="preserve">
+    <value>txtOwnCloudPassword</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPassword.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPassword.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudUsername.Name" xml:space="preserve">
+    <value>txtOwnCloudUsername</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudUsername.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudUsername.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudHost.Name" xml:space="preserve">
+    <value>txtOwnCloudHost</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudHost.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudHost.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPath.Name" xml:space="preserve">
+    <value>lblOwnCloudPath</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPath.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPath.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPassword.Name" xml:space="preserve">
+    <value>lblOwnCloudPassword</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPassword.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPassword.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudUsername.Name" xml:space="preserve">
+    <value>lblOwnCloudUsername</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudUsername.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudUsername.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHost.Name" xml:space="preserve">
+    <value>lblOwnCloudHost</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHost.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudHost.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOwnCloud.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpOwnCloud.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="tpOwnCloud.Text" xml:space="preserve">
+    <value>ownCloud / Nextcloud</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOwnCloud.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;cbMediaFireUseLongLink.Name" xml:space="preserve">
+    <value>cbMediaFireUseLongLink</value>
+  </data>
+  <data name="&gt;&gt;cbMediaFireUseLongLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbMediaFireUseLongLink.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;cbMediaFireUseLongLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePath.Name" xml:space="preserve">
+    <value>txtMediaFirePath</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePath.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePath.Name" xml:space="preserve">
+    <value>lblMediaFirePath</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePath.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePath.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePassword.Name" xml:space="preserve">
+    <value>txtMediaFirePassword</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePassword.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFirePassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFireEmail.Name" xml:space="preserve">
+    <value>txtMediaFireEmail</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFireEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFireEmail.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;txtMediaFireEmail.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePassword.Name" xml:space="preserve">
+    <value>lblMediaFirePassword</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePassword.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFirePassword.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFireEmail.Name" xml:space="preserve">
+    <value>lblMediaFireEmail</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFireEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFireEmail.Parent" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;lblMediaFireEmail.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tpMediaFire.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpMediaFire.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpMediaFire.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 519</value>
+  </data>
+  <data name="tpMediaFire.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="tpMediaFire.Text" xml:space="preserve">
+    <value>MediaFire</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Name" xml:space="preserve">
+    <value>tpMediaFire</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpMediaFire.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletDevices.Name" xml:space="preserve">
+    <value>lblPushbulletDevices</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletDevices.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletDevices.Parent" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletDevices.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cboPushbulletDevices.Name" xml:space="preserve">
+    <value>cboPushbulletDevices</value>
+  </data>
+  <data name="&gt;&gt;cboPushbulletDevices.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboPushbulletDevices.Parent" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;cboPushbulletDevices.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnPushbulletGetDeviceList.Name" xml:space="preserve">
+    <value>btnPushbulletGetDeviceList</value>
+  </data>
+  <data name="&gt;&gt;btnPushbulletGetDeviceList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPushbulletGetDeviceList.Parent" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;btnPushbulletGetDeviceList.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletUserKey.Name" xml:space="preserve">
+    <value>lblPushbulletUserKey</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletUserKey.Parent" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;lblPushbulletUserKey.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtPushbulletUserKey.Name" xml:space="preserve">
+    <value>txtPushbulletUserKey</value>
+  </data>
+  <data name="&gt;&gt;txtPushbulletUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPushbulletUserKey.Parent" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;txtPushbulletUserKey.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpPushbullet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPushbullet.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPushbullet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPushbullet.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="tpPushbullet.Text" xml:space="preserve">
+    <value>Pushbullet</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Name" xml:space="preserve">
+    <value>tpPushbullet</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPushbullet.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;btnSendSpaceRegister.Name" xml:space="preserve">
+    <value>btnSendSpaceRegister</value>
+  </data>
+  <data name="&gt;&gt;btnSendSpaceRegister.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSendSpaceRegister.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;btnSendSpaceRegister.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpacePassword.Name" xml:space="preserve">
+    <value>lblSendSpacePassword</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpacePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpacePassword.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpacePassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpaceUsername.Name" xml:space="preserve">
+    <value>lblSendSpaceUsername</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpaceUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpaceUsername.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;lblSendSpaceUsername.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpacePassword.Name" xml:space="preserve">
+    <value>txtSendSpacePassword</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpacePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpacePassword.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpacePassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpaceUserName.Name" xml:space="preserve">
+    <value>txtSendSpaceUserName</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpaceUserName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpaceUserName.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;txtSendSpaceUserName.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;atcSendSpaceAccountType.Name" xml:space="preserve">
+    <value>atcSendSpaceAccountType</value>
+  </data>
+  <data name="&gt;&gt;atcSendSpaceAccountType.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;atcSendSpaceAccountType.Parent" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;atcSendSpaceAccountType.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpSendSpace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSendSpace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSendSpace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSendSpace.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpSendSpace.Text" xml:space="preserve">
+    <value>SendSpace</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Name" xml:space="preserve">
+    <value>tpSendSpace</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSendSpace.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttStatus.Name" xml:space="preserve">
+    <value>lblGe_ttStatus</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttStatus.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttStatus.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttPassword.Name" xml:space="preserve">
+    <value>lblGe_ttPassword</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttPassword.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttPassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttEmail.Name" xml:space="preserve">
+    <value>lblGe_ttEmail</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttEmail.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;lblGe_ttEmail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnGe_ttLogin.Name" xml:space="preserve">
+    <value>btnGe_ttLogin</value>
+  </data>
+  <data name="&gt;&gt;btnGe_ttLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnGe_ttLogin.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;btnGe_ttLogin.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttPassword.Name" xml:space="preserve">
+    <value>txtGe_ttPassword</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttPassword.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttPassword.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttEmail.Name" xml:space="preserve">
+    <value>txtGe_ttEmail</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttEmail.Parent" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;txtGe_ttEmail.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpGe_tt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpGe_tt.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGe_tt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpGe_tt.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tpGe_tt.Text" xml:space="preserve">
+    <value>Ge.tt</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Name" xml:space="preserve">
+    <value>tpGe_tt</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGe_tt.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbLocalhostrDirectURL.Name" xml:space="preserve">
+    <value>cbLocalhostrDirectURL</value>
+  </data>
+  <data name="&gt;&gt;cbLocalhostrDirectURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbLocalhostrDirectURL.Parent" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;cbLocalhostrDirectURL.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrPassword.Name" xml:space="preserve">
+    <value>lblLocalhostrPassword</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrPassword.Parent" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrPassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrEmail.Name" xml:space="preserve">
+    <value>lblLocalhostrEmail</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrEmail.Parent" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;lblLocalhostrEmail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrPassword.Name" xml:space="preserve">
+    <value>txtLocalhostrPassword</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrPassword.Parent" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrEmail.Name" xml:space="preserve">
+    <value>txtLocalhostrEmail</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrEmail.Parent" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;txtLocalhostrEmail.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpHostr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpHostr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpHostr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpHostr.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tpHostr.Text" xml:space="preserve">
+    <value>Hostr</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Name" xml:space="preserve">
+    <value>tpHostr</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpHostr.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;txtJiraIssuePrefix.Name" xml:space="preserve">
+    <value>txtJiraIssuePrefix</value>
+  </data>
+  <data name="&gt;&gt;txtJiraIssuePrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtJiraIssuePrefix.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;txtJiraIssuePrefix.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblJiraIssuePrefix.Name" xml:space="preserve">
+    <value>lblJiraIssuePrefix</value>
+  </data>
+  <data name="&gt;&gt;lblJiraIssuePrefix.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblJiraIssuePrefix.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;lblJiraIssuePrefix.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;oAuthJira.Name" xml:space="preserve">
+    <value>oAuthJira</value>
+  </data>
+  <data name="&gt;&gt;oAuthJira.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oAuthJira.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;oAuthJira.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpJira.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpJira.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpJira.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="tpJira.Text" xml:space="preserve">
+    <value>Atlassian Jira</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Name" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpJira.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpJira.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaInfo.Name" xml:space="preserve">
+    <value>lblLambdaInfo</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaInfo.Parent" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaInfo.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaApiKey.Name" xml:space="preserve">
+    <value>lblLambdaApiKey</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaApiKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaApiKey.Parent" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaApiKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtLambdaApiKey.Name" xml:space="preserve">
+    <value>txtLambdaApiKey</value>
+  </data>
+  <data name="&gt;&gt;txtLambdaApiKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLambdaApiKey.Parent" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;txtLambdaApiKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaUploadURL.Name" xml:space="preserve">
+    <value>lblLambdaUploadURL</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaUploadURL.Parent" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;lblLambdaUploadURL.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbLambdaUploadURL.Name" xml:space="preserve">
+    <value>cbLambdaUploadURL</value>
+  </data>
+  <data name="&gt;&gt;cbLambdaUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbLambdaUploadURL.Parent" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;cbLambdaUploadURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpLambda.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpLambda.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpLambda.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpLambda.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="tpLambda.Text" xml:space="preserve">
+    <value>Lambda</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Name" xml:space="preserve">
+    <value>tpLambda</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpLambda.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;btnPomfTest.Name" xml:space="preserve">
+    <value>btnPomfTest</value>
+  </data>
+  <data name="&gt;&gt;btnPomfTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPomfTest.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;btnPomfTest.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtPomfResultURL.Name" xml:space="preserve">
+    <value>txtPomfResultURL</value>
+  </data>
+  <data name="&gt;&gt;txtPomfResultURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPomfResultURL.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;txtPomfResultURL.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtPomfUploadURL.Name" xml:space="preserve">
+    <value>txtPomfUploadURL</value>
+  </data>
+  <data name="&gt;&gt;txtPomfUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPomfUploadURL.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;txtPomfUploadURL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblPomfResultURL.Name" xml:space="preserve">
+    <value>lblPomfResultURL</value>
+  </data>
+  <data name="&gt;&gt;lblPomfResultURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPomfResultURL.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;lblPomfResultURL.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploadURL.Name" xml:space="preserve">
+    <value>lblPomfUploadURL</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploadURL.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploadURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploaders.Name" xml:space="preserve">
+    <value>lblPomfUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploaders.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;lblPomfUploaders.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;cbPomfUploaders.Name" xml:space="preserve">
+    <value>cbPomfUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbPomfUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPomfUploaders.Parent" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;cbPomfUploaders.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tpPomf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPomf.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPomf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPomf.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="tpPomf.Text" xml:space="preserve">
+    <value>Pomf</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Name" xml:space="preserve">
+    <value>tpPomf</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPomf.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileAPIURL.Name" xml:space="preserve">
+    <value>cbSeafileAPIURL</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileAPIURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileAPIURL.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileAPIURL.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Name" xml:space="preserve">
+    <value>btnSeafileLibraryPasswordValidate</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileLibraryPasswordValidate.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileLibraryPassword.Name" xml:space="preserve">
+    <value>txtSeafileLibraryPassword</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileLibraryPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileLibraryPassword.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileLibraryPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileLibraryPassword.Name" xml:space="preserve">
+    <value>lblSeafileLibraryPassword</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileLibraryPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileLibraryPassword.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileLibraryPassword.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvSeafileLibraries.Name" xml:space="preserve">
+    <value>lvSeafileLibraries</value>
+  </data>
+  <data name="&gt;&gt;lvSeafileLibraries.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvSeafileLibraries.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lvSeafileLibraries.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnSeafilePathValidate.Name" xml:space="preserve">
+    <value>btnSeafilePathValidate</value>
+  </data>
+  <data name="&gt;&gt;btnSeafilePathValidate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSeafilePathValidate.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;btnSeafilePathValidate.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileDirectoryPath.Name" xml:space="preserve">
+    <value>txtSeafileDirectoryPath</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileDirectoryPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileDirectoryPath.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileDirectoryPath.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileWritePermNotif.Name" xml:space="preserve">
+    <value>lblSeafileWritePermNotif</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileWritePermNotif.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileWritePermNotif.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileWritePermNotif.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePath.Name" xml:space="preserve">
+    <value>lblSeafilePath</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePath.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePath.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Name" xml:space="preserve">
+    <value>txtSeafileUploadLocationRefresh</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUploadLocationRefresh.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSelectLibrary.Name" xml:space="preserve">
+    <value>lblSeafileSelectLibrary</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSelectLibrary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSelectLibrary.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSelectLibrary.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAuthToken.Name" xml:space="preserve">
+    <value>btnSeafileCheckAuthToken</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAuthToken.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAPIURL.Name" xml:space="preserve">
+    <value>btnSeafileCheckAPIURL</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAPIURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAPIURL.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileCheckAPIURL.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Name" xml:space="preserve">
+    <value>cbSeafileIgnoreInvalidCert</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileIgnoreInvalidCert.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURL.Name" xml:space="preserve">
+    <value>cbSeafileCreateShareableURL</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURL.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAuthToken.Name" xml:space="preserve">
+    <value>txtSeafileAuthToken</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAuthToken.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAuthToken.Name" xml:space="preserve">
+    <value>lblSeafileAuthToken</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAuthToken.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAPIURL.Name" xml:space="preserve">
+    <value>lblSeafileAPIURL</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAPIURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAPIURL.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAPIURL.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="tpSeafile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSeafile.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSeafile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSeafile.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="tpSeafile.Text" xml:space="preserve">
+    <value>Seafile</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Name" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSeafile.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableUseDirectURL.Name" xml:space="preserve">
+    <value>cbStreamableUseDirectURL</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableUseDirectURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableUseDirectURL.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableUseDirectURL.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtStreamablePassword.Name" xml:space="preserve">
+    <value>txtStreamablePassword</value>
+  </data>
+  <data name="&gt;&gt;txtStreamablePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtStreamablePassword.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;txtStreamablePassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtStreamableUsername.Name" xml:space="preserve">
+    <value>txtStreamableUsername</value>
+  </data>
+  <data name="&gt;&gt;txtStreamableUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtStreamableUsername.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;txtStreamableUsername.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblStreamableUsername.Name" xml:space="preserve">
+    <value>lblStreamableUsername</value>
+  </data>
+  <data name="&gt;&gt;lblStreamableUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStreamableUsername.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;lblStreamableUsername.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblStreamablePassword.Name" xml:space="preserve">
+    <value>lblStreamablePassword</value>
+  </data>
+  <data name="&gt;&gt;lblStreamablePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStreamablePassword.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;lblStreamablePassword.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableAnonymous.Name" xml:space="preserve">
+    <value>cbStreamableAnonymous</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableAnonymous.Parent" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;cbStreamableAnonymous.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tpStreamable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpStreamable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpStreamable.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="tpStreamable.Text" xml:space="preserve">
+    <value>Streamable</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Name" xml:space="preserve">
+    <value>tpStreamable</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpStreamable.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;btnSulGetAPIKey.Name" xml:space="preserve">
+    <value>btnSulGetAPIKey</value>
+  </data>
+  <data name="&gt;&gt;btnSulGetAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSulGetAPIKey.Parent" xml:space="preserve">
+    <value>tpSul</value>
+  </data>
+  <data name="&gt;&gt;btnSulGetAPIKey.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtSulAPIKey.Name" xml:space="preserve">
+    <value>txtSulAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtSulAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSulAPIKey.Parent" xml:space="preserve">
+    <value>tpSul</value>
+  </data>
+  <data name="&gt;&gt;txtSulAPIKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblSulAPIKey.Name" xml:space="preserve">
+    <value>lblSulAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblSulAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSulAPIKey.Parent" xml:space="preserve">
+    <value>tpSul</value>
+  </data>
+  <data name="&gt;&gt;lblSulAPIKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpSul.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSul.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSul.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSul.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="tpSul.Text" xml:space="preserve">
+    <value>s-ul</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Name" xml:space="preserve">
+    <value>tpSul</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSul.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSul.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioFetchAPIKey.Name" xml:space="preserve">
+    <value>btnLithiioFetchAPIKey</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioFetchAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioFetchAPIKey.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioFetchAPIKey.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioPassword.Name" xml:space="preserve">
+    <value>txtLithiioPassword</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioPassword.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioPassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioEmail.Name" xml:space="preserve">
+    <value>txtLithiioEmail</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioEmail.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioEmail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioPassword.Name" xml:space="preserve">
+    <value>lblLithiioPassword</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioPassword.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioEmail.Name" xml:space="preserve">
+    <value>lblLithiioEmail</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioEmail.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioEmail.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioGetAPIKey.Name" xml:space="preserve">
+    <value>btnLithiioGetAPIKey</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioGetAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioGetAPIKey.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;btnLithiioGetAPIKey.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioApiKey.Name" xml:space="preserve">
+    <value>lblLithiioApiKey</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioApiKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioApiKey.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;lblLithiioApiKey.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioApiKey.Name" xml:space="preserve">
+    <value>txtLithiioApiKey</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioApiKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioApiKey.Parent" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;txtLithiioApiKey.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tpLithiio.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpLithiio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpLithiio.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpLithiio.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="tpLithiio.Text" xml:space="preserve">
+    <value>Lithiio</value>
+  </data>
+  <data name="&gt;&gt;tpLithiio.Name" xml:space="preserve">
+    <value>tpLithiio</value>
+  </data>
+  <data name="&gt;&gt;tpLithiio.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpLithiio.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpLithiio.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
+    <value>gbPlikSettings</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpPlik.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpPlik.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPlik.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpPlik.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="tpPlik.Text" xml:space="preserve">
+    <value>Plik</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Name" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPlik.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Name" xml:space="preserve">
+    <value>cbYouTubeUseShortenedLink</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubeUseShortenedLink.Parent" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubeUseShortenedLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubePrivacyType.Name" xml:space="preserve">
+    <value>cbYouTubePrivacyType</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubePrivacyType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubePrivacyType.Parent" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;cbYouTubePrivacyType.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblYouTubePrivacyType.Name" xml:space="preserve">
+    <value>lblYouTubePrivacyType</value>
+  </data>
+  <data name="&gt;&gt;lblYouTubePrivacyType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblYouTubePrivacyType.Parent" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;lblYouTubePrivacyType.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;oauth2YouTube.Name" xml:space="preserve">
+    <value>oauth2YouTube</value>
+  </data>
+  <data name="&gt;&gt;oauth2YouTube.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2YouTube.Parent" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;oauth2YouTube.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpYouTube.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpYouTube.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpYouTube.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="tpYouTube.Text" xml:space="preserve">
+    <value>YouTube</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Name" xml:space="preserve">
+    <value>tpYouTube</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpYouTube.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;lbSharedFolderAccounts.Name" xml:space="preserve">
+    <value>lbSharedFolderAccounts</value>
+  </data>
+  <data name="&gt;&gt;lbSharedFolderAccounts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lbSharedFolderAccounts.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;lbSharedFolderAccounts.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pgSharedFolderAccount.Name" xml:space="preserve">
+    <value>pgSharedFolderAccount</value>
+  </data>
+  <data name="&gt;&gt;pgSharedFolderAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PropertyGrid, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pgSharedFolderAccount.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;pgSharedFolderAccount.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderDuplicate.Name" xml:space="preserve">
+    <value>btnSharedFolderDuplicate</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderDuplicate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderDuplicate.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderDuplicate.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderRemove.Name" xml:space="preserve">
+    <value>btnSharedFolderRemove</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderRemove.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderRemove.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderAdd.Name" xml:space="preserve">
+    <value>btnSharedFolderAdd</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderAdd.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;btnSharedFolderAdd.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderFiles.Name" xml:space="preserve">
+    <value>lblSharedFolderFiles</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderFiles.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderFiles.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderText.Name" xml:space="preserve">
+    <value>lblSharedFolderText</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderText.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderText.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderFiles.Name" xml:space="preserve">
+    <value>cboSharedFolderFiles</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderFiles.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderFiles.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderImages.Name" xml:space="preserve">
+    <value>lblSharedFolderImages</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderImages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderImages.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;lblSharedFolderImages.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderText.Name" xml:space="preserve">
+    <value>cboSharedFolderText</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderText.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderText.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderImages.Name" xml:space="preserve">
+    <value>cboSharedFolderImages</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderImages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderImages.Parent" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;cboSharedFolderImages.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="tpSharedFolder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpSharedFolder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpSharedFolder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpSharedFolder.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="tpSharedFolder.Text" xml:space="preserve">
+    <value>Shared folder</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Name" xml:space="preserve">
+    <value>tpSharedFolder</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpSharedFolder.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;txtEmailAutomaticSendTo.Name" xml:space="preserve">
+    <value>txtEmailAutomaticSendTo</value>
+  </data>
+  <data name="&gt;&gt;txtEmailAutomaticSendTo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailAutomaticSendTo.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailAutomaticSendTo.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbEmailAutomaticSend.Name" xml:space="preserve">
+    <value>cbEmailAutomaticSend</value>
+  </data>
+  <data name="&gt;&gt;cbEmailAutomaticSend.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbEmailAutomaticSend.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;cbEmailAutomaticSend.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpServer.Name" xml:space="preserve">
+    <value>lblEmailSmtpServer</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpServer.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpServer.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblEmailPassword.Name" xml:space="preserve">
+    <value>lblEmailPassword</value>
+  </data>
+  <data name="&gt;&gt;lblEmailPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailPassword.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbEmailRememberLastTo.Name" xml:space="preserve">
+    <value>cbEmailRememberLastTo</value>
+  </data>
+  <data name="&gt;&gt;cbEmailRememberLastTo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbEmailRememberLastTo.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;cbEmailRememberLastTo.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtEmailFrom.Name" xml:space="preserve">
+    <value>txtEmailFrom</value>
+  </data>
+  <data name="&gt;&gt;txtEmailFrom.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailFrom.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailFrom.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtEmailPassword.Name" xml:space="preserve">
+    <value>txtEmailPassword</value>
+  </data>
+  <data name="&gt;&gt;txtEmailPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailPassword.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailPassword.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultBody.Name" xml:space="preserve">
+    <value>txtEmailDefaultBody</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultBody.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultBody.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultBody.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblEmailFrom.Name" xml:space="preserve">
+    <value>lblEmailFrom</value>
+  </data>
+  <data name="&gt;&gt;lblEmailFrom.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailFrom.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailFrom.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;txtEmailSmtpServer.Name" xml:space="preserve">
+    <value>txtEmailSmtpServer</value>
+  </data>
+  <data name="&gt;&gt;txtEmailSmtpServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailSmtpServer.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailSmtpServer.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultSubject.Name" xml:space="preserve">
+    <value>lblEmailDefaultSubject</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultSubject.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultSubject.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultSubject.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultBody.Name" xml:space="preserve">
+    <value>lblEmailDefaultBody</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultBody.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultBody.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailDefaultBody.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;nudEmailSmtpPort.Name" xml:space="preserve">
+    <value>nudEmailSmtpPort</value>
+  </data>
+  <data name="&gt;&gt;nudEmailSmtpPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudEmailSmtpPort.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;nudEmailSmtpPort.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpPort.Name" xml:space="preserve">
+    <value>lblEmailSmtpPort</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpPort.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;lblEmailSmtpPort.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultSubject.Name" xml:space="preserve">
+    <value>txtEmailDefaultSubject</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultSubject.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultSubject.Parent" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;txtEmailDefaultSubject.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="tpEmail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 202</value>
+  </data>
+  <data name="tpEmail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpEmail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 0</value>
+  </data>
+  <data name="tpEmail.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="tpEmail.Text" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Name" xml:space="preserve">
+    <value>tpEmail</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.Parent" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpEmail.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="tcFileUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcFileUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Name" xml:space="preserve">
+    <value>tcFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.Parent" xml:space="preserve">
+    <value>tpFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcFileUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpFileUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
+  </data>
+  <data name="tpFileUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpFileUploaders.Text" xml:space="preserve">
+    <value>File uploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Name" xml:space="preserve">
+    <value>tpFileUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpFileUploaders.Parent" xml:space="preserve">
     <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpURLShorteners.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpFileUploaders.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Name" xml:space="preserve">
+    <value>cbFTPAppendRemoteDirectory</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;cbFTPAppendRemoteDirectory.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnFTPTest.Name" xml:space="preserve">
+    <value>btnFTPTest</value>
+  </data>
+  <data name="&gt;&gt;btnFTPTest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFTPTest.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;btnFTPTest.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblFTPProtocol.Name" xml:space="preserve">
+    <value>lblFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;lblFTPProtocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPProtocol.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPProtocol.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblFTPName.Name" xml:space="preserve">
+    <value>lblFTPName</value>
+  </data>
+  <data name="&gt;&gt;lblFTPName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPName.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPName.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbFTPRemoveFileExtension.Name" xml:space="preserve">
+    <value>cbFTPRemoveFileExtension</value>
+  </data>
+  <data name="&gt;&gt;cbFTPRemoveFileExtension.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPRemoveFileExtension.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;cbFTPRemoveFileExtension.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtFTPName.Name" xml:space="preserve">
+    <value>txtFTPName</value>
+  </data>
+  <data name="&gt;&gt;txtFTPName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPName.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPName.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblFTPHost.Name" xml:space="preserve">
+    <value>lblFTPHost</value>
+  </data>
+  <data name="&gt;&gt;lblFTPHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPHost.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPHost.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;eiFTP.Name" xml:space="preserve">
+    <value>eiFTP</value>
+  </data>
+  <data name="&gt;&gt;eiFTP.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;eiFTP.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;eiFTP.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
+    <value>pFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;btnFTPClient.Name" xml:space="preserve">
+    <value>btnFTPClient</value>
+  </data>
+  <data name="&gt;&gt;btnFTPClient.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFTPClient.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;btnFTPClient.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtFTPHost.Name" xml:space="preserve">
+    <value>txtFTPHost</value>
+  </data>
+  <data name="&gt;&gt;txtFTPHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPHost.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPHost.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPort.Name" xml:space="preserve">
+    <value>lblFTPPort</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPort.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPort.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lblFTPTransferMode.Name" xml:space="preserve">
+    <value>lblFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;lblFTPTransferMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPTransferMode.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPTransferMode.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;nudFTPPort.Name" xml:space="preserve">
+    <value>nudFTPPort</value>
+  </data>
+  <data name="&gt;&gt;nudFTPPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudFTPPort.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;nudFTPPort.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreviewValue.Name" xml:space="preserve">
+    <value>lblFTPURLPreviewValue</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreviewValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreviewValue.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreviewValue.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;lblFTPUsername.Name" xml:space="preserve">
+    <value>lblFTPUsername</value>
+  </data>
+  <data name="&gt;&gt;lblFTPUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPUsername.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPUsername.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreview.Name" xml:space="preserve">
+    <value>lblFTPURLPreview</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreview.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreview.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPreview.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;txtFTPUsername.Name" xml:space="preserve">
+    <value>txtFTPUsername</value>
+  </data>
+  <data name="&gt;&gt;txtFTPUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPUsername.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPUsername.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;cbFTPURLPathProtocol.Name" xml:space="preserve">
+    <value>cbFTPURLPathProtocol</value>
+  </data>
+  <data name="&gt;&gt;cbFTPURLPathProtocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPURLPathProtocol.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;cbFTPURLPathProtocol.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPassword.Name" xml:space="preserve">
+    <value>lblFTPPassword</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPassword.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPPassword.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;txtFTPURLPath.Name" xml:space="preserve">
+    <value>txtFTPURLPath</value>
+  </data>
+  <data name="&gt;&gt;txtFTPURLPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPURLPath.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPURLPath.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;txtFTPPassword.Name" xml:space="preserve">
+    <value>txtFTPPassword</value>
+  </data>
+  <data name="&gt;&gt;txtFTPPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPPassword.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPPassword.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPath.Name" xml:space="preserve">
+    <value>lblFTPURLPath</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPath.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPURLPath.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="&gt;&gt;lblFTPRemoteDirectory.Name" xml:space="preserve">
+    <value>lblFTPRemoteDirectory</value>
+  </data>
+  <data name="&gt;&gt;lblFTPRemoteDirectory.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPRemoteDirectory.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;lblFTPRemoteDirectory.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;txtFTPRemoteDirectory.Name" xml:space="preserve">
+    <value>txtFTPRemoteDirectory</value>
+  </data>
+  <data name="&gt;&gt;txtFTPRemoteDirectory.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPRemoteDirectory.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;txtFTPRemoteDirectory.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="gbFTPAccount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 72</value>
+  </data>
+  <data name="gbFTPAccount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>776, 416</value>
+  </data>
+  <data name="gbFTPAccount.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="gbFTPAccount.Text" xml:space="preserve">
+    <value>Account</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
+    <value>tpFTP</value>
+  </data>
+  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyPassphrase.Name" xml:space="preserve">
+    <value>txtSFTPKeyPassphrase</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyPassphrase.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyPassphrase.Parent" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyPassphrase.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Name" xml:space="preserve">
+    <value>btnSFTPKeyLocationBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.Parent" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;btnSFTPKeyLocationBrowse.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyPassphrase.Name" xml:space="preserve">
+    <value>lblSFTPKeyPassphrase</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyPassphrase.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyPassphrase.Parent" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyPassphrase.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyLocation.Name" xml:space="preserve">
+    <value>txtSFTPKeyLocation</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyLocation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyLocation.Parent" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;txtSFTPKeyLocation.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyLocation.Name" xml:space="preserve">
+    <value>lblSFTPKeyLocation</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyLocation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyLocation.Parent" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;lblSFTPKeyLocation.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="gbSFTP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 288</value>
+  </data>
+  <data name="gbSFTP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>744, 76</value>
+  </data>
+  <data name="gbSFTP.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="gbSFTP.Text" xml:space="preserve">
+    <value>SFTP</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
+    <value>gbSFTP</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="txtSFTPKeyPassphrase.Location" type="System.Drawing.Point, System.Drawing">
     <value>184, 44</value>
@@ -3739,30 +9481,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblSFTPKeyLocation.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="gbSFTP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 288</value>
-  </data>
-  <data name="gbSFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>744, 76</value>
-  </data>
-  <data name="gbSFTP.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="gbSFTP.Text" xml:space="preserve">
-    <value>SFTP</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Name" xml:space="preserve">
-    <value>gbSFTP</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbSFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="cbFTPAppendRemoteDirectory.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3986,6 +9704,51 @@ store.book[0].title</value>
   <data name="pFTPTransferMode.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
+  <data name="&gt;&gt;rbFTPTransferModeActive.Name" xml:space="preserve">
+    <value>rbFTPTransferModeActive</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModeActive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModeActive.Parent" xml:space="preserve">
+    <value>pFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModeActive.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModePassive.Name" xml:space="preserve">
+    <value>rbFTPTransferModePassive</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModePassive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModePassive.Parent" xml:space="preserve">
+    <value>pFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;rbFTPTransferModePassive.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="pFTPTransferMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 141</value>
+  </data>
+  <data name="pFTPTransferMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>336, 20</value>
+  </data>
+  <data name="pFTPTransferMode.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
+    <value>pFTPTransferMode</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
   <data name="rbFTPTransferModeActive.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -4046,27 +9809,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;rbFTPTransferModePassive.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="pFTPTransferMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 141</value>
-  </data>
-  <data name="pFTPTransferMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 20</value>
-  </data>
-  <data name="pFTPTransferMode.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Name" xml:space="preserve">
-    <value>pFTPTransferMode</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPTransferMode.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="btnFTPClient.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -4117,6 +9859,63 @@ store.book[0].title</value>
   </data>
   <data name="pFTPProtocol.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTP.Name" xml:space="preserve">
+    <value>rbFTPProtocolFTP</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTP.Parent" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTP.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTPS.Name" xml:space="preserve">
+    <value>rbFTPProtocolFTPS</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTPS.Parent" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolFTPS.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolSFTP.Name" xml:space="preserve">
+    <value>rbFTPProtocolSFTP</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolSFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolSFTP.Parent" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;rbFTPProtocolSFTP.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="pFTPProtocol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 45</value>
+  </data>
+  <data name="pFTPProtocol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>336, 20</value>
+  </data>
+  <data name="pFTPProtocol.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
+    <value>pFTPProtocol</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
   <data name="rbFTPProtocolFTP.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4207,27 +10006,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;rbFTPProtocolSFTP.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="pFTPProtocol.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 45</value>
-  </data>
-  <data name="pFTPProtocol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 20</value>
-  </data>
-  <data name="pFTPProtocol.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Name" xml:space="preserve">
-    <value>pFTPProtocol</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;pFTPProtocol.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="lblFTPPort.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4595,6 +10373,90 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtFTPRemoteDirectory.ZOrder" xml:space="preserve">
     <value>26</value>
   </data>
+  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Name" xml:space="preserve">
+    <value>btnFTPSCertificateLocationBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.Parent" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;btnFTPSCertificateLocationBrowse.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtFTPSCertificateLocation.Name" xml:space="preserve">
+    <value>txtFTPSCertificateLocation</value>
+  </data>
+  <data name="&gt;&gt;txtFTPSCertificateLocation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFTPSCertificateLocation.Parent" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;txtFTPSCertificateLocation.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSCertificateLocation.Name" xml:space="preserve">
+    <value>lblFTPSCertificateLocation</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSCertificateLocation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSCertificateLocation.Parent" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSCertificateLocation.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbFTPSEncryption.Name" xml:space="preserve">
+    <value>cbFTPSEncryption</value>
+  </data>
+  <data name="&gt;&gt;cbFTPSEncryption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFTPSEncryption.Parent" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;cbFTPSEncryption.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSEncryption.Name" xml:space="preserve">
+    <value>lblFTPSEncryption</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSEncryption.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSEncryption.Parent" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;lblFTPSEncryption.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="gbFTPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 288</value>
+  </data>
+  <data name="gbFTPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>744, 76</value>
+  </data>
+  <data name="gbFTPS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="gbFTPS.Text" xml:space="preserve">
+    <value>FTPS</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
+    <value>gbFTPS</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
+    <value>gbFTPAccount</value>
+  </data>
+  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
   <data name="btnFTPSCertificateLocationBrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -4723,54 +10585,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblFTPSEncryption.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="gbFTPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 288</value>
-  </data>
-  <data name="gbFTPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>744, 76</value>
-  </data>
-  <data name="gbFTPS.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="gbFTPS.Text" xml:space="preserve">
-    <value>FTPS</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Name" xml:space="preserve">
-    <value>gbFTPS</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.Parent" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbFTPS.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="gbFTPAccount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 72</value>
-  </data>
-  <data name="gbFTPAccount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>776, 416</value>
-  </data>
-  <data name="gbFTPAccount.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="gbFTPAccount.Text" xml:space="preserve">
-    <value>Account</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Name" xml:space="preserve">
-    <value>gbFTPAccount</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.Parent" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;gbFTPAccount.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnFTPDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -5057,33 +10871,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbFTPText.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="tpFTP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpFTP.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 519</value>
-  </data>
-  <data name="tpFTP.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tpFTP.Text" xml:space="preserve">
-    <value>FTP / FTPS / SFTP</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Name" xml:space="preserve">
-    <value>tpFTP</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFTP.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="cbDropboxUseDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -5356,33 +11143,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Dropbox.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpDropbox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpDropbox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpDropbox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpDropbox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpDropbox.Text" xml:space="preserve">
-    <value>Dropbox</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Name" xml:space="preserve">
-    <value>tpDropbox</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpDropbox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="tvOneDrive.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -5487,33 +11247,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oAuth2OneDrive.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="tpOneDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpOneDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOneDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpOneDrive.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="tpOneDrive.Text" xml:space="preserve">
-    <value>OneDrive</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Name" xml:space="preserve">
-    <value>tpOneDrive</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="cbGoogleDriveDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5626,18 +11359,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblGoogleDriveFolderID.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="chGoogleDriveTitle.Text" xml:space="preserve">
-    <value>Title</value>
-  </data>
-  <data name="chGoogleDriveTitle.Width" type="System.Int32, mscorlib">
-    <value>200</value>
-  </data>
-  <data name="chGoogleDriveDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chGoogleDriveDescription.Width" type="System.Int32, mscorlib">
-    <value>228</value>
-  </data>
   <data name="lvGoogleDriveFoldersList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 112</value>
   </data>
@@ -5658,6 +11379,18 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvGoogleDriveFoldersList.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="chGoogleDriveTitle.Text" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="chGoogleDriveTitle.Width" type="System.Int32, mscorlib">
+    <value>200</value>
+  </data>
+  <data name="chGoogleDriveDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chGoogleDriveDescription.Width" type="System.Int32, mscorlib">
+    <value>228</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -5739,33 +11472,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oauth2GoogleDrive.ZOrder" xml:space="preserve">
     <value>7</value>
-  </data>
-  <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGoogleDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGoogleDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGoogleDrive.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpGoogleDrive.Text" xml:space="preserve">
-    <value>Google Drive</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Name" xml:space="preserve">
-    <value>tpGoogleDrive</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleDrive.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="pbPuush.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6004,33 +11710,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblPuushPassword.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpPuush.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPuush.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPuush.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPuush.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="tpPuush.Text" xml:space="preserve">
-    <value>puush</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Name" xml:space="preserve">
-    <value>tpPuush</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPuush.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="lblBoxFolderTip.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -6091,12 +11770,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbBoxShare.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="chBoxFoldersName.Text" xml:space="preserve">
-    <value>Folder name</value>
-  </data>
-  <data name="chBoxFoldersName.Width" type="System.Int32, mscorlib">
-    <value>435</value>
-  </data>
   <data name="lvBoxFolders.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 72</value>
   </data>
@@ -6117,6 +11790,12 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvBoxFolders.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="chBoxFoldersName.Text" xml:space="preserve">
+    <value>Folder name</value>
+  </data>
+  <data name="chBoxFoldersName.Width" type="System.Int32, mscorlib">
+    <value>435</value>
   </data>
   <data name="lblBoxFolderID.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6199,32 +11878,137 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2Box.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
+  <data name="&gt;&gt;lblAmazonS3StripExtension.Name" xml:space="preserve">
+    <value>lblAmazonS3StripExtension</value>
   </data>
-  <data name="tpBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;lblAmazonS3StripExtension.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
+  <data name="&gt;&gt;lblAmazonS3StripExtension.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
   </data>
-  <data name="tpBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lblAmazonS3StripExtension.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Name" xml:space="preserve">
+    <value>cbAmazonS3StripExtensionText</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionText.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionText.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StorageClass.Name" xml:space="preserve">
+    <value>cbAmazonS3StorageClass</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StorageClass.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StorageClass.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StorageClass.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpBox.Text" xml:space="preserve">
-    <value>Box</value>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Name" xml:space="preserve">
+    <value>cbAmazonS3StripExtensionVideo</value>
   </data>
-  <data name="&gt;&gt;tpBox.Name" xml:space="preserve">
-    <value>tpBox</value>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
   </data>
-  <data name="&gt;&gt;tpBox.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionVideo.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;tpBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cbAmazonS3PublicACL.Name" xml:space="preserve">
+    <value>cbAmazonS3PublicACL</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3PublicACL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3PublicACL.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3PublicACL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Name" xml:space="preserve">
+    <value>cbAmazonS3StripExtensionImage</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3StripExtensionImage.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Name" xml:space="preserve">
+    <value>cbAmazonS3UsePathStyle</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3UsePathStyle.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;cbAmazonS3UsePathStyle.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Name" xml:space="preserve">
+    <value>btnAmazonS3StorageClassHelp</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;btnAmazonS3StorageClassHelp.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3StorageClass.Name" xml:space="preserve">
+    <value>lblAmazonS3StorageClass</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3StorageClass.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3StorageClass.Parent" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;lblAmazonS3StorageClass.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 408</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Size" type="System.Drawing.Size, System.Drawing">
+    <value>416, 144</value>
+  </data>
+  <data name="gbAmazonS3Advanced.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="gbAmazonS3Advanced.Text" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
+    <value>gbAmazonS3Advanced</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
+    <value>tpAmazonS3</value>
+  </data>
+  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblAmazonS3StripExtension.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6483,30 +12267,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblAmazonS3StorageClass.ZOrder" xml:space="preserve">
     <value>8</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 408</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>416, 144</value>
-  </data>
-  <data name="gbAmazonS3Advanced.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="gbAmazonS3Advanced.Text" xml:space="preserve">
-    <value>Advanced</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Name" xml:space="preserve">
-    <value>gbAmazonS3Advanced</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.Parent" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;gbAmazonS3Advanced.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblAmazonS3Endpoint.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7000,33 +12760,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtAmazonS3AccessKey.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
-  <data name="tpAmazonS3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpAmazonS3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAmazonS3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpAmazonS3.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="tpAmazonS3.Text" xml:space="preserve">
-    <value>Amazon S3</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Name" xml:space="preserve">
-    <value>tpAmazonS3</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpAmazonS3.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="lblGoogleCloudStoragePathPreview.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -7255,357 +12988,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;oauth2GoogleCloudStorage.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpGoogleCloudStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGoogleCloudStorage.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
-  </data>
-  <data name="tpGoogleCloudStorage.Text" xml:space="preserve">
-    <value>Google Cloud Storage</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Name" xml:space="preserve">
-    <value>tpGoogleCloudStorage</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGoogleCloudStorage.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
-    <value>blob.core.windows.net</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
-    <value>blob.core.usgovcloudapi.net</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
-    <value>blob.core.chinacloudapi.cn</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
-    <value>blob.core.cloudapi.de</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 173</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 21</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Name" xml:space="preserve">
-    <value>cbAzureStorageEnvironment</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 156</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblAzureStorageEnvironment.Text" xml:space="preserve">
-    <value>Environment:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Name" xml:space="preserve">
-    <value>lblAzureStorageEnvironment</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAzureStoragePortal.Location" type="System.Drawing.Point, System.Drawing">
-    <value>552, 30</value>
-  </data>
-  <data name="btnAzureStoragePortal.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 24</value>
-  </data>
-  <data name="btnAzureStoragePortal.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="btnAzureStoragePortal.Text" xml:space="preserve">
-    <value>...</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Name" xml:space="preserve">
-    <value>btnAzureStoragePortal</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;btnAzureStoragePortal.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="txtAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 128</value>
-  </data>
-  <data name="txtAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Name" xml:space="preserve">
-    <value>txtAzureStorageContainer</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="lblAzureStorageContainer.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageContainer.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 112</value>
-  </data>
-  <data name="lblAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
-  </data>
-  <data name="lblAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="lblAzureStorageContainer.Text" xml:space="preserve">
-    <value>Container:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Name" xml:space="preserve">
-    <value>lblAzureStorageContainer</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 80</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Name" xml:space="preserve">
-    <value>txtAzureStorageAccessKey</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 64</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="lblAzureStorageAccessKey.Text" xml:space="preserve">
-    <value>Access key:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Name" xml:space="preserve">
-    <value>lblAzureStorageAccessKey</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="txtAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 32</value>
-  </data>
-  <data name="txtAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Name" xml:space="preserve">
-    <value>txtAzureStorageAccountName</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="lblAzureStorageAccountName.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblAzureStorageAccountName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 16</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 13</value>
-  </data>
-  <data name="lblAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lblAzureStorageAccountName.Text" xml:space="preserve">
-    <value>Account name:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Name" xml:space="preserve">
-    <value>lblAzureStorageAccountName</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 222</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
-  </data>
-  <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Name" xml:space="preserve">
-    <value>txtAzureStorageCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 206</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
-    <value>Custom Domain:</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Name" xml:space="preserve">
-    <value>lblAzureStorageCustomDomain</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.Parent" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAzureStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpAzureStorage.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
-  </data>
-  <data name="tpAzureStorage.Text" xml:space="preserve">
-    <value>Azure Storage</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Name" xml:space="preserve">
-    <value>tpAzureStorage</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpAzureStorage.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="cbGfycatIsPublic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -7677,33 +13059,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oauth2Gfycat.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="tpGfycat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGfycat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGfycat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGfycat.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
-  </data>
-  <data name="tpGfycat.Text" xml:space="preserve">
-    <value>Gfycat</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Name" xml:space="preserve">
-    <value>tpGfycat</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGfycat.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="btnMegaRefreshFolders.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -7997,30 +13352,6 @@ store.book[0].title</value>
     <value>tpMega</value>
   </data>
   <data name="&gt;&gt;lblMegaPassword.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="tpMega.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpMega.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpMega.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="tpMega.Text" xml:space="preserve">
-    <value>Mega</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Name" xml:space="preserve">
-    <value>tpMega</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpMega.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.AutoSize" type="System.Boolean, mscorlib">
@@ -8377,33 +13708,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblOwnCloudHost.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOwnCloud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpOwnCloud.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="tpOwnCloud.Text" xml:space="preserve">
-    <value>ownCloud / Nextcloud</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
-    <value>tpOwnCloud</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOwnCloud.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="cbMediaFireUseLongLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -8587,33 +13891,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblMediaFireEmail.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tpMediaFire.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpMediaFire.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpMediaFire.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpMediaFire.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="tpMediaFire.Text" xml:space="preserve">
-    <value>MediaFire</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Name" xml:space="preserve">
-    <value>tpMediaFire</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpMediaFire.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="lblPushbulletDevices.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -8748,33 +14025,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;txtPushbulletUserKey.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="tpPushbullet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPushbullet.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPushbullet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPushbullet.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="tpPushbullet.Text" xml:space="preserve">
-    <value>Pushbullet</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Name" xml:space="preserve">
-    <value>tpPushbullet</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPushbullet.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
   <data name="btnSendSpaceRegister.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -8925,33 +14175,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;atcSendSpaceAccountType.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="tpSendSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSendSpace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSendSpace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSendSpace.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="tpSendSpace.Text" xml:space="preserve">
-    <value>SendSpace</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Name" xml:space="preserve">
-    <value>tpSendSpace</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSendSpace.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="lblGe_ttStatus.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -9112,33 +14335,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtGe_ttEmail.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpGe_tt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpGe_tt.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGe_tt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpGe_tt.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tpGe_tt.Text" xml:space="preserve">
-    <value>Ge.tt</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Name" xml:space="preserve">
-    <value>tpGe_tt</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpGe_tt.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
   <data name="cbLocalhostrDirectURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -9271,33 +14467,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;txtLocalhostrEmail.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpHostr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpHostr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpHostr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpHostr.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="tpHostr.Text" xml:space="preserve">
-    <value>Hostr</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Name" xml:space="preserve">
-    <value>tpHostr</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpHostr.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
   <data name="txtJiraIssuePrefix.Location" type="System.Drawing.Point, System.Drawing">
     <value>472, 277</value>
   </data>
@@ -9351,6 +14520,66 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lblJiraIssuePrefix.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtJiraConfigHelp.Name" xml:space="preserve">
+    <value>txtJiraConfigHelp</value>
+  </data>
+  <data name="&gt;&gt;txtJiraConfigHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtJiraConfigHelp.Parent" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;txtJiraConfigHelp.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtJiraHost.Name" xml:space="preserve">
+    <value>txtJiraHost</value>
+  </data>
+  <data name="&gt;&gt;txtJiraHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtJiraHost.Parent" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;txtJiraHost.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblJiraHost.Name" xml:space="preserve">
+    <value>lblJiraHost</value>
+  </data>
+  <data name="&gt;&gt;lblJiraHost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblJiraHost.Parent" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;lblJiraHost.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="gbJiraServer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 13</value>
+  </data>
+  <data name="gbJiraServer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 358</value>
+  </data>
+  <data name="gbJiraServer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbJiraServer.Text" xml:space="preserve">
+    <value>Jira server</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
+    <value>gbJiraServer</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
+    <value>tpJira</value>
+  </data>
+  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="txtJiraConfigHelp.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
@@ -9436,30 +14665,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblJiraHost.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="gbJiraServer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 13</value>
-  </data>
-  <data name="gbJiraServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 358</value>
-  </data>
-  <data name="gbJiraServer.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbJiraServer.Text" xml:space="preserve">
-    <value>Jira server</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Name" xml:space="preserve">
-    <value>gbJiraServer</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.Parent" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;gbJiraServer.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="oAuthJira.Location" type="System.Drawing.Point, System.Drawing">
     <value>473, 13</value>
   </data>
@@ -9480,30 +14685,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;oAuthJira.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="tpJira.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpJira.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpJira.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="tpJira.Text" xml:space="preserve">
-    <value>Atlassian Jira</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Name" xml:space="preserve">
-    <value>tpJira</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpJira.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpJira.ZOrder" xml:space="preserve">
-    <value>17</value>
   </data>
   <data name="lblLambdaInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -9636,33 +14817,6 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;cbLambdaUploadURL.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="tpLambda.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpLambda.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpLambda.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpLambda.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="tpLambda.Text" xml:space="preserve">
-    <value>Lambda</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Name" xml:space="preserve">
-    <value>tpLambda</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpLambda.ZOrder" xml:space="preserve">
-    <value>18</value>
   </data>
   <data name="btnPomfTest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -9847,33 +15001,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;cbPomfUploaders.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tpPomf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPomf.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPomf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPomf.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="tpPomf.Text" xml:space="preserve">
-    <value>Pomf</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Name" xml:space="preserve">
-    <value>tpPomf</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPomf.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
   <data name="cbSeafileAPIURL.Items" xml:space="preserve">
     <value>https://seacloud.cc/api2/</value>
   </data>
@@ -9900,6 +15027,78 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;cbSeafileAPIURL.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileSharePassword.Name" xml:space="preserve">
+    <value>txtSeafileSharePassword</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileSharePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileSharePassword.Parent" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileSharePassword.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSharePassword.Name" xml:space="preserve">
+    <value>lblSeafileSharePassword</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSharePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSharePassword.Parent" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileSharePassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;nudSeafileExpireDays.Name" xml:space="preserve">
+    <value>nudSeafileExpireDays</value>
+  </data>
+  <data name="&gt;&gt;nudSeafileExpireDays.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudSeafileExpireDays.Parent" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;nudSeafileExpireDays.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileDaysToExpire.Name" xml:space="preserve">
+    <value>lblSeafileDaysToExpire</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileDaysToExpire.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileDaysToExpire.Parent" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileDaysToExpire.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpSeafileShareSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 346</value>
+  </data>
+  <data name="grpSeafileShareSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 115</value>
+  </data>
+  <data name="grpSeafileShareSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="grpSeafileShareSettings.Text" xml:space="preserve">
+    <value>Seafile share settings</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
+    <value>grpSeafileShareSettings</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="txtSeafileSharePassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>19, 79</value>
@@ -10003,30 +15202,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblSeafileDaysToExpire.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="grpSeafileShareSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 346</value>
-  </data>
-  <data name="grpSeafileShareSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 115</value>
-  </data>
-  <data name="grpSeafileShareSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="grpSeafileShareSettings.Text" xml:space="preserve">
-    <value>Seafile share settings</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Name" xml:space="preserve">
-    <value>grpSeafileShareSettings</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileShareSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="btnSeafileLibraryPasswordValidate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -10105,21 +15280,6 @@ store.book[0].title</value>
   <data name="&gt;&gt;lblSeafileLibraryPassword.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="colSeafileLibraryName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="colSeafileLibraryName.Width" type="System.Int32, mscorlib">
-    <value>217</value>
-  </data>
-  <data name="colSeafileLibrarySize.Text" xml:space="preserve">
-    <value>Size</value>
-  </data>
-  <data name="colSeafileLibrarySize.Width" type="System.Int32, mscorlib">
-    <value>74</value>
-  </data>
-  <data name="colSeafileLibraryEncrypted.Text" xml:space="preserve">
-    <value>Encrypted</value>
-  </data>
   <data name="lvSeafileLibraries.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 162</value>
   </data>
@@ -10140,6 +15300,21 @@ store.book[0].title</value>
   </data>
   <data name="&gt;&gt;lvSeafileLibraries.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="colSeafileLibraryName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="colSeafileLibraryName.Width" type="System.Int32, mscorlib">
+    <value>217</value>
+  </data>
+  <data name="colSeafileLibrarySize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="colSeafileLibrarySize.Width" type="System.Int32, mscorlib">
+    <value>74</value>
+  </data>
+  <data name="colSeafileLibraryEncrypted.Text" xml:space="preserve">
+    <value>Encrypted</value>
   </data>
   <data name="btnSeafilePathValidate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -10307,6 +15482,90 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblSeafileSelectLibrary.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Name" xml:space="preserve">
+    <value>btnRefreshSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRefreshSeafileAccInfo.Parent" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;btnRefreshSeafileAccInfo.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoUsage.Name" xml:space="preserve">
+    <value>txtSeafileAccInfoUsage</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoUsage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoUsage.Parent" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoUsage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoEmail.Name" xml:space="preserve">
+    <value>txtSeafileAccInfoEmail</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoEmail.Parent" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileAccInfoEmail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoEmail.Name" xml:space="preserve">
+    <value>lblSeafileAccInfoEmail</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoEmail.Parent" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoEmail.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoUsage.Name" xml:space="preserve">
+    <value>lblSeafileAccInfoUsage</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoUsage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoUsage.Parent" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileAccInfoUsage.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="grpSeafileAccInfo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 181</value>
+  </data>
+  <data name="grpSeafileAccInfo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 149</value>
+  </data>
+  <data name="grpSeafileAccInfo.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="grpSeafileAccInfo.Text" xml:space="preserve">
+    <value>Account information</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
+    <value>grpSeafileAccInfo</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
   <data name="btnRefreshSeafileAccInfo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -10436,30 +15695,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblSeafileAccInfoUsage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="grpSeafileAccInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 181</value>
-  </data>
-  <data name="grpSeafileAccInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 149</value>
-  </data>
-  <data name="grpSeafileAccInfo.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="grpSeafileAccInfo.Text" xml:space="preserve">
-    <value>Account information</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Name" xml:space="preserve">
-    <value>grpSeafileAccInfo</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileAccInfo.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="btnSeafileCheckAuthToken.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -10513,6 +15748,90 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;btnSeafileCheckAPIURL.ZOrder" xml:space="preserve">
     <value>14</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileGetAuthToken.Name" xml:space="preserve">
+    <value>btnSeafileGetAuthToken</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileGetAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileGetAuthToken.Parent" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;btnSeafileGetAuthToken.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtSeafilePassword.Name" xml:space="preserve">
+    <value>txtSeafilePassword</value>
+  </data>
+  <data name="&gt;&gt;txtSeafilePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafilePassword.Parent" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;txtSeafilePassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUsername.Name" xml:space="preserve">
+    <value>txtSeafileUsername</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUsername.Parent" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;txtSeafileUsername.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileUsername.Name" xml:space="preserve">
+    <value>lblSeafileUsername</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileUsername.Parent" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;lblSeafileUsername.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePassword.Name" xml:space="preserve">
+    <value>lblSeafilePassword</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePassword.Parent" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;lblSeafilePassword.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Location" type="System.Drawing.Point, System.Drawing">
+    <value>406, 16</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Size" type="System.Drawing.Size, System.Drawing">
+    <value>227, 149</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="grpSeafileObtainAuthToken.Text" xml:space="preserve">
+    <value>Obtain auth token</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
+    <value>grpSeafileObtainAuthToken</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
+    <value>15</value>
   </data>
   <data name="btnSeafileGetAuthToken.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -10642,30 +15961,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lblSeafilePassword.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 16</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 149</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="grpSeafileObtainAuthToken.Text" xml:space="preserve">
-    <value>Obtain auth token</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Name" xml:space="preserve">
-    <value>grpSeafileObtainAuthToken</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.Parent" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;grpSeafileObtainAuthToken.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -10806,33 +16101,6 @@ Using an encrypted library disables sharing.</value>
     <value>tpSeafile</value>
   </data>
   <data name="&gt;&gt;lblSeafileAPIURL.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="tpSeafile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSeafile.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSeafile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSeafile.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="tpSeafile.Text" xml:space="preserve">
-    <value>Seafile</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Name" xml:space="preserve">
-    <value>tpSeafile</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSeafile.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
   <data name="cbStreamableUseDirectURL.AutoSize" type="System.Boolean, mscorlib">
@@ -11012,30 +16280,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cbStreamableAnonymous.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="tpStreamable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpStreamable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpStreamable.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="tpStreamable.Text" xml:space="preserve">
-    <value>Streamable</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Name" xml:space="preserve">
-    <value>tpStreamable</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpStreamable.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
   <data name="btnSulGetAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -11113,33 +16357,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lblSulAPIKey.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="tpSul.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSul.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSul.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSul.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
-  </data>
-  <data name="tpSul.Text" xml:space="preserve">
-    <value>s-ul</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Name" xml:space="preserve">
-    <value>tpSul</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSul.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSul.ZOrder" xml:space="preserve">
-    <value>22</value>
   </data>
   <data name="btnLithiioFetchAPIKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -11348,32 +16565,77 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtLithiioApiKey.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="tpLithiio.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
+  <data name="&gt;&gt;cbPlikOneShot.Name" xml:space="preserve">
+    <value>cbPlikOneShot</value>
   </data>
-  <data name="tpLithiio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;cbPlikOneShot.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpLithiio.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
+  <data name="&gt;&gt;cbPlikOneShot.Parent" xml:space="preserve">
+    <value>gbPlikSettings</value>
   </data>
-  <data name="tpLithiio.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+  <data name="&gt;&gt;cbPlikOneShot.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="tpLithiio.Text" xml:space="preserve">
-    <value>Lithiio</value>
+  <data name="&gt;&gt;txtPlikComment.Name" xml:space="preserve">
+    <value>txtPlikComment</value>
   </data>
-  <data name="&gt;&gt;tpLithiio.Name" xml:space="preserve">
-    <value>tpLithiio</value>
+  <data name="&gt;&gt;txtPlikComment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpLithiio.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtPlikComment.Parent" xml:space="preserve">
+    <value>gbPlikSettings</value>
   </data>
-  <data name="&gt;&gt;tpLithiio.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
+  <data name="&gt;&gt;txtPlikComment.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tpLithiio.ZOrder" xml:space="preserve">
-    <value>23</value>
+  <data name="&gt;&gt;cbPlikComment.Name" xml:space="preserve">
+    <value>cbPlikComment</value>
+  </data>
+  <data name="&gt;&gt;cbPlikComment.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPlikComment.Parent" xml:space="preserve">
+    <value>gbPlikSettings</value>
+  </data>
+  <data name="&gt;&gt;cbPlikComment.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbPlikRemovable.Name" xml:space="preserve">
+    <value>cbPlikRemovable</value>
+  </data>
+  <data name="&gt;&gt;cbPlikRemovable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPlikRemovable.Parent" xml:space="preserve">
+    <value>gbPlikSettings</value>
+  </data>
+  <data name="&gt;&gt;cbPlikRemovable.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="gbPlikSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>292, 19</value>
+  </data>
+  <data name="gbPlikSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>344, 247</value>
+  </data>
+  <data name="gbPlikSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="gbPlikSettings.Text" xml:space="preserve">
+    <value>Other settings</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
+    <value>gbPlikSettings</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
+    <value>tpPlik</value>
+  </data>
+  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbPlikOneShot.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -11489,29 +16751,173 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cbPlikRemovable.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="gbPlikSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>292, 19</value>
+  <data name="&gt;&gt;nudPlikTTL.Name" xml:space="preserve">
+    <value>nudPlikTTL</value>
   </data>
-  <data name="gbPlikSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 247</value>
+  <data name="&gt;&gt;nudPlikTTL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gbPlikSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="&gt;&gt;nudPlikTTL.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
   </data>
-  <data name="gbPlikSettings.Text" xml:space="preserve">
-    <value>Other settings</value>
+  <data name="&gt;&gt;nudPlikTTL.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="&gt;&gt;gbPlikSettings.Name" xml:space="preserve">
-    <value>gbPlikSettings</value>
+  <data name="&gt;&gt;cbxPlikTTLUnit.Name" xml:space="preserve">
+    <value>cbxPlikTTLUnit</value>
   </data>
-  <data name="&gt;&gt;gbPlikSettings.Type" xml:space="preserve">
+  <data name="&gt;&gt;cbxPlikTTLUnit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbxPlikTTLUnit.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;cbxPlikTTLUnit.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblPlikTTL.Name" xml:space="preserve">
+    <value>lblPlikTTL</value>
+  </data>
+  <data name="&gt;&gt;lblPlikTTL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlikTTL.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;lblPlikTTL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtPlikURL.Name" xml:space="preserve">
+    <value>txtPlikURL</value>
+  </data>
+  <data name="&gt;&gt;txtPlikURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPlikURL.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;txtPlikURL.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblPlikURL.Name" xml:space="preserve">
+    <value>lblPlikURL</value>
+  </data>
+  <data name="&gt;&gt;lblPlikURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlikURL.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;lblPlikURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbPlikIsSecured.Name" xml:space="preserve">
+    <value>cbPlikIsSecured</value>
+  </data>
+  <data name="&gt;&gt;cbPlikIsSecured.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPlikIsSecured.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;cbPlikIsSecured.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblPlikAPIKey.Name" xml:space="preserve">
+    <value>lblPlikAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblPlikAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlikAPIKey.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;lblPlikAPIKey.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtPlikAPIKey.Name" xml:space="preserve">
+    <value>txtPlikAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtPlikAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPlikAPIKey.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;txtPlikAPIKey.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblPlikPassword.Name" xml:space="preserve">
+    <value>lblPlikPassword</value>
+  </data>
+  <data name="&gt;&gt;lblPlikPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlikPassword.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;lblPlikPassword.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;lblPlikUsername.Name" xml:space="preserve">
+    <value>lblPlikUsername</value>
+  </data>
+  <data name="&gt;&gt;lblPlikUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPlikUsername.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;lblPlikUsername.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;txtPlikPassword.Name" xml:space="preserve">
+    <value>txtPlikPassword</value>
+  </data>
+  <data name="&gt;&gt;txtPlikPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPlikPassword.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;txtPlikPassword.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtPlikLogin.Name" xml:space="preserve">
+    <value>txtPlikLogin</value>
+  </data>
+  <data name="&gt;&gt;txtPlikLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPlikLogin.Parent" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;txtPlikLogin.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="gbPlikLoginCredentials.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 19</value>
+  </data>
+  <data name="gbPlikLoginCredentials.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 247</value>
+  </data>
+  <data name="gbPlikLoginCredentials.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="gbPlikLoginCredentials.Text" xml:space="preserve">
+    <value>Login Credentials</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
+    <value>gbPlikLoginCredentials</value>
+  </data>
+  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPlikSettings.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
     <value>tpPlik</value>
   </data>
-  <data name="&gt;&gt;gbPlikSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="nudPlikTTL.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 217</value>
@@ -11831,57 +17237,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtPlikLogin.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="gbPlikLoginCredentials.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 19</value>
-  </data>
-  <data name="gbPlikLoginCredentials.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 247</value>
-  </data>
-  <data name="gbPlikLoginCredentials.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="gbPlikLoginCredentials.Text" xml:space="preserve">
-    <value>Login Credentials</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Name" xml:space="preserve">
-    <value>gbPlikLoginCredentials</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.Parent" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;gbPlikLoginCredentials.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpPlik.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpPlik.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPlik.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpPlik.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="tpPlik.Text" xml:space="preserve">
-    <value>Plik</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Name" xml:space="preserve">
-    <value>tpPlik</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpPlik.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
   <data name="cbYouTubeUseShortenedLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -11983,30 +17338,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;oauth2YouTube.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="tpYouTube.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpYouTube.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpYouTube.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
-  </data>
-  <data name="tpYouTube.Text" xml:space="preserve">
-    <value>YouTube</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Name" xml:space="preserve">
-    <value>tpYouTube</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpYouTube.ZOrder" xml:space="preserve">
-    <value>25</value>
   </data>
   <data name="lbSharedFolderAccounts.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -12277,33 +17608,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;cboSharedFolderImages.ZOrder" xml:space="preserve">
     <value>10</value>
-  </data>
-  <data name="tpSharedFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpSharedFolder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpSharedFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpSharedFolder.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="tpSharedFolder.Text" xml:space="preserve">
-    <value>Shared folder</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.Name" xml:space="preserve">
-    <value>tpSharedFolder</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpSharedFolder.ZOrder" xml:space="preserve">
-    <value>26</value>
   </data>
   <data name="txtEmailAutomaticSendTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 408</value>
@@ -12698,84 +18002,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtEmailDefaultSubject.ZOrder" xml:space="preserve">
     <value>14</value>
   </data>
-  <data name="tpEmail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 202</value>
-  </data>
-  <data name="tpEmail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
-  </data>
-  <data name="tpEmail.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="tpEmail.Text" xml:space="preserve">
-    <value>Email</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Name" xml:space="preserve">
-    <value>tpEmail</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.Parent" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpEmail.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="tcFileUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
-  </data>
-  <data name="tcFileUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcFileUploaders.Name" xml:space="preserve">
-    <value>tcFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcFileUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcFileUploaders.Parent" xml:space="preserve">
-    <value>tpFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcFileUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpFileUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpFileUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
-  </data>
-  <data name="tpFileUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpFileUploaders.Text" xml:space="preserve">
-    <value>File uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFileUploaders.Name" xml:space="preserve">
-    <value>tpFileUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFileUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFileUploaders.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpFileUploaders.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="btnCopyShowFiles.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -12793,6 +18019,372 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;btnCopyShowFiles.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
+    <value>tpTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTextUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>986, 569</value>
+  </data>
+  <data name="tpTextUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpTextUploaders.Text" xml:space="preserve">
+    <value>Text uploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTextUploaders.Name" xml:space="preserve">
+    <value>tpTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTextUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTextUploaders.Parent" xml:space="preserve">
+    <value>tcUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTextUploaders.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
+    <value>tpPaste_ee</value>
+  </data>
+  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
+    <value>tpUpaste</value>
+  </data>
+  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;tpPastie.Name" xml:space="preserve">
+    <value>tpPastie</value>
+  </data>
+  <data name="&gt;&gt;tpPastie.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPastie.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPastie.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tcTextUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcTextUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
+    <value>tpTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinRaw.Name" xml:space="preserve">
+    <value>cbPastebinRaw</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinRaw.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinRaw.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinRaw.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinSyntax.Name" xml:space="preserve">
+    <value>cbPastebinSyntax</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinSyntax.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinSyntax.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinSyntax.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinRegister.Name" xml:space="preserve">
+    <value>btnPastebinRegister</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinRegister.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinRegister.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinRegister.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinSyntax.Name" xml:space="preserve">
+    <value>lblPastebinSyntax</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinSyntax.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinSyntax.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinSyntax.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinExpiration.Name" xml:space="preserve">
+    <value>lblPastebinExpiration</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinExpiration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinExpiration.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinExpiration.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPrivacy.Name" xml:space="preserve">
+    <value>lblPastebinPrivacy</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPrivacy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPrivacy.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPrivacy.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinTitle.Name" xml:space="preserve">
+    <value>lblPastebinTitle</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinTitle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinTitle.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinTitle.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPassword.Name" xml:space="preserve">
+    <value>lblPastebinPassword</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPassword.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinPassword.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinUsername.Name" xml:space="preserve">
+    <value>lblPastebinUsername</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinUsername.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinUsername.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinExpiration.Name" xml:space="preserve">
+    <value>cbPastebinExpiration</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinExpiration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinExpiration.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinExpiration.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinPrivacy.Name" xml:space="preserve">
+    <value>cbPastebinPrivacy</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinPrivacy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinPrivacy.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;cbPastebinPrivacy.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinTitle.Name" xml:space="preserve">
+    <value>txtPastebinTitle</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinTitle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinTitle.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinTitle.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinPassword.Name" xml:space="preserve">
+    <value>txtPastebinPassword</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinPassword.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinPassword.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinUsername.Name" xml:space="preserve">
+    <value>txtPastebinUsername</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinUsername.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;txtPastebinUsername.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinLoginStatus.Name" xml:space="preserve">
+    <value>lblPastebinLoginStatus</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinLoginStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinLoginStatus.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;lblPastebinLoginStatus.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinLogin.Name" xml:space="preserve">
+    <value>btnPastebinLogin</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinLogin.Parent" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;btnPastebinLogin.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="tpPastebin.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpPastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpPastebin.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpPastebin.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpPastebin.Text" xml:space="preserve">
+    <value>Pastebin</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
+    <value>tpPastebin</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
+    <value>tcTextUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbPastebinRaw.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13214,32 +18806,68 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnPastebinLogin.ZOrder" xml:space="preserve">
     <value>15</value>
   </data>
-  <data name="tpPastebin.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;btnPaste_eeGetUserKey.Name" xml:space="preserve">
+    <value>btnPaste_eeGetUserKey</value>
+  </data>
+  <data name="&gt;&gt;btnPaste_eeGetUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPaste_eeGetUserKey.Parent" xml:space="preserve">
+    <value>tpPaste_ee</value>
+  </data>
+  <data name="&gt;&gt;btnPaste_eeGetUserKey.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Name" xml:space="preserve">
+    <value>lblPaste_eeUserAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPaste_eeUserAPIKey.Parent" xml:space="preserve">
+    <value>tpPaste_ee</value>
+  </data>
+  <data name="&gt;&gt;lblPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Name" xml:space="preserve">
+    <value>txtPaste_eeUserAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPaste_eeUserAPIKey.Parent" xml:space="preserve">
+    <value>tpPaste_ee</value>
+  </data>
+  <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpPaste_ee.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpPaste_ee.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpPastebin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="tpPaste_ee.Size" type="System.Drawing.Size, System.Drawing">
+    <value>178, 42</value>
   </data>
-  <data name="tpPastebin.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpPaste_ee.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpPastebin.Text" xml:space="preserve">
-    <value>Pastebin</value>
+  <data name="tpPaste_ee.Text" xml:space="preserve">
+    <value>Paste.ee</value>
   </data>
-  <data name="&gt;&gt;tpPastebin.Name" xml:space="preserve">
-    <value>tpPastebin</value>
+  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
+    <value>tpPaste_ee</value>
   </data>
-  <data name="&gt;&gt;tpPastebin.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPastebin.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpPastebin.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnPaste_eeGetUserKey.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -13319,32 +18947,113 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtPaste_eeUserAPIKey.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpPaste_ee.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;lblGistCustomURLExample.Name" xml:space="preserve">
+    <value>lblGistCustomURLExample</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURLExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURLExample.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURLExample.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblGistOAuthInfo.Name" xml:space="preserve">
+    <value>lblGistOAuthInfo</value>
+  </data>
+  <data name="&gt;&gt;lblGistOAuthInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGistOAuthInfo.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;lblGistOAuthInfo.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURL.Name" xml:space="preserve">
+    <value>lblGistCustomURL</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURL.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;lblGistCustomURL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtGistCustomURL.Name" xml:space="preserve">
+    <value>txtGistCustomURL</value>
+  </data>
+  <data name="&gt;&gt;txtGistCustomURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtGistCustomURL.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;txtGistCustomURL.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbGistUseRawURL.Name" xml:space="preserve">
+    <value>cbGistUseRawURL</value>
+  </data>
+  <data name="&gt;&gt;cbGistUseRawURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGistUseRawURL.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;cbGistUseRawURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbGistPublishPublic.Name" xml:space="preserve">
+    <value>cbGistPublishPublic</value>
+  </data>
+  <data name="&gt;&gt;cbGistPublishPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGistPublishPublic.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;cbGistPublishPublic.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;oAuth2Gist.Name" xml:space="preserve">
+    <value>oAuth2Gist</value>
+  </data>
+  <data name="&gt;&gt;oAuth2Gist.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oAuth2Gist.Parent" xml:space="preserve">
+    <value>tpGist</value>
+  </data>
+  <data name="&gt;&gt;oAuth2Gist.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tpGist.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPaste_ee.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpPaste_ee.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpGist.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpPaste_ee.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpGist.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpPaste_ee.Text" xml:space="preserve">
-    <value>Paste.ee</value>
+  <data name="tpGist.Text" xml:space="preserve">
+    <value>GitHub Gist</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Name" xml:space="preserve">
-    <value>tpPaste_ee</value>
+  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
+    <value>tpGist</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpPaste_ee.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="lblGistCustomURLExample.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13538,29 +19247,68 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oAuth2Gist.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tpGist.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;cbUpasteIsPublic.Name" xml:space="preserve">
+    <value>cbUpasteIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbUpasteIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbUpasteIsPublic.Parent" xml:space="preserve">
+    <value>tpUpaste</value>
+  </data>
+  <data name="&gt;&gt;cbUpasteIsPublic.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblUpasteUserKey.Name" xml:space="preserve">
+    <value>lblUpasteUserKey</value>
+  </data>
+  <data name="&gt;&gt;lblUpasteUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUpasteUserKey.Parent" xml:space="preserve">
+    <value>tpUpaste</value>
+  </data>
+  <data name="&gt;&gt;lblUpasteUserKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtUpasteUserKey.Name" xml:space="preserve">
+    <value>txtUpasteUserKey</value>
+  </data>
+  <data name="&gt;&gt;txtUpasteUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtUpasteUserKey.Parent" xml:space="preserve">
+    <value>tpUpaste</value>
+  </data>
+  <data name="&gt;&gt;txtUpasteUserKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpUpaste.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpGist.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpUpaste.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpUpaste.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpGist.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpUpaste.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="tpGist.Text" xml:space="preserve">
-    <value>GitHub Gist</value>
+  <data name="tpUpaste.Text" xml:space="preserve">
+    <value>uPaste</value>
   </data>
-  <data name="&gt;&gt;tpGist.Name" xml:space="preserve">
-    <value>tpGist</value>
+  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
+    <value>tpUpaste</value>
   </data>
-  <data name="&gt;&gt;tpGist.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGist.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpGist.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="cbUpasteIsPublic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13643,32 +19391,92 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtUpasteUserKey.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpUpaste.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;cbHastebinUseFileExtension.Name" xml:space="preserve">
+    <value>cbHastebinUseFileExtension</value>
+  </data>
+  <data name="&gt;&gt;cbHastebinUseFileExtension.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbHastebinUseFileExtension.Parent" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;cbHastebinUseFileExtension.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Name" xml:space="preserve">
+    <value>txtHastebinSyntaxHighlighting</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.Parent" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinSyntaxHighlighting.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinCustomDomain.Name" xml:space="preserve">
+    <value>txtHastebinCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinCustomDomain.Parent" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;txtHastebinCustomDomain.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Name" xml:space="preserve">
+    <value>lblHastebinSyntaxHighlighting</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.Parent" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinSyntaxHighlighting.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinCustomDomain.Name" xml:space="preserve">
+    <value>lblHastebinCustomDomain</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinCustomDomain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinCustomDomain.Parent" xml:space="preserve">
+    <value>tpHastebin</value>
+  </data>
+  <data name="&gt;&gt;lblHastebinCustomDomain.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpHastebin.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUpaste.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpHastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpUpaste.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpHastebin.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpUpaste.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpHastebin.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpUpaste.Text" xml:space="preserve">
-    <value>uPaste</value>
+  <data name="tpHastebin.Text" xml:space="preserve">
+    <value>Hastebin</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Name" xml:space="preserve">
-    <value>tpUpaste</value>
+  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
+    <value>tpHastebin</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpUpaste.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="cbHastebinUseFileExtension.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13802,32 +19610,80 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblHastebinCustomDomain.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpHastebin.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Name" xml:space="preserve">
+    <value>lblOneTimeSecretAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretAPIKey.Parent" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretAPIKey.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretEmail.Name" xml:space="preserve">
+    <value>lblOneTimeSecretEmail</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretEmail.Parent" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;lblOneTimeSecretEmail.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Name" xml:space="preserve">
+    <value>txtOneTimeSecretAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretAPIKey.Parent" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretAPIKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretEmail.Name" xml:space="preserve">
+    <value>txtOneTimeSecretEmail</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretEmail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretEmail.Parent" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
+  </data>
+  <data name="&gt;&gt;txtOneTimeSecretEmail.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpOneTimeSecret.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpHastebin.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpOneTimeSecret.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpHastebin.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpOneTimeSecret.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 42</value>
   </data>
-  <data name="tpHastebin.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="tpOneTimeSecret.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="tpHastebin.Text" xml:space="preserve">
-    <value>Hastebin</value>
+  <data name="tpOneTimeSecret.Text" xml:space="preserve">
+    <value>OneTimeSecret</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Name" xml:space="preserve">
-    <value>tpHastebin</value>
+  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
+    <value>tpOneTimeSecret</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
     <value>tcTextUploaders</value>
   </data>
-  <data name="&gt;&gt;tpHastebin.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="lblOneTimeSecretAPIKey.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -13931,51 +19787,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;txtOneTimeSecretEmail.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tpOneTimeSecret.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpOneTimeSecret.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpOneTimeSecret.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 42</value>
-  </data>
-  <data name="tpOneTimeSecret.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="tpOneTimeSecret.Text" xml:space="preserve">
-    <value>OneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Name" xml:space="preserve">
-    <value>tpOneTimeSecret</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.Parent" xml:space="preserve">
-    <value>tcTextUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpOneTimeSecret.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="cbPastieIsPublic.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbPastieIsPublic.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbPastieIsPublic.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 22</value>
-  </data>
-  <data name="cbPastieIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
-  </data>
-  <data name="cbPastieIsPublic.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="cbPastieIsPublic.Text" xml:space="preserve">
-    <value>Is public upload?</value>
-  </data>
   <data name="&gt;&gt;cbPastieIsPublic.Name" xml:space="preserve">
     <value>cbPastieIsPublic</value>
   </data>
@@ -14015,56 +19826,332 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;tpPastie.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tcTextUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="cbPastieIsPublic.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="tcTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+  <data name="cbPastieIsPublic.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="tcTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
+  <data name="cbPastieIsPublic.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 22</value>
   </data>
-  <data name="tcTextUploaders.TabIndex" type="System.Int32, mscorlib">
+  <data name="cbPastieIsPublic.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 17</value>
+  </data>
+  <data name="cbPastieIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcTextUploaders.Name" xml:space="preserve">
-    <value>tcTextUploaders</value>
+  <data name="cbPastieIsPublic.Text" xml:space="preserve">
+    <value>Is public upload?</value>
   </data>
-  <data name="&gt;&gt;tcTextUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;cbPastieIsPublic.Name" xml:space="preserve">
+    <value>cbPastieIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbPastieIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPastieIsPublic.Parent" xml:space="preserve">
+    <value>tpPastie</value>
+  </data>
+  <data name="&gt;&gt;cbPastieIsPublic.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcTextUploaders.Parent" xml:space="preserve">
-    <value>tpTextUploaders</value>
+  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
+    <value>tpImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tcTextUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpTextUploaders.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpTextUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpImageUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
     <value>986, 569</value>
   </data>
-  <data name="tpTextUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpImageUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpTextUploaders.Text" xml:space="preserve">
-    <value>Text uploaders</value>
+  <data name="tpImageUploaders.Text" xml:space="preserve">
+    <value>Image uploaders</value>
   </data>
-  <data name="&gt;&gt;tpTextUploaders.Name" xml:space="preserve">
-    <value>tpTextUploaders</value>
+  <data name="&gt;&gt;tpImageUploaders.Name" xml:space="preserve">
+    <value>tpImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpTextUploaders.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpImageUploaders.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpTextUploaders.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpImageUploaders.Parent" xml:space="preserve">
     <value>tcUploaders</value>
   </data>
-  <data name="&gt;&gt;tpTextUploaders.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpImageUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
+    <value>tpFlickr</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
+    <value>tpPhotobucket</value>
+  </data>
+  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
+    <value>tpGooglePhotos</value>
+  </data>
+  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
+    <value>tpVgyme</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tcImageUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcImageUploaders.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>780, 480</value>
+  </data>
+  <data name="tcImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>980, 563</value>
+  </data>
+  <data name="tcImageUploaders.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
+    <value>tpImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUseGIFV.Name" xml:space="preserve">
+    <value>cbImgurUseGIFV</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUseGIFV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUseGIFV.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUseGIFV.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Name" xml:space="preserve">
+    <value>cbImgurUploadSelectedAlbum</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;cbImgurUploadSelectedAlbum.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbImgurDirectLink.Name" xml:space="preserve">
+    <value>cbImgurDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbImgurDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImgurDirectLink.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;cbImgurDirectLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;atcImgurAccountType.Name" xml:space="preserve">
+    <value>atcImgurAccountType</value>
+  </data>
+  <data name="&gt;&gt;atcImgurAccountType.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;atcImgurAccountType.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;atcImgurAccountType.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;oauth2Imgur.Name" xml:space="preserve">
+    <value>oauth2Imgur</value>
+  </data>
+  <data name="&gt;&gt;oauth2Imgur.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Imgur.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;oauth2Imgur.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvImgurAlbumList.Name" xml:space="preserve">
+    <value>lvImgurAlbumList</value>
+  </data>
+  <data name="&gt;&gt;lvImgurAlbumList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvImgurAlbumList.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;lvImgurAlbumList.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnImgurRefreshAlbumList.Name" xml:space="preserve">
+    <value>btnImgurRefreshAlbumList</value>
+  </data>
+  <data name="&gt;&gt;btnImgurRefreshAlbumList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnImgurRefreshAlbumList.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;btnImgurRefreshAlbumList.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cbImgurThumbnailType.Name" xml:space="preserve">
+    <value>cbImgurThumbnailType</value>
+  </data>
+  <data name="&gt;&gt;cbImgurThumbnailType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImgurThumbnailType.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;cbImgurThumbnailType.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblImgurThumbnailType.Name" xml:space="preserve">
+    <value>lblImgurThumbnailType</value>
+  </data>
+  <data name="&gt;&gt;lblImgurThumbnailType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImgurThumbnailType.Parent" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;lblImgurThumbnailType.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tpImgur.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpImgur.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpImgur.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpImgur.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpImgur.Text" xml:space="preserve">
+    <value>Imgur</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
+    <value>tpImgur</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
+    <value>tcImageUploaders</value>
+  </data>
+  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbImgurUseGIFV.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14198,21 +20285,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauth2Imgur.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="chImgurID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="chImgurTitle.Text" xml:space="preserve">
-    <value>Title</value>
-  </data>
-  <data name="chImgurTitle.Width" type="System.Int32, mscorlib">
-    <value>150</value>
-  </data>
-  <data name="chImgurDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chImgurDescription.Width" type="System.Int32, mscorlib">
-    <value>226</value>
-  </data>
   <data name="lvImgurAlbumList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 48</value>
   </data>
@@ -14233,6 +20305,21 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvImgurAlbumList.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="chImgurID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="chImgurTitle.Text" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="chImgurTitle.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="chImgurDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chImgurDescription.Width" type="System.Int32, mscorlib">
+    <value>226</value>
   </data>
   <data name="btnImgurRefreshAlbumList.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -14315,32 +20402,128 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblImgurThumbnailType.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpImgur.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnImageShackLogin.Name" xml:space="preserve">
+    <value>btnImageShackLogin</value>
   </data>
-  <data name="tpImgur.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnImageShackLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpImgur.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="&gt;&gt;btnImageShackLogin.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
   </data>
-  <data name="tpImgur.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnImageShackLogin.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Name" xml:space="preserve">
+    <value>btnImageShackOpenPublicProfile</value>
+  </data>
+  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnImageShackOpenPublicProfile.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;btnImageShackOpenPublicProfile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbImageShackIsPublic.Name" xml:space="preserve">
+    <value>cbImageShackIsPublic</value>
+  </data>
+  <data name="&gt;&gt;cbImageShackIsPublic.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageShackIsPublic.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;cbImageShackIsPublic.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpImgur.Text" xml:space="preserve">
-    <value>Imgur</value>
+  <data name="&gt;&gt;btnImageShackOpenMyImages.Name" xml:space="preserve">
+    <value>btnImageShackOpenMyImages</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Name" xml:space="preserve">
-    <value>tpImgur</value>
+  <data name="&gt;&gt;btnImageShackOpenMyImages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnImageShackOpenMyImages.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;btnImageShackOpenMyImages.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackUsername.Name" xml:space="preserve">
+    <value>lblImageShackUsername</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackUsername.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackUsername.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackUsername.Name" xml:space="preserve">
+    <value>txtImageShackUsername</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackUsername.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackUsername.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackPassword.Name" xml:space="preserve">
+    <value>txtImageShackPassword</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackPassword.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;txtImageShackPassword.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackPassword.Name" xml:space="preserve">
+    <value>lblImageShackPassword</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackPassword.Parent" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;lblImageShackPassword.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tpImageShack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpImageShack.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpImageShack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpImageShack.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpImageShack.Text" xml:space="preserve">
+    <value>ImageShack</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
+    <value>tpImageShack</value>
+  </data>
+  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImgur.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpImgur.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnImageShackLogin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -14555,32 +20738,116 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblImageShackPassword.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="tpImageShack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;atcTinyPicAccountType.Name" xml:space="preserve">
+    <value>atcTinyPicAccountType</value>
   </data>
-  <data name="tpImageShack.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;atcTinyPicAccountType.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.AccountTypeControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="tpImageShack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="&gt;&gt;atcTinyPicAccountType.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
   </data>
-  <data name="tpImageShack.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;atcTinyPicAccountType.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpImageShack.Text" xml:space="preserve">
-    <value>ImageShack</value>
+  <data name="&gt;&gt;btnTinyPicLogin.Name" xml:space="preserve">
+    <value>btnTinyPicLogin</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Name" xml:space="preserve">
-    <value>tpImageShack</value>
+  <data name="&gt;&gt;btnTinyPicLogin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnTinyPicLogin.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;btnTinyPicLogin.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicPassword.Name" xml:space="preserve">
+    <value>txtTinyPicPassword</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicPassword.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicPassword.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicPassword.Name" xml:space="preserve">
+    <value>lblTinyPicPassword</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicPassword.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicUsername.Name" xml:space="preserve">
+    <value>txtTinyPicUsername</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicUsername.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;txtTinyPicUsername.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicUsername.Name" xml:space="preserve">
+    <value>lblTinyPicUsername</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicUsername.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;lblTinyPicUsername.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnTinyPicOpenMyImages.Name" xml:space="preserve">
+    <value>btnTinyPicOpenMyImages</value>
+  </data>
+  <data name="&gt;&gt;btnTinyPicOpenMyImages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnTinyPicOpenMyImages.Parent" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;btnTinyPicOpenMyImages.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tpTinyPic.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTinyPic.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpTinyPic.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpTinyPic.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpTinyPic.Text" xml:space="preserve">
+    <value>TinyPic</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
+    <value>tpTinyPic</value>
+  </data>
+  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpImageShack.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="atcTinyPicAccountType.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 16</value>
@@ -14759,32 +21026,56 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnTinyPicOpenMyImages.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="tpTinyPic.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;cbFlickrDirectLink.Name" xml:space="preserve">
+    <value>cbFlickrDirectLink</value>
   </data>
-  <data name="tpTinyPic.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;cbFlickrDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpTinyPic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="&gt;&gt;cbFlickrDirectLink.Parent" xml:space="preserve">
+    <value>tpFlickr</value>
   </data>
-  <data name="tpTinyPic.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cbFlickrDirectLink.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;oauthFlickr.Name" xml:space="preserve">
+    <value>oauthFlickr</value>
+  </data>
+  <data name="&gt;&gt;oauthFlickr.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauthFlickr.Parent" xml:space="preserve">
+    <value>tpFlickr</value>
+  </data>
+  <data name="&gt;&gt;oauthFlickr.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpTinyPic.Text" xml:space="preserve">
-    <value>TinyPic</value>
+  <data name="tpFlickr.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Name" xml:space="preserve">
-    <value>tpTinyPic</value>
+  <data name="tpFlickr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Type" xml:space="preserve">
+  <data name="tpFlickr.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpFlickr.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpFlickr.Text" xml:space="preserve">
+    <value>Flickr</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
+    <value>tpFlickr</value>
+  </data>
+  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpTinyPic.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="cbFlickrDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -14837,32 +21128,128 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauthFlickr.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpFlickr.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
+    <value>tpPhotobucket</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
+    <value>tpPhotobucket</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
+    <value>tpPhotobucket</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpPhotobucket.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpFlickr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpPhotobucket.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpFlickr.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpPhotobucket.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpFlickr.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpPhotobucket.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpFlickr.Text" xml:space="preserve">
-    <value>Flickr</value>
+  <data name="tpPhotobucket.Text" xml:space="preserve">
+    <value>Photobucket</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Name" xml:space="preserve">
-    <value>tpFlickr</value>
+  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
+    <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpFlickr.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAddAlbum.Name" xml:space="preserve">
+    <value>btnPhotobucketAddAlbum</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAddAlbum.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAddAlbum.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAddAlbum.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Name" xml:space="preserve">
+    <value>btnPhotobucketRemoveAlbum</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketRemoveAlbum.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Name" xml:space="preserve">
+    <value>cboPhotobucketAlbumPaths</value>
+  </data>
+  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboPhotobucketAlbumPaths.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;cboPhotobucketAlbumPaths.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="gbPhotobucketAlbumPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 208</value>
+  </data>
+  <data name="gbPhotobucketAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 64</value>
+  </data>
+  <data name="gbPhotobucketAlbumPath.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="gbPhotobucketAlbumPath.Text" xml:space="preserve">
+    <value>Upload images to</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
+    <value>tpPhotobucket</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnPhotobucketAddAlbum.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -14942,29 +21329,89 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cboPhotobucketAlbumPaths.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="gbPhotobucketAlbumPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 208</value>
+  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Name" xml:space="preserve">
+    <value>lblPhotobucketNewAlbumName</value>
   </data>
-  <data name="gbPhotobucketAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 64</value>
+  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gbPhotobucketAlbumPath.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lblPhotobucketNewAlbumName.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketNewAlbumName.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Name" xml:space="preserve">
+    <value>lblPhotobucketParentAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketParentAlbumPath.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="gbPhotobucketAlbumPath.Text" xml:space="preserve">
-    <value>Upload images to</value>
+  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Name" xml:space="preserve">
+    <value>txtPhotobucketNewAlbumName</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbumPath</value>
+  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Type" xml:space="preserve">
+  <data name="&gt;&gt;txtPhotobucketNewAlbumName.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketNewAlbumName.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Name" xml:space="preserve">
+    <value>txtPhotobucketParentAlbumPath</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketParentAlbumPath.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Name" xml:space="preserve">
+    <value>btnPhotobucketCreateAlbum</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketCreateAlbum.Parent" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketCreateAlbum.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="gbPhotobucketAlbums.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 280</value>
+  </data>
+  <data name="gbPhotobucketAlbums.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 128</value>
+  </data>
+  <data name="gbPhotobucketAlbums.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="gbPhotobucketAlbums.Text" xml:space="preserve">
+    <value>Create new album</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
+    <value>gbPhotobucketAlbums</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
     <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbumPath.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblPhotobucketNewAlbumName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -15095,29 +21542,113 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;btnPhotobucketCreateAlbum.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="gbPhotobucketAlbums.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 280</value>
+  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Name" xml:space="preserve">
+    <value>lblPhotobucketDefaultAlbumName</value>
   </data>
-  <data name="gbPhotobucketAlbums.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 128</value>
+  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gbPhotobucketAlbums.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketDefaultAlbumName.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthOpen.Name" xml:space="preserve">
+    <value>btnPhotobucketAuthOpen</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthOpen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthOpen.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthOpen.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Name" xml:space="preserve">
+    <value>txtPhotobucketDefaultAlbumName</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketDefaultAlbumName.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="gbPhotobucketAlbums.Text" xml:space="preserve">
-    <value>Create new album</value>
+  <data name="&gt;&gt;lblPhotobucketVerificationCode.Name" xml:space="preserve">
+    <value>lblPhotobucketVerificationCode</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Name" xml:space="preserve">
-    <value>gbPhotobucketAlbums</value>
+  <data name="&gt;&gt;lblPhotobucketVerificationCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblPhotobucketVerificationCode.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketVerificationCode.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthComplete.Name" xml:space="preserve">
+    <value>btnPhotobucketAuthComplete</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthComplete.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthComplete.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;btnPhotobucketAuthComplete.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketVerificationCode.Name" xml:space="preserve">
+    <value>txtPhotobucketVerificationCode</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketVerificationCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketVerificationCode.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;txtPhotobucketVerificationCode.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketAccountStatus.Name" xml:space="preserve">
+    <value>lblPhotobucketAccountStatus</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketAccountStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketAccountStatus.Parent" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;lblPhotobucketAccountStatus.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="gbPhotobucketUserAccount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="gbPhotobucketUserAccount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>712, 184</value>
+  </data>
+  <data name="gbPhotobucketUserAccount.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbPhotobucketUserAccount.Text" xml:space="preserve">
+    <value>User account</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
+    <value>gbPhotobucketUserAccount</value>
+  </data>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
     <value>tpPhotobucket</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketAlbums.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="lblPhotobucketDefaultAlbumName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -15305,56 +21836,92 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblPhotobucketAccountStatus.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="gbPhotobucketUserAccount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 16</value>
+  <data name="&gt;&gt;txtPicasaAlbumID.Name" xml:space="preserve">
+    <value>txtPicasaAlbumID</value>
   </data>
-  <data name="gbPhotobucketUserAccount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 184</value>
+  <data name="&gt;&gt;txtPicasaAlbumID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gbPhotobucketUserAccount.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;txtPicasaAlbumID.Parent" xml:space="preserve">
+    <value>tpGooglePhotos</value>
+  </data>
+  <data name="&gt;&gt;txtPicasaAlbumID.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="gbPhotobucketUserAccount.Text" xml:space="preserve">
-    <value>User account</value>
+  <data name="&gt;&gt;lblPicasaAlbumID.Name" xml:space="preserve">
+    <value>lblPicasaAlbumID</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Name" xml:space="preserve">
-    <value>gbPhotobucketUserAccount</value>
+  <data name="&gt;&gt;lblPicasaAlbumID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblPicasaAlbumID.Parent" xml:space="preserve">
+    <value>tpGooglePhotos</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.Parent" xml:space="preserve">
-    <value>tpPhotobucket</value>
+  <data name="&gt;&gt;lblPicasaAlbumID.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;gbPhotobucketUserAccount.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lvPicasaAlbumList.Name" xml:space="preserve">
+    <value>lvPicasaAlbumList</value>
+  </data>
+  <data name="&gt;&gt;lvPicasaAlbumList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvPicasaAlbumList.Parent" xml:space="preserve">
+    <value>tpGooglePhotos</value>
+  </data>
+  <data name="&gt;&gt;lvPicasaAlbumList.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpPhotobucket.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Name" xml:space="preserve">
+    <value>btnPicasaRefreshAlbumList</value>
+  </data>
+  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPicasaRefreshAlbumList.Parent" xml:space="preserve">
+    <value>tpGooglePhotos</value>
+  </data>
+  <data name="&gt;&gt;btnPicasaRefreshAlbumList.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;oauth2Picasa.Name" xml:space="preserve">
+    <value>oauth2Picasa</value>
+  </data>
+  <data name="&gt;&gt;oauth2Picasa.Type" xml:space="preserve">
+    <value>ShareX.UploadersLib.OAuthControl, ShareX.UploadersLib, Version=12.2.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;oauth2Picasa.Parent" xml:space="preserve">
+    <value>tpGooglePhotos</value>
+  </data>
+  <data name="&gt;&gt;oauth2Picasa.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpGooglePhotos.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpPhotobucket.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpGooglePhotos.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpPhotobucket.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpGooglePhotos.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpPhotobucket.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="tpGooglePhotos.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="tpPhotobucket.Text" xml:space="preserve">
-    <value>Photobucket</value>
+  <data name="tpGooglePhotos.Text" xml:space="preserve">
+    <value>Google Photos</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Name" xml:space="preserve">
-    <value>tpPhotobucket</value>
+  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
+    <value>tpGooglePhotos</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpPhotobucket.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="txtPicasaAlbumID.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 64</value>
@@ -15407,24 +21974,6 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblPicasaAlbumID.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="chPicasaID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="chPicasaID.Width" type="System.Int32, mscorlib">
-    <value>135</value>
-  </data>
-  <data name="chPicasaName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="chPicasaName.Width" type="System.Int32, mscorlib">
-    <value>150</value>
-  </data>
-  <data name="chPicasaDescription.Text" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="chPicasaDescription.Width" type="System.Int32, mscorlib">
-    <value>143</value>
-  </data>
   <data name="lvPicasaAlbumList.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 88</value>
   </data>
@@ -15445,6 +21994,24 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvPicasaAlbumList.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="chPicasaID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="chPicasaID.Width" type="System.Int32, mscorlib">
+    <value>135</value>
+  </data>
+  <data name="chPicasaName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="chPicasaName.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="chPicasaDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="chPicasaDescription.Width" type="System.Int32, mscorlib">
+    <value>143</value>
   </data>
   <data name="btnPicasaRefreshAlbumList.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -15497,32 +22064,140 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;oauth2Picasa.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpGooglePhotos.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnCheveretoTestAll.Name" xml:space="preserve">
+    <value>btnCheveretoTestAll</value>
   </data>
-  <data name="tpGooglePhotos.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnCheveretoTestAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpGooglePhotos.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
+  <data name="&gt;&gt;btnCheveretoTestAll.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
   </data>
-  <data name="tpGooglePhotos.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnCheveretoTestAll.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURLExample.Name" xml:space="preserve">
+    <value>lblCheveretoUploadURLExample</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURLExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURLExample.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURLExample.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploaders.Name" xml:space="preserve">
+    <value>lblCheveretoUploaders</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploaders.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploaders.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoUploaders.Name" xml:space="preserve">
+    <value>cbCheveretoUploaders</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoUploaders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoUploaders.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoUploaders.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoDirectURL.Name" xml:space="preserve">
+    <value>cbCheveretoDirectURL</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoDirectURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoDirectURL.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;cbCheveretoDirectURL.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURL.Name" xml:space="preserve">
+    <value>lblCheveretoUploadURL</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURL.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoUploadURL.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoUploadURL.Name" xml:space="preserve">
+    <value>txtCheveretoUploadURL</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoUploadURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoUploadURL.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoUploadURL.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoAPIKey.Name" xml:space="preserve">
+    <value>txtCheveretoAPIKey</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoAPIKey.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;txtCheveretoAPIKey.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoAPIKey.Name" xml:space="preserve">
+    <value>lblCheveretoAPIKey</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoAPIKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoAPIKey.Parent" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;lblCheveretoAPIKey.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpGooglePhotos.Text" xml:space="preserve">
-    <value>Google Photos</value>
+  <data name="tpChevereto.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Name" xml:space="preserve">
-    <value>tpGooglePhotos</value>
+  <data name="tpChevereto.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Type" xml:space="preserve">
+  <data name="tpChevereto.Size" type="System.Drawing.Size, System.Drawing">
+    <value>972, 537</value>
+  </data>
+  <data name="tpChevereto.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="tpChevereto.Text" xml:space="preserve">
+    <value>Chevereto</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
+    <value>tpChevereto</value>
+  </data>
+  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpGooglePhotos.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="btnCheveretoTestAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -15767,32 +22442,68 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;lblCheveretoAPIKey.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpChevereto.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;llVgymeAccountDetailsPage.Name" xml:space="preserve">
+    <value>llVgymeAccountDetailsPage</value>
+  </data>
+  <data name="&gt;&gt;llVgymeAccountDetailsPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;llVgymeAccountDetailsPage.Parent" xml:space="preserve">
+    <value>tpVgyme</value>
+  </data>
+  <data name="&gt;&gt;llVgymeAccountDetailsPage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtVgymeUserKey.Name" xml:space="preserve">
+    <value>txtVgymeUserKey</value>
+  </data>
+  <data name="&gt;&gt;txtVgymeUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtVgymeUserKey.Parent" xml:space="preserve">
+    <value>tpVgyme</value>
+  </data>
+  <data name="&gt;&gt;txtVgymeUserKey.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lvlVgymeUserKey.Name" xml:space="preserve">
+    <value>lvlVgymeUserKey</value>
+  </data>
+  <data name="&gt;&gt;lvlVgymeUserKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvlVgymeUserKey.Parent" xml:space="preserve">
+    <value>tpVgyme</value>
+  </data>
+  <data name="&gt;&gt;lvlVgymeUserKey.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpVgyme.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpChevereto.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpVgyme.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpChevereto.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpVgyme.Size" type="System.Drawing.Size, System.Drawing">
     <value>972, 537</value>
   </data>
-  <data name="tpChevereto.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="tpVgyme.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
   </data>
-  <data name="tpChevereto.Text" xml:space="preserve">
-    <value>Chevereto</value>
+  <data name="tpVgyme.Text" xml:space="preserve">
+    <value>vgy.me</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Name" xml:space="preserve">
-    <value>tpChevereto</value>
+  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
+    <value>tpVgyme</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
     <value>tcImageUploaders</value>
   </data>
-  <data name="&gt;&gt;tpChevereto.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="llVgymeAccountDetailsPage.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -15874,87 +22585,6 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;lvlVgymeUserKey.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="tpVgyme.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpVgyme.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpVgyme.Size" type="System.Drawing.Size, System.Drawing">
-    <value>972, 537</value>
-  </data>
-  <data name="tpVgyme.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="tpVgyme.Text" xml:space="preserve">
-    <value>vgy.me</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Name" xml:space="preserve">
-    <value>tpVgyme</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.Parent" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpVgyme.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tcImageUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcImageUploaders.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>780, 480</value>
-  </data>
-  <data name="tcImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>980, 563</value>
-  </data>
-  <data name="tcImageUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Name" xml:space="preserve">
-    <value>tcImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.Parent" xml:space="preserve">
-    <value>tpImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tcImageUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpImageUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpImageUploaders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>986, 569</value>
-  </data>
-  <data name="tpImageUploaders.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpImageUploaders.Text" xml:space="preserve">
-    <value>Image uploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Name" xml:space="preserve">
-    <value>tpImageUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.Parent" xml:space="preserve">
-    <value>tcUploaders</value>
-  </data>
-  <data name="&gt;&gt;tpImageUploaders.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="tcUploaders.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -372,6 +372,8 @@ namespace ShareX.UploadersLib
         public string AzureStorageContainer = "";
         public string AzureStorageEnvironment = "blob.core.windows.net";
         public string AzureStorageCustomDomain = "";
+        public string AzureStorageUploadPath = "";
+        public bool AzureStorageExcludeContainer = false;
 
         #endregion Azure Storage
 


### PR DESCRIPTION
Addresses #2710, #2845, and #3144 with a variety of changes.

1) Support masking container name when using a custom domain.
2) Return paths without $root in the URL.
3) Allow for custom upload paths like S3.