### PR TITLE
 MathHelpers: add CryptoRandom()

### DIFF
--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -243,7 +243,7 @@ namespace ShareX.HelpersLib
 
         public static char GetRandomChar(string chars)
         {
-            return chars[MathHelpers.Random(chars.Length - 1)];
+            return chars[MathHelpers.CryptoRandom(chars.Length - 1)];
         }
 
         public static string GetRandomString(string chars, int length)
@@ -283,7 +283,7 @@ namespace ShareX.HelpersLib
             string[] lines = text.Trim().Lines();
             if (lines != null && lines.Length > 0)
             {
-                return lines[MathHelpers.Random(0, lines.Length - 1)];
+                return lines[MathHelpers.CryptoRandom(0, lines.Length - 1)];
             }
             return null;
         }

--- a/ShareX.HelpersLib/Helpers/MathHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/MathHelpers.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using System;
+using System.Security.Cryptography;
 
 namespace ShareX.HelpersLib
 {
@@ -36,6 +37,19 @@ namespace ShareX.HelpersLib
         private static readonly object randomLock = new object();
         private static readonly Random random = new Random();
 
+        private static readonly object cryptoRandomLock = new object();
+        private static readonly RNGCryptoServiceProvider cryptoRandom = new RNGCryptoServiceProvider();
+        private static byte[] rngBuf = new byte[4];
+
+        /// <summary>
+        /// Returns a random number between 0 and <c>max</c> (inclusive).
+        /// </summary>
+        /// <remarks>
+        /// This uses <c>System.Random()</c>, which does not provide safe random numbers. This function
+        /// should not be used to generate things that should be unique, like random file names.
+        /// </remarks>
+        /// <param name="max">The upper limit of the number (inclusive).</param>
+        /// <returns>A random number.</returns>
         public static int Random(int max)
         {
             lock (randomLock)
@@ -49,6 +63,54 @@ namespace ShareX.HelpersLib
             lock (randomLock)
             {
                 return random.Next(min, max + 1);
+            }
+        }
+
+        /// <summary>
+        /// Returns a random number between 0 and <c>max</c> (inclusive) generated with a cryptographic PRNG.
+        /// </summary>
+        /// <param name="max">The upper limit of the number (inclusive).</param>
+        /// <returns>A cryptographically random number.</returns>
+        public static int CryptoRandom(int max)
+        {
+            return CryptoRandom(0, max);
+        }
+
+        /// <summary>
+        /// Returns a random number between <c>min</c> and <c>max</c> (inclusive) generated with a cryptographic PRNG.
+        /// </summary>
+        /// <param name="min">The lower limit of the number.</param>
+        /// <param name="max">The upper limit of the number (inclusive).</param>
+        /// <returns>A cryptographically random number.</returns>
+        public static int CryptoRandom(int min, int max)
+        {
+            // this code avoids bias in random number generation, which is important when generating random filenames, etc.
+            // adapted from https://web.archive.org/web/20150114085328/http://msdn.microsoft.com:80/en-us/magazine/cc163367.aspx
+            if (min > max)
+            {
+                throw new ArgumentOutOfRangeException("min");
+            }
+
+            if (min == max)
+            {
+                return min;
+            }
+
+            lock (cryptoRandomLock)
+            {
+                var diff = (long)max - min;
+                long ceiling = (1 + (long)uint.MaxValue);
+                long remainder = ceiling % diff;
+                // this should only iterate once unless we generate really large numbers
+                uint r;
+
+                do
+                {
+                    cryptoRandom.GetBytes(rngBuf);
+                    r = BitConverter.ToUInt32(rngBuf, 0);
+                } while (r >= ceiling - remainder);
+
+                return (int)(min + (r % diff));
             }
         }
 


### PR DESCRIPTION
`MathHelpers.CryptoRandom()` uses a PRNG that returns high-quality random numbers. This PR makes randomly generated file names (like `5vnQUQ.png`) more unique, more collision resistant, and less guessable (`System.Random()` is seeded with the system time, I think via [`Environment.TickCount`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.tickcount?view=netframework-4.7.2)). 

Some uploader targets (e.g. B2) are able to upload the same file to the same path as a new "revision" or "version", so it is important to make sure that randomly named files will be sufficiently unique.