### PR TITLE
Small change in translated word in German

### DIFF
--- a/ShareX/Forms/MainForm.de.resx
+++ b/ShareX/Forms/MainForm.de.resx
@@ -181,7 +181,7 @@
     <value>Arbeitsablauf</value>
   </data>
   <data name="tsmiScreenColorPicker.Text" xml:space="preserve">
-    <value>Bildschirmfarbenauswähler...</value>
+    <value>Bildschirmfarbauswähler...</value>
   </data>
   <data name="tsmiImageEffects.Text" xml:space="preserve">
     <value>Bildeffekt...</value>
@@ -430,7 +430,7 @@
     <value>Arbeitsablauf</value>
   </data>
   <data name="tsmiTrayScreenColorPicker.Text" xml:space="preserve">
-    <value>Bildschirmfarbenauswähler...</value>
+    <value>Bildschirmfarbauswähler...</value>
   </data>
   <data name="tsmiTrayImageEffects.Text" xml:space="preserve">
     <value>Bildeffekte...</value>

--- a/ShareX/Forms/TaskSettingsForm.de.resx
+++ b/ShareX/Forms/TaskSettingsForm.de.resx
@@ -406,6 +406,6 @@
     <value>Bearbeiten...</value>
   </data>
   <data name="lblToolsScreenColorPickerFormat.Text" xml:space="preserve">
-    <value>Bildschirmfarbenauswähler-Format</value>
+    <value>Bildschirmfarbauswähler-Format</value>
   </data>
 </root>


### PR DESCRIPTION
Rename “Bildschirmfarbenauswähler” in all strings of German translations to “Bildschirmfarbauswähler” to clarify that you only pick one color at a time and not multiple ones.