### PR TITLE
fixes #2265: Added two pass encoding option

### DIFF
--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegHelper.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegHelper.cs
@@ -92,6 +92,15 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
+        public bool EncodeVideo(string input, string output)
+        {
+            Options.IsRecording = false;
+            Options.IsLossless = false;
+            Options.InputPath = input;
+            Options.OutputPath = output;
+            return Run(Options.FFmpeg.FFmpegPath, Options.GetFFmpegCommands());
+        }
+
         public bool EncodeGIF(string input, string output, string tempFolder)
         {
             bool result;

--- a/ShareX.ScreenCaptureLib/Screencast/ScreenRecorder.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/ScreenRecorder.cs
@@ -109,7 +109,7 @@ namespace ShareX.ScreenCaptureLib
                 throw new Exception("Screen recorder cache path is empty.");
             }
 
-            FPS = outputType == ScreenRecordOutput.GIF ? options.GIFFPS : options.ScreenRecordFPS;
+            FPS = options.FPS;
             DurationSeconds = options.Duration;
             CaptureRectangle = captureRectangle;
             CachePath = options.OutputPath;
@@ -228,6 +228,14 @@ namespace ShareX.ScreenCaptureLib
                     }
                 }
             }
+        }
+
+        public bool FFmpegEncodeVideo(string input, string output)
+        {
+            Helpers.CreateDirectoryFromFilePath(output);
+            bool result = ffmpegCli.EncodeVideo(input, output);
+            //DebugHelper.WriteLine("Video encoding result:\nInput file size: {0}\nOutput file size: {1}", new FileInfo(input).Length.ToSizeString(), new FileInfo(output).Length.ToSizeString());
+            return result;
         }
 
         public bool FFmpegEncodeAsGIF(string sourceFilePath, string targetFilePath, string tempFolder)

--- a/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
@@ -34,10 +34,11 @@ namespace ShareX.ScreenCaptureLib
 {
     public class ScreencastOptions
     {
-        public ScreenRecordOutput OutputType { get; set; }
+        public bool IsRecording { get; set; }
+        public bool IsLossless { get; set; }
+        public string InputPath { get; set; }
         public string OutputPath { get; set; }
-        public int GIFFPS { get; set; }
-        public int ScreenRecordFPS { get; set; }
+        public int FPS { get; set; }
         public Rectangle CaptureArea { get; set; }
         public float Duration { get; set; }
         public bool DrawCursor { get; set; }
@@ -47,7 +48,7 @@ namespace ShareX.ScreenCaptureLib
         {
             string commands;
 
-            if (!string.IsNullOrEmpty(FFmpeg.VideoSource) && FFmpeg.VideoSource.Equals("screen-capture-recorder", StringComparison.InvariantCultureIgnoreCase))
+            if (IsRecording && !string.IsNullOrEmpty(FFmpeg.VideoSource) && FFmpeg.VideoSource.Equals("screen-capture-recorder", StringComparison.InvariantCultureIgnoreCase))
             {
                 // https://github.com/rdp/screen-capture-recorder-to-video-windows-free
                 string registryPath = "Software\\screen-capture-recorder";
@@ -59,10 +60,10 @@ namespace ShareX.ScreenCaptureLib
                 RegistryHelpers.CreateRegistry(registryPath, "capture_mouse_default_1", DrawCursor ? 1 : 0);
             }
 
-            if (FFmpeg.UseCustomCommands && !string.IsNullOrEmpty(FFmpeg.CustomCommands))
+            if (!IsLossless && FFmpeg.UseCustomCommands && !string.IsNullOrEmpty(FFmpeg.CustomCommands))
             {
                 commands = FFmpeg.CustomCommands.
-                    Replace("$fps$", FFmpeg.VideoCodec == FFmpegVideoCodec.gif ? GIFFPS.ToString() : ScreenRecordFPS.ToString(), StringComparison.InvariantCultureIgnoreCase).
+                    Replace("$fps$", FPS.ToString(), StringComparison.InvariantCultureIgnoreCase).
                     Replace("$area_x$", CaptureArea.X.ToString(), StringComparison.InvariantCultureIgnoreCase).
                     Replace("$area_y$", CaptureArea.Y.ToString(), StringComparison.InvariantCultureIgnoreCase).
                     Replace("$area_width$", CaptureArea.Width.ToString(), StringComparison.InvariantCultureIgnoreCase).
@@ -81,7 +82,7 @@ namespace ShareX.ScreenCaptureLib
 
         public string GetFFmpegArgs(bool isCustom = false)
         {
-            if (!FFmpeg.IsVideoSourceSelected && !FFmpeg.IsAudioSourceSelected)
+            if (IsRecording && !FFmpeg.IsVideoSourceSelected && !FFmpeg.IsAudioSourceSelected)
             {
                 return null;
             }
@@ -98,41 +99,48 @@ namespace ShareX.ScreenCaptureLib
             }
             else
             {
-                fps = FFmpeg.VideoCodec == FFmpegVideoCodec.gif ? GIFFPS.ToString() : ScreenRecordFPS.ToString();
+                fps = FPS.ToString();
             }
 
-            if (FFmpeg.IsVideoSourceSelected)
+            if (IsRecording)
             {
-                if (FFmpeg.VideoSource.Equals(FFmpegHelper.SourceGDIGrab, StringComparison.InvariantCultureIgnoreCase))
+                if (FFmpeg.IsVideoSourceSelected)
                 {
-                    // http://ffmpeg.org/ffmpeg-devices.html#gdigrab
-                    args.AppendFormat("-f gdigrab -framerate {0} -offset_x {1} -offset_y {2} -video_size {3}x{4} -draw_mouse {5} -i desktop ",
-                        fps, isCustom ? "$area_x$" : CaptureArea.X.ToString(), isCustom ? "$area_y$" : CaptureArea.Y.ToString(),
-                        isCustom ? "$area_width$" : CaptureArea.Width.ToString(), isCustom ? "$area_height$" : CaptureArea.Height.ToString(),
-                        isCustom ? "$cursor$" : DrawCursor ? "1" : "0");
-
-                    if (FFmpeg.IsAudioSourceSelected)
+                    if (FFmpeg.VideoSource.Equals(FFmpegHelper.SourceGDIGrab, StringComparison.InvariantCultureIgnoreCase))
                     {
-                        args.AppendFormat("-f dshow -i audio=\"{0}\" ", FFmpeg.AudioSource);
-                    }
-                }
-                else
-                {
-                    args.AppendFormat("-f dshow -framerate {0} -i video=\"{1}\"", fps, FFmpeg.VideoSource);
+                        // http://ffmpeg.org/ffmpeg-devices.html#gdigrab
+                        args.AppendFormat("-f gdigrab -framerate {0} -offset_x {1} -offset_y {2} -video_size {3}x{4} -draw_mouse {5} -i desktop ",
+                            fps, isCustom ? "$area_x$" : CaptureArea.X.ToString(), isCustom ? "$area_y$" : CaptureArea.Y.ToString(),
+                            isCustom ? "$area_width$" : CaptureArea.Width.ToString(), isCustom ? "$area_height$" : CaptureArea.Height.ToString(),
+                            isCustom ? "$cursor$" : DrawCursor ? "1" : "0");
 
-                    if (FFmpeg.IsAudioSourceSelected)
-                    {
-                        args.AppendFormat(":audio=\"{0}\" ", FFmpeg.AudioSource);
+                        if (FFmpeg.IsAudioSourceSelected)
+                        {
+                            args.AppendFormat("-f dshow -i audio=\"{0}\" ", FFmpeg.AudioSource);
+                        }
                     }
                     else
                     {
-                        args.Append(" ");
+                        args.AppendFormat("-f dshow -framerate {0} -i video=\"{1}\"", fps, FFmpeg.VideoSource);
+
+                        if (FFmpeg.IsAudioSourceSelected)
+                        {
+                            args.AppendFormat(":audio=\"{0}\" ", FFmpeg.AudioSource);
+                        }
+                        else
+                        {
+                            args.Append(" ");
+                        }
                     }
                 }
+                else if (FFmpeg.IsAudioSourceSelected)
+                {
+                    args.AppendFormat("-f dshow -i audio=\"{0}\" ", FFmpeg.AudioSource);
+                }
             }
-            else if (FFmpeg.IsAudioSourceSelected)
+            else
             {
-                args.AppendFormat("-f dshow -i audio=\"{0}\" ", FFmpeg.AudioSource);
+                args.Append($"-i \"{InputPath}\" ");
             }
 
             if (!string.IsNullOrEmpty(FFmpeg.UserArgs))
@@ -144,48 +152,51 @@ namespace ShareX.ScreenCaptureLib
             {
                 string videoCodec;
 
-                switch (FFmpeg.VideoCodec)
+                if (IsLossless)
                 {
-                    default:
-                        videoCodec = FFmpeg.VideoCodec.ToString();
-                        break;
-                    case FFmpegVideoCodec.gif:
-                        videoCodec = FFmpegVideoCodec.libx264.ToString();
-                        break;
+                    videoCodec = FFmpegVideoCodec.libx264.ToString();
+                }
+                else
+                {
+                    videoCodec = FFmpeg.VideoCodec.ToString();
                 }
 
                 args.AppendFormat("-c:v {0} ", videoCodec);
                 args.AppendFormat("-r {0} ", fps); // output FPS
 
-                switch (FFmpeg.VideoCodec)
+                if (IsLossless)
                 {
-                    case FFmpegVideoCodec.libx264: // https://trac.ffmpeg.org/wiki/Encode/H.264
-                    case FFmpegVideoCodec.libx265: // https://trac.ffmpeg.org/wiki/Encode/H.265
-                        args.AppendFormat("-preset {0} ", FFmpeg.x264_Preset);
-                        args.AppendFormat("-tune {0} ", FFmpegTune.zerolatency);
-                        args.AppendFormat("-crf {0} ", FFmpeg.x264_CRF);
-                        args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // -pix_fmt yuv420p required otherwise can't stream in Chrome
-                        args.AppendFormat("-movflags {0} ", "+faststart"); // This will move some information to the beginning of your file and allow the video to begin playing before it is completely downloaded by the viewer
-                        break;
-                    case FFmpegVideoCodec.libvpx: // https://trac.ffmpeg.org/wiki/Encode/VP8
-                        args.AppendFormat("-deadline {0} ", "realtime");
-                        args.AppendFormat("-b:v {0}k ", FFmpeg.VPx_bitrate);
-                        args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // -pix_fmt yuv420p required otherwise causing issues in Chrome related to WebM transparency support
-                        break;
-                    case FFmpegVideoCodec.libxvid: // https://trac.ffmpeg.org/wiki/Encode/MPEG-4
-                        args.AppendFormat("-qscale:v {0} ", FFmpeg.XviD_qscale);
-                        break;
-                    case FFmpegVideoCodec.h264_nvenc: // https://trac.ffmpeg.org/wiki/HWAccelIntro#NVENC
-                    case FFmpegVideoCodec.hevc_nvenc:
-                        args.AppendFormat("-preset {0} ", FFmpeg.NVENC_preset);
-                        args.AppendFormat("-b:v {0}k ", FFmpeg.NVENC_bitrate);
-                        args.AppendFormat("-pix_fmt {0} ", "yuv420p");
-                        break;
-                    case FFmpegVideoCodec.gif:
-                        args.AppendFormat("-preset {0} ", FFmpegPreset.ultrafast);
-                        args.AppendFormat("-tune {0} ", FFmpegTune.zerolatency);
-                        args.AppendFormat("-qp {0} ", 0);
-                        break;
+                    args.AppendFormat("-preset {0} ", FFmpegPreset.ultrafast);
+                    args.AppendFormat("-tune {0} ", FFmpegTune.zerolatency);
+                    args.AppendFormat("-qp {0} ", 0);
+                }
+                else
+                {
+                    switch (FFmpeg.VideoCodec)
+                    {
+                        case FFmpegVideoCodec.libx264: // https://trac.ffmpeg.org/wiki/Encode/H.264
+                        case FFmpegVideoCodec.libx265: // https://trac.ffmpeg.org/wiki/Encode/H.265
+                            args.AppendFormat("-preset {0} ", FFmpeg.x264_Preset);
+                            args.AppendFormat("-tune {0} ", FFmpegTune.zerolatency);
+                            args.AppendFormat("-crf {0} ", FFmpeg.x264_CRF);
+                            args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // -pix_fmt yuv420p required otherwise can't stream in Chrome
+                            args.AppendFormat("-movflags {0} ", "+faststart"); // This will move some information to the beginning of your file and allow the video to begin playing before it is completely downloaded by the viewer
+                            break;
+                        case FFmpegVideoCodec.libvpx: // https://trac.ffmpeg.org/wiki/Encode/VP8
+                            args.AppendFormat("-deadline {0} ", "realtime");
+                            args.AppendFormat("-b:v {0}k ", FFmpeg.VPx_bitrate);
+                            args.AppendFormat("-pix_fmt {0} ", "yuv420p"); // -pix_fmt yuv420p required otherwise causing issues in Chrome related to WebM transparency support
+                            break;
+                        case FFmpegVideoCodec.libxvid: // https://trac.ffmpeg.org/wiki/Encode/MPEG-4
+                            args.AppendFormat("-qscale:v {0} ", FFmpeg.XviD_qscale);
+                            break;
+                        case FFmpegVideoCodec.h264_nvenc: // https://trac.ffmpeg.org/wiki/HWAccelIntro#NVENC
+                        case FFmpegVideoCodec.hevc_nvenc:
+                            args.AppendFormat("-preset {0} ", FFmpeg.NVENC_preset);
+                            args.AppendFormat("-b:v {0}k ", FFmpeg.NVENC_bitrate);
+                            args.AppendFormat("-pix_fmt {0} ", "yuv420p");
+                            break;
+                    }
                 }
             }
 

--- a/ShareX/Forms/TaskSettingsForm.Designer.cs
+++ b/ShareX/Forms/TaskSettingsForm.Designer.cs
@@ -161,7 +161,8 @@
             this.nudRegionCaptureMagnifierPixelCount = new System.Windows.Forms.NumericUpDown();
             this.nudRegionCaptureMagnifierPixelSize = new System.Windows.Forms.NumericUpDown();
             this.tpScreenRecorder = new System.Windows.Forms.TabPage();
-            this.cbScreenRecorderConfirmAbort = new System.Windows.Forms.CheckBox();
+            this.cbScreenRecordTwoPassEncoding = new System.Windows.Forms.CheckBox();
+            this.cbScreenRecordConfirmAbort = new System.Windows.Forms.CheckBox();
             this.cbScreenRecorderShowCursor = new System.Windows.Forms.CheckBox();
             this.btnScreenRecorderFFmpegOptions = new System.Windows.Forms.Button();
             this.lblScreenRecorderStartDelay = new System.Windows.Forms.Label();
@@ -169,9 +170,9 @@
             this.lblScreenRecorderFixedDuration = new System.Windows.Forms.Label();
             this.nudScreenRecordFPS = new System.Windows.Forms.NumericUpDown();
             this.lblScreenRecordFPS = new System.Windows.Forms.Label();
-            this.chkRunScreencastCLI = new System.Windows.Forms.CheckBox();
-            this.btnEncoderConfig = new System.Windows.Forms.Button();
-            this.cboEncoder = new System.Windows.Forms.ComboBox();
+            this.cbScreenRecordRunScreencastCLI = new System.Windows.Forms.CheckBox();
+            this.btnScreenRecordEncoderConfig = new System.Windows.Forms.Button();
+            this.cbScreenRecordEncoder = new System.Windows.Forms.ComboBox();
             this.nudScreenRecorderDuration = new System.Windows.Forms.NumericUpDown();
             this.nudScreenRecorderStartDelay = new System.Windows.Forms.NumericUpDown();
             this.cbScreenRecorderFixedDuration = new System.Windows.Forms.CheckBox();
@@ -1408,7 +1409,8 @@
             // tpScreenRecorder
             // 
             this.tpScreenRecorder.BackColor = System.Drawing.SystemColors.Window;
-            this.tpScreenRecorder.Controls.Add(this.cbScreenRecorderConfirmAbort);
+            this.tpScreenRecorder.Controls.Add(this.cbScreenRecordTwoPassEncoding);
+            this.tpScreenRecorder.Controls.Add(this.cbScreenRecordConfirmAbort);
             this.tpScreenRecorder.Controls.Add(this.cbScreenRecorderShowCursor);
             this.tpScreenRecorder.Controls.Add(this.btnScreenRecorderFFmpegOptions);
             this.tpScreenRecorder.Controls.Add(this.lblScreenRecorderStartDelay);
@@ -1416,9 +1418,9 @@
             this.tpScreenRecorder.Controls.Add(this.lblScreenRecorderFixedDuration);
             this.tpScreenRecorder.Controls.Add(this.nudScreenRecordFPS);
             this.tpScreenRecorder.Controls.Add(this.lblScreenRecordFPS);
-            this.tpScreenRecorder.Controls.Add(this.chkRunScreencastCLI);
-            this.tpScreenRecorder.Controls.Add(this.btnEncoderConfig);
-            this.tpScreenRecorder.Controls.Add(this.cboEncoder);
+            this.tpScreenRecorder.Controls.Add(this.cbScreenRecordRunScreencastCLI);
+            this.tpScreenRecorder.Controls.Add(this.btnScreenRecordEncoderConfig);
+            this.tpScreenRecorder.Controls.Add(this.cbScreenRecordEncoder);
             this.tpScreenRecorder.Controls.Add(this.nudScreenRecorderDuration);
             this.tpScreenRecorder.Controls.Add(this.nudScreenRecorderStartDelay);
             this.tpScreenRecorder.Controls.Add(this.cbScreenRecorderFixedDuration);
@@ -1427,12 +1429,19 @@
             resources.ApplyResources(this.tpScreenRecorder, "tpScreenRecorder");
             this.tpScreenRecorder.Name = "tpScreenRecorder";
             // 
-            // cbScreenRecorderConfirmAbort
+            // cbScreenRecordTwoPassEncoding
             // 
-            resources.ApplyResources(this.cbScreenRecorderConfirmAbort, "cbScreenRecorderConfirmAbort");
-            this.cbScreenRecorderConfirmAbort.Name = "cbScreenRecorderConfirmAbort";
-            this.cbScreenRecorderConfirmAbort.UseVisualStyleBackColor = true;
-            this.cbScreenRecorderConfirmAbort.CheckedChanged += new System.EventHandler(this.chkConfirmAbort_CheckedChanged);
+            resources.ApplyResources(this.cbScreenRecordTwoPassEncoding, "cbScreenRecordTwoPassEncoding");
+            this.cbScreenRecordTwoPassEncoding.Name = "cbScreenRecordTwoPassEncoding";
+            this.cbScreenRecordTwoPassEncoding.UseVisualStyleBackColor = true;
+            this.cbScreenRecordTwoPassEncoding.CheckedChanged += new System.EventHandler(this.cbScreenRecordTwoPassEncoding_CheckedChanged);
+            // 
+            // cbScreenRecordConfirmAbort
+            // 
+            resources.ApplyResources(this.cbScreenRecordConfirmAbort, "cbScreenRecordConfirmAbort");
+            this.cbScreenRecordConfirmAbort.Name = "cbScreenRecordConfirmAbort";
+            this.cbScreenRecordConfirmAbort.UseVisualStyleBackColor = true;
+            this.cbScreenRecordConfirmAbort.CheckedChanged += new System.EventHandler(this.cbScreenRecordConfirmAbort_CheckedChanged);
             // 
             // cbScreenRecorderShowCursor
             // 
@@ -1491,27 +1500,27 @@
             resources.ApplyResources(this.lblScreenRecordFPS, "lblScreenRecordFPS");
             this.lblScreenRecordFPS.Name = "lblScreenRecordFPS";
             // 
-            // chkRunScreencastCLI
+            // cbScreenRecordRunScreencastCLI
             // 
-            resources.ApplyResources(this.chkRunScreencastCLI, "chkRunScreencastCLI");
-            this.chkRunScreencastCLI.Name = "chkRunScreencastCLI";
-            this.chkRunScreencastCLI.UseVisualStyleBackColor = true;
-            this.chkRunScreencastCLI.CheckedChanged += new System.EventHandler(this.chkRunScreencastCLI_CheckedChanged);
+            resources.ApplyResources(this.cbScreenRecordRunScreencastCLI, "cbScreenRecordRunScreencastCLI");
+            this.cbScreenRecordRunScreencastCLI.Name = "cbScreenRecordRunScreencastCLI";
+            this.cbScreenRecordRunScreencastCLI.UseVisualStyleBackColor = true;
+            this.cbScreenRecordRunScreencastCLI.CheckedChanged += new System.EventHandler(this.cbScreenRecordRunScreencastCLI_CheckedChanged);
             // 
-            // btnEncoderConfig
+            // btnScreenRecordEncoderConfig
             // 
-            resources.ApplyResources(this.btnEncoderConfig, "btnEncoderConfig");
-            this.btnEncoderConfig.Name = "btnEncoderConfig";
-            this.btnEncoderConfig.UseVisualStyleBackColor = true;
-            this.btnEncoderConfig.Click += new System.EventHandler(this.btnEncoderConfig_Click);
+            resources.ApplyResources(this.btnScreenRecordEncoderConfig, "btnScreenRecordEncoderConfig");
+            this.btnScreenRecordEncoderConfig.Name = "btnScreenRecordEncoderConfig";
+            this.btnScreenRecordEncoderConfig.UseVisualStyleBackColor = true;
+            this.btnScreenRecordEncoderConfig.Click += new System.EventHandler(this.btnEncoderConfig_Click);
             // 
-            // cboEncoder
+            // cbScreenRecordEncoder
             // 
-            this.cboEncoder.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboEncoder.FormattingEnabled = true;
-            resources.ApplyResources(this.cboEncoder, "cboEncoder");
-            this.cboEncoder.Name = "cboEncoder";
-            this.cboEncoder.SelectedIndexChanged += new System.EventHandler(this.cboEncoder_SelectedIndexChanged);
+            this.cbScreenRecordEncoder.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbScreenRecordEncoder.FormattingEnabled = true;
+            resources.ApplyResources(this.cbScreenRecordEncoder, "cbScreenRecordEncoder");
+            this.cbScreenRecordEncoder.Name = "cbScreenRecordEncoder";
+            this.cbScreenRecordEncoder.SelectedIndexChanged += new System.EventHandler(this.cboEncoder_SelectedIndexChanged);
             // 
             // nudScreenRecorderDuration
             // 
@@ -2267,8 +2276,8 @@
         private System.Windows.Forms.ToolStripMenuItem tsmiURLSharingServices;
         private System.Windows.Forms.ComboBox cbImageFileExist;
         private System.Windows.Forms.Label lblImageFileExist;
-        private System.Windows.Forms.ComboBox cboEncoder;
-        private System.Windows.Forms.Button btnEncoderConfig;
+        private System.Windows.Forms.ComboBox cbScreenRecordEncoder;
+        private System.Windows.Forms.Button btnScreenRecordEncoderConfig;
         private System.Windows.Forms.TabPage tpThumbnail;
         private System.Windows.Forms.Label lblThumbnailHeight;
         private System.Windows.Forms.Label lblThumbnailWidth;
@@ -2279,7 +2288,7 @@
         private System.Windows.Forms.Label lblThumbnailNamePreview;
         private System.Windows.Forms.CheckBox cbThumbnailIfSmaller;
         private System.Windows.Forms.CheckBox cbClipboardUploadAutoIndexFolder;
-        private System.Windows.Forms.CheckBox chkRunScreencastCLI;
+        private System.Windows.Forms.CheckBox cbScreenRecordRunScreencastCLI;
         private System.Windows.Forms.CheckBox chkClipboardUploadURLContents;
         private System.Windows.Forms.NumericUpDown nudScreenRecordFPS;
         private System.Windows.Forms.Label lblScreenRecordFPS;
@@ -2373,7 +2382,8 @@
         private System.Windows.Forms.ComboBox cbImagePNGBitDepth;
         private System.Windows.Forms.Label lblImagePNGBitDepth;
         private System.Windows.Forms.Button btnWatchFolderEdit;
-        private System.Windows.Forms.CheckBox cbScreenRecorderConfirmAbort;
+        private System.Windows.Forms.CheckBox cbScreenRecordConfirmAbort;
         private System.Windows.Forms.CheckBox cbFileUploadReplaceProblematicCharacters;
+        private System.Windows.Forms.CheckBox cbScreenRecordTwoPassEncoding;
     }
 }

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -289,10 +289,11 @@ namespace ShareX
             cbScreenRecorderFixedDuration.Checked = nudScreenRecorderDuration.Enabled = TaskSettings.CaptureSettings.ScreenRecordFixedDuration;
             nudScreenRecorderDuration.SetValue((decimal)TaskSettings.CaptureSettings.ScreenRecordDuration);
             chkScreenRecordAutoStart.Checked = nudScreenRecorderStartDelay.Enabled = TaskSettings.CaptureSettings.ScreenRecordAutoStart;
-            cbScreenRecorderConfirmAbort.Checked = TaskSettings.CaptureSettings.ScreenRecordAskConfirmationOnAbort;
+            cbScreenRecordConfirmAbort.Checked = TaskSettings.CaptureSettings.ScreenRecordAskConfirmationOnAbort;
             nudScreenRecorderStartDelay.SetValue((decimal)TaskSettings.CaptureSettings.ScreenRecordStartDelay);
             cbScreenRecorderShowCursor.Checked = TaskSettings.CaptureSettings.ScreenRecordShowCursor;
-            chkRunScreencastCLI.Checked = cboEncoder.Enabled = btnEncoderConfig.Enabled = TaskSettings.CaptureSettings.RunScreencastCLI;
+            cbScreenRecordTwoPassEncoding.Checked = TaskSettings.CaptureSettings.ScreenRecordTwoPassEncoding;
+            cbScreenRecordRunScreencastCLI.Checked = cbScreenRecordEncoder.Enabled = btnScreenRecordEncoderConfig.Enabled = TaskSettings.CaptureSettings.RunScreencastCLI;
             UpdateVideoEncoders();
 
             #endregion Screen recorder
@@ -1031,17 +1032,17 @@ namespace ShareX
 
         private void UpdateVideoEncoders()
         {
-            cboEncoder.Items.Clear();
+            cbScreenRecordEncoder.Items.Clear();
 
             if (Program.Settings.VideoEncoders.Count > 0)
             {
-                Program.Settings.VideoEncoders.ForEach(x => cboEncoder.Items.Add(x));
-                cboEncoder.SelectedIndex = TaskSettings.CaptureSettings.VideoEncoderSelected.BetweenOrDefault(0, Program.Settings.VideoEncoders.Count - 1);
+                Program.Settings.VideoEncoders.ForEach(x => cbScreenRecordEncoder.Items.Add(x));
+                cbScreenRecordEncoder.SelectedIndex = TaskSettings.CaptureSettings.VideoEncoderSelected.BetweenOrDefault(0, Program.Settings.VideoEncoders.Count - 1);
             }
-            else if (!cboEncoder.Items.Contains(Resources.TaskSettingsForm_ConfigureEncoder_Configure_CLI_video_encoders_____))
+            else if (!cbScreenRecordEncoder.Items.Contains(Resources.TaskSettingsForm_ConfigureEncoder_Configure_CLI_video_encoders_____))
             {
-                cboEncoder.Items.Add(Resources.TaskSettingsForm_ConfigureEncoder_Configure_CLI_video_encoders_____);
-                cboEncoder.SelectedIndex = 0;
+                cbScreenRecordEncoder.Items.Add(Resources.TaskSettingsForm_ConfigureEncoder_Configure_CLI_video_encoders_____);
+                cbScreenRecordEncoder.SelectedIndex = 0;
             }
         }
 
@@ -1102,19 +1103,19 @@ namespace ShareX
             TaskSettings.CaptureSettings.ScreenRecordShowCursor = cbScreenRecorderShowCursor.Checked;
         }
 
-        private void chkConfirmAbort_CheckedChanged(object sender, EventArgs e)
+        private void cbScreenRecordTwoPassEncoding_CheckedChanged(object sender, EventArgs e)
         {
-            TaskSettings.CaptureSettings.ScreenRecordAskConfirmationOnAbort = cbScreenRecorderConfirmAbort.Checked;
+            TaskSettings.CaptureSettings.ScreenRecordTwoPassEncoding = cbScreenRecordTwoPassEncoding.Checked;
         }
 
-        private void chkRunScreencastCLI_CheckedChanged(object sender, EventArgs e)
+        private void cbScreenRecordRunScreencastCLI_CheckedChanged(object sender, EventArgs e)
         {
-            TaskSettings.CaptureSettings.RunScreencastCLI = cboEncoder.Enabled = btnEncoderConfig.Enabled = chkRunScreencastCLI.Checked;
+            TaskSettings.CaptureSettings.RunScreencastCLI = cbScreenRecordEncoder.Enabled = btnScreenRecordEncoderConfig.Enabled = cbScreenRecordRunScreencastCLI.Checked;
         }
 
         private void cboEncoder_SelectedIndexChanged(object sender, EventArgs e)
         {
-            TaskSettings.CaptureSettings.VideoEncoderSelected = cboEncoder.SelectedIndex;
+            TaskSettings.CaptureSettings.VideoEncoderSelected = cbScreenRecordEncoder.SelectedIndex;
         }
 
         private void btnEncoderConfig_Click(object sender, EventArgs e)
@@ -1124,6 +1125,11 @@ namespace ShareX
                 form.ShowDialog();
                 UpdateVideoEncoders();
             }
+        }
+
+        private void cbScreenRecordConfirmAbort_CheckedChanged(object sender, EventArgs e)
+        {
+            TaskSettings.CaptureSettings.ScreenRecordAskConfirmationOnAbort = cbScreenRecordConfirmAbort.Checked;
         }
 
         #endregion Screen recorder

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -1050,9 +1050,9 @@ namespace ShareX
         {
             ScreencastOptions options = new ScreencastOptions
             {
+                IsRecording = true,
                 FFmpeg = TaskSettings.CaptureSettings.FFmpegOptions,
-                ScreenRecordFPS = TaskSettings.CaptureSettings.ScreenRecordFPS,
-                GIFFPS = TaskSettings.CaptureSettings.GIFFPS,
+                FPS = TaskSettings.CaptureSettings.ScreenRecordFPS,
                 Duration = TaskSettings.CaptureSettings.ScreenRecordFixedDuration ? TaskSettings.CaptureSettings.ScreenRecordDuration : 0,
                 OutputPath = "output.mp4",
                 CaptureArea = Screen.PrimaryScreen.Bounds,

--- a/ShareX/Forms/TaskSettingsForm.resx
+++ b/ShareX/Forms/TaskSettingsForm.resx
@@ -297,6 +297,1494 @@
   <data name="&gt;&gt;cmsTask.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;cbOverrideCustomUploader.Name" xml:space="preserve">
+    <value>cbOverrideCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;cbOverrideCustomUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOverrideCustomUploader.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;cbOverrideCustomUploader.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCustomUploader.Name" xml:space="preserve">
+    <value>chkOverrideCustomUploader</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCustomUploader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCustomUploader.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCustomUploader.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideFTP.Name" xml:space="preserve">
+    <value>chkOverrideFTP</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideFTP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideFTP.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideFTP.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cboFTPaccounts.Name" xml:space="preserve">
+    <value>cboFTPaccounts</value>
+  </data>
+  <data name="&gt;&gt;cboFTPaccounts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cboFTPaccounts.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;cboFTPaccounts.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnAfterCapture.Name" xml:space="preserve">
+    <value>btnAfterCapture</value>
+  </data>
+  <data name="&gt;&gt;btnAfterCapture.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;btnAfterCapture.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;btnAfterCapture.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnAfterUpload.Name" xml:space="preserve">
+    <value>btnAfterUpload</value>
+  </data>
+  <data name="&gt;&gt;btnAfterUpload.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;btnAfterUpload.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;btnAfterUpload.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;btnDestinations.Name" xml:space="preserve">
+    <value>btnDestinations</value>
+  </data>
+  <data name="&gt;&gt;btnDestinations.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;btnDestinations.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;btnDestinations.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;btnTask.Name" xml:space="preserve">
+    <value>btnTask</value>
+  </data>
+  <data name="&gt;&gt;btnTask.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;btnTask.Parent" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;btnTask.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="tpTask.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTask.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpTask.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpTask.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpTask.Text" xml:space="preserve">
+    <value>Task</value>
+  </data>
+  <data name="&gt;&gt;tpTask.Name" xml:space="preserve">
+    <value>tpTask</value>
+  </data>
+  <data name="&gt;&gt;tpTask.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTask.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpTask.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
+    <value>pGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideGeneralSettings.Name" xml:space="preserve">
+    <value>chkOverrideGeneralSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideGeneralSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideGeneralSettings.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideGeneralSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tpGeneral.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
+    <value>tpImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpImage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpImage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpImage.Text" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="&gt;&gt;tpImage.Name" xml:space="preserve">
+    <value>tpImage</value>
+  </data>
+  <data name="&gt;&gt;tpImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpImage.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpImage.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCaptureSettings.Name" xml:space="preserve">
+    <value>chkOverrideCaptureSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCaptureSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCaptureSettings.Parent" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideCaptureSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpCaptureGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCaptureGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpCaptureGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Name" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowFPS.Name" xml:space="preserve">
+    <value>cbRegionCaptureShowFPS</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowFPS.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowFPS.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Name" xml:space="preserve">
+    <value>cbRegionCaptureIsFixedSize</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Name" xml:space="preserve">
+    <value>cbRegionCaptureShowCrosshair</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Name" xml:space="preserve">
+    <value>lblRegionCaptureMagnifierPixelSize</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Name" xml:space="preserve">
+    <value>lblRegionCaptureMagnifierPixelCount</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Name" xml:space="preserve">
+    <value>cbRegionCaptureUseSquareMagnifier</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Name" xml:space="preserve">
+    <value>cbRegionCaptureShowMagnifier</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowInfo.Name" xml:space="preserve">
+    <value>cbRegionCaptureShowInfo</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowInfo.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureShowInfo.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Name" xml:space="preserve">
+    <value>btnRegionCaptureSnapSizesRemove</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Name" xml:space="preserve">
+    <value>btnRegionCaptureSnapSizesAdd</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Name" xml:space="preserve">
+    <value>cbRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Name" xml:space="preserve">
+    <value>lblRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Name" xml:space="preserve">
+    <value>cbRegionCaptureUseCustomInfoText</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectControls.Name" xml:space="preserve">
+    <value>cbRegionCaptureDetectControls</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectControls.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectControls.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Name" xml:space="preserve">
+    <value>cbRegionCaptureDetectWindows</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureDetectWindows.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Name" xml:space="preserve">
+    <value>cbRegionCaptureMouse5ClickAction</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Name" xml:space="preserve">
+    <value>lblRegionCaptureMouse5ClickAction</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Name" xml:space="preserve">
+    <value>cbRegionCaptureMouse4ClickAction</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Name" xml:space="preserve">
+    <value>lblRegionCaptureMouse4ClickAction</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Name" xml:space="preserve">
+    <value>cbRegionCaptureMouseMiddleClickAction</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Name" xml:space="preserve">
+    <value>lblRegionCaptureMouseMiddleClickAction</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Name" xml:space="preserve">
+    <value>cbRegionCaptureMouseRightClickAction</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Name" xml:space="preserve">
+    <value>lblRegionCaptureMouseRightClickAction</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Name" xml:space="preserve">
+    <value>cbRegionCaptureMultiRegionMode</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseDimming.Name" xml:space="preserve">
+    <value>cbRegionCaptureUseDimming</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseDimming.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseDimming.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseDimming.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Name" xml:space="preserve">
+    <value>txtRegionCaptureCustomInfoText</value>
+  </data>
+  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Name" xml:space="preserve">
+    <value>nudRegionCaptureMagnifierPixelCount</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.ZOrder" xml:space="preserve">
+    <value>28</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Name" xml:space="preserve">
+    <value>nudRegionCaptureMagnifierPixelSize</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
+    <value>29</value>
+  </data>
+  <data name="tpRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpRegionCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpRegionCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpRegionCapture.Text" xml:space="preserve">
+    <value>Region capture</value>
+  </data>
+  <data name="&gt;&gt;tpRegionCapture.Name" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;tpRegionCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpRegionCapture.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpRegionCapture.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 160</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Size" type="System.Drawing.Size, System.Drawing">
+    <value>376, 17</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Text" xml:space="preserve">
+    <value>Record using lossless encoding and after that apply user encoding options</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Name" xml:space="preserve">
+    <value>cbScreenRecordTwoPassEncoding</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 207</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 17</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Text" xml:space="preserve">
+    <value>Ask for confirmation when aborting</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Name" xml:space="preserve">
+    <value>cbScreenRecordConfirmAbort</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 88</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 17</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Text" xml:space="preserve">
+    <value>Show cursor in recording</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Name" xml:space="preserve">
+    <value>cbScreenRecorderShowCursor</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 24</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Text" xml:space="preserve">
+    <value>Screen recording options...</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Name" xml:space="preserve">
+    <value>btnScreenRecorderFFmpegOptions</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 114</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 13</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Text" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Name" xml:space="preserve">
+    <value>lblScreenRecorderStartDelay</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 112</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 17</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Text" xml:space="preserve">
+    <value>Start recording after:</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Name" xml:space="preserve">
+    <value>chkScreenRecordAutoStart</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 138</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 13</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Text" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Name" xml:space="preserve">
+    <value>lblScreenRecorderFixedDuration</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="nudScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 36</value>
+  </data>
+  <data name="nudScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="nudScreenRecordFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Name" xml:space="preserve">
+    <value>nudScreenRecordFPS</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblScreenRecordFPS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecordFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="lblScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 13</value>
+  </data>
+  <data name="lblScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="lblScreenRecordFPS.Text" xml:space="preserve">
+    <value>Screen recording FPS:</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Name" xml:space="preserve">
+    <value>lblScreenRecordFPS</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 184</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 17</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Text" xml:space="preserve">
+    <value>Run CLI afterwards:</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Name" xml:space="preserve">
+    <value>cbScreenRecordRunScreencastCLI</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Location" type="System.Drawing.Point, System.Drawing">
+    <value>458, 181</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 23</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Text" xml:space="preserve">
+    <value>Profiles...</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Name" xml:space="preserve">
+    <value>btnScreenRecordEncoderConfig</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="cbScreenRecordEncoder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 182</value>
+  </data>
+  <data name="cbScreenRecordEncoder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 21</value>
+  </data>
+  <data name="cbScreenRecordEncoder.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Name" xml:space="preserve">
+    <value>cbScreenRecordEncoder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="nudScreenRecorderDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 134</value>
+  </data>
+  <data name="nudScreenRecorderDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecorderDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="nudScreenRecorderDuration.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Name" xml:space="preserve">
+    <value>nudScreenRecorderDuration</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 110</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Name" xml:space="preserve">
+    <value>nudScreenRecorderStartDelay</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 136</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 17</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Text" xml:space="preserve">
+    <value>Fixed duration:</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Name" xml:space="preserve">
+    <value>cbScreenRecorderFixedDuration</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="nudGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 60</value>
+  </data>
+  <data name="nudGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudGIFFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="nudGIFFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Name" xml:space="preserve">
+    <value>nudGIFFPS</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="lblGIFFPS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGIFFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 64</value>
+  </data>
+  <data name="lblGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="lblGIFFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblGIFFPS.Text" xml:space="preserve">
+    <value>GIF FPS:</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Name" xml:space="preserve">
+    <value>lblGIFFPS</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="tpScreenRecorder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpScreenRecorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpScreenRecorder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpScreenRecorder.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpScreenRecorder.Text" xml:space="preserve">
+    <value>Screen recorder</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Name" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tcCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 473</value>
+  </data>
+  <data name="tcCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Name" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Parent" xml:space="preserve">
+    <value>tpCapture</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpCapture.Text" xml:space="preserve">
+    <value>Capture</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Name" xml:space="preserve">
+    <value>tpCapture</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
+    <value>tcUpload</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
+    <value>tpUpload</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpUpload.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpUpload.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpUpload.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpUpload.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tpUpload.Text" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Name" xml:space="preserve">
+    <value>tpUpload</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideActions.Name" xml:space="preserve">
+    <value>chkOverrideActions</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideActions.Parent" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideActions.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpActions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpActions.Text" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Name" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpActions.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderEdit.Name" xml:space="preserve">
+    <value>btnWatchFolderEdit</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderEdit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderEdit.Parent" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderEdit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbWatchFolderEnabled.Name" xml:space="preserve">
+    <value>cbWatchFolderEnabled</value>
+  </data>
+  <data name="&gt;&gt;cbWatchFolderEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbWatchFolderEnabled.Parent" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;cbWatchFolderEnabled.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lvWatchFolderList.Name" xml:space="preserve">
+    <value>lvWatchFolderList</value>
+  </data>
+  <data name="&gt;&gt;lvWatchFolderList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvWatchFolderList.Parent" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;lvWatchFolderList.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderRemove.Name" xml:space="preserve">
+    <value>btnWatchFolderRemove</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderRemove.Parent" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderRemove.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderAdd.Name" xml:space="preserve">
+    <value>btnWatchFolderAdd</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderAdd.Parent" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;btnWatchFolderAdd.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="tpWatchFolders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpWatchFolders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpWatchFolders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpWatchFolders.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tpWatchFolders.Text" xml:space="preserve">
+    <value>Watch folders</value>
+  </data>
+  <data name="&gt;&gt;tpWatchFolders.Name" xml:space="preserve">
+    <value>tpWatchFolders</value>
+  </data>
+  <data name="&gt;&gt;tpWatchFolders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpWatchFolders.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpWatchFolders.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
+    <value>pTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideToolsSettings.Name" xml:space="preserve">
+    <value>chkOverrideToolsSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideToolsSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideToolsSettings.Parent" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideToolsSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpTools.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTools.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpTools.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tpTools.Text" xml:space="preserve">
+    <value>Tools</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Name" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpTools.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;pgTaskSettings.Name" xml:space="preserve">
+    <value>pgTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;pgTaskSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.PropertyGrid, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pgTaskSettings.Parent" xml:space="preserve">
+    <value>tpAdvanced</value>
+  </data>
+  <data name="&gt;&gt;pgTaskSettings.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideAdvancedSettings.Name" xml:space="preserve">
+    <value>chkOverrideAdvancedSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideAdvancedSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideAdvancedSettings.Parent" xml:space="preserve">
+    <value>tpAdvanced</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideAdvancedSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpAdvanced.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpAdvanced.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAdvanced.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpAdvanced.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpAdvanced.Text" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Name" xml:space="preserve">
+    <value>tpAdvanced</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tcTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="tcTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>202, 3</value>
+  </data>
+  <data name="tcTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>579, 505</value>
+  </data>
+  <data name="tcTaskSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tcTaskSettings.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Name" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="cbOverrideCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 328</value>
   </data>
@@ -468,36 +1956,6 @@
   <metadata name="cmsDestinations.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>396, 17</value>
   </metadata>
-  <data name="tsmiImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiImageUploaders.Text" xml:space="preserve">
-    <value>Image uploaders</value>
-  </data>
-  <data name="tsmiTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiTextUploaders.Text" xml:space="preserve">
-    <value>Text uploaders</value>
-  </data>
-  <data name="tsmiFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiFileUploaders.Text" xml:space="preserve">
-    <value>File uploaders</value>
-  </data>
-  <data name="tsmiURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiURLShorteners.Text" xml:space="preserve">
-    <value>URL shorteners</value>
-  </data>
-  <data name="tsmiURLSharingServices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiURLSharingServices.Text" xml:space="preserve">
-    <value>URL sharing services</value>
-  </data>
   <data name="cmsDestinations.Size" type="System.Drawing.Size, System.Drawing">
     <value>182, 114</value>
   </data>
@@ -531,6 +1989,36 @@
   <data name="&gt;&gt;btnDestinations.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="tsmiImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiImageUploaders.Text" xml:space="preserve">
+    <value>Image uploaders</value>
+  </data>
+  <data name="tsmiTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiTextUploaders.Text" xml:space="preserve">
+    <value>Text uploaders</value>
+  </data>
+  <data name="tsmiFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiFileUploaders.Text" xml:space="preserve">
+    <value>File uploaders</value>
+  </data>
+  <data name="tsmiURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiURLShorteners.Text" xml:space="preserve">
+    <value>URL shorteners</value>
+  </data>
+  <data name="tsmiURLSharingServices.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiURLSharingServices.Text" xml:space="preserve">
+    <value>URL sharing services</value>
+  </data>
   <data name="btnTask.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -561,31 +2049,76 @@
   <data name="&gt;&gt;btnTask.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="tpTask.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;lblAfterTaskNotification.Name" xml:space="preserve">
+    <value>lblAfterTaskNotification</value>
   </data>
-  <data name="tpTask.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;lblAfterTaskNotification.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpTask.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
+  <data name="&gt;&gt;lblAfterTaskNotification.Parent" xml:space="preserve">
+    <value>pGeneral</value>
   </data>
-  <data name="tpTask.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lblAfterTaskNotification.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpTask.Text" xml:space="preserve">
-    <value>Task</value>
+  <data name="&gt;&gt;cboPopUpNotification.Name" xml:space="preserve">
+    <value>cboPopUpNotification</value>
   </data>
-  <data name="&gt;&gt;tpTask.Name" xml:space="preserve">
-    <value>tpTask</value>
+  <data name="&gt;&gt;cboPopUpNotification.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpTask.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cboPopUpNotification.Parent" xml:space="preserve">
+    <value>pGeneral</value>
   </data>
-  <data name="&gt;&gt;tpTask.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
+  <data name="&gt;&gt;cboPopUpNotification.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tpTask.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cbPlaySoundAfterUpload.Name" xml:space="preserve">
+    <value>cbPlaySoundAfterUpload</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterUpload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterUpload.Parent" xml:space="preserve">
+    <value>pGeneral</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterUpload.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterCapture.Name" xml:space="preserve">
+    <value>cbPlaySoundAfterCapture</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterCapture.Parent" xml:space="preserve">
+    <value>pGeneral</value>
+  </data>
+  <data name="&gt;&gt;cbPlaySoundAfterCapture.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="pGeneral.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
+    <value>pGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="lblAfterTaskNotification.AutoSize" type="System.Boolean, mscorlib">
@@ -699,30 +2232,6 @@
   <data name="&gt;&gt;cbPlaySoundAfterCapture.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="pGeneral.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
-    <value>pGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="chkOverrideGeneralSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -759,29 +2268,302 @@
   <data name="&gt;&gt;chkOverrideGeneralSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
+    <value>tpQuality</value>
   </data>
-  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tpGeneral.Text" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
+  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
+    <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tcImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 473</value>
+  </data>
+  <data name="tcImage.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
+    <value>tpImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
+    <value>tpQuality</value>
+  </data>
+  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideImageSettings.Name" xml:space="preserve">
+    <value>chkOverrideImageSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideImageSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideImageSettings.Parent" xml:space="preserve">
+    <value>tpQuality</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideImageSettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpQuality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpQuality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
+    <value>tpQuality</value>
+  </data>
+  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cbImagePNGBitDepth.Name" xml:space="preserve">
+    <value>cbImagePNGBitDepth</value>
+  </data>
+  <data name="&gt;&gt;cbImagePNGBitDepth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImagePNGBitDepth.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;cbImagePNGBitDepth.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblImagePNGBitDepth.Name" xml:space="preserve">
+    <value>lblImagePNGBitDepth</value>
+  </data>
+  <data name="&gt;&gt;lblImagePNGBitDepth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImagePNGBitDepth.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImagePNGBitDepth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbImageAutoUseJPEG.Name" xml:space="preserve">
+    <value>cbImageAutoUseJPEG</value>
+  </data>
+  <data name="&gt;&gt;cbImageAutoUseJPEG.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageAutoUseJPEG.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;cbImageAutoUseJPEG.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblImageFormat.Name" xml:space="preserve">
+    <value>lblImageFormat</value>
+  </data>
+  <data name="&gt;&gt;lblImageFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageFormat.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageFormat.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbImageFileExist.Name" xml:space="preserve">
+    <value>cbImageFileExist</value>
+  </data>
+  <data name="&gt;&gt;cbImageFileExist.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageFileExist.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;cbImageFileExist.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblImageFileExist.Name" xml:space="preserve">
+    <value>lblImageFileExist</value>
+  </data>
+  <data name="&gt;&gt;lblImageFileExist.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageFileExist.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageFileExist.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Name" xml:space="preserve">
+    <value>nudImageAutoUseJPEGSize</value>
+  </data>
+  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;nudImageAutoUseJPEGSize.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblImageSizeLimitHint.Name" xml:space="preserve">
+    <value>lblImageSizeLimitHint</value>
+  </data>
+  <data name="&gt;&gt;lblImageSizeLimitHint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageSizeLimitHint.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageSizeLimitHint.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;nudImageJPEGQuality.Name" xml:space="preserve">
+    <value>nudImageJPEGQuality</value>
+  </data>
+  <data name="&gt;&gt;nudImageJPEGQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudImageJPEGQuality.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;nudImageJPEGQuality.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;cbImageFormat.Name" xml:space="preserve">
+    <value>cbImageFormat</value>
+  </data>
+  <data name="&gt;&gt;cbImageFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageFormat.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;cbImageFormat.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQualityHint.Name" xml:space="preserve">
+    <value>lblImageJPEGQualityHint</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQualityHint.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQualityHint.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQualityHint.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblImageGIFQuality.Name" xml:space="preserve">
+    <value>lblImageGIFQuality</value>
+  </data>
+  <data name="&gt;&gt;lblImageGIFQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageGIFQuality.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageGIFQuality.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQuality.Name" xml:space="preserve">
+    <value>lblImageJPEGQuality</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQuality.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;lblImageJPEGQuality.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cbImageGIFQuality.Name" xml:space="preserve">
+    <value>cbImageGIFQuality</value>
+  </data>
+  <data name="&gt;&gt;cbImageGIFQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageGIFQuality.Parent" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;cbImageGIFQuality.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="pImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 422</value>
+  </data>
+  <data name="pImage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
+    <value>tpQuality</value>
+  </data>
+  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbImagePNGBitDepth.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 72</value>
@@ -1055,7 +2837,6 @@
   </data>
   <data name="lblImageJPEGQualityHint.Text" xml:space="preserve">
     <value>0 - 100</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblImageJPEGQualityHint.Name" xml:space="preserve">
     <value>lblImageJPEGQualityHint</value>
@@ -1150,30 +2931,6 @@
   <data name="&gt;&gt;cbImageGIFQuality.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="pImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 422</value>
-  </data>
-  <data name="pImage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="chkOverrideImageSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1210,26 +2967,80 @@
   <data name="&gt;&gt;chkOverrideImageSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpQuality.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;lblImageEffectsNote.Name" xml:space="preserve">
+    <value>lblImageEffectsNote</value>
+  </data>
+  <data name="&gt;&gt;lblImageEffectsNote.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageEffectsNote.Parent" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;lblImageEffectsNote.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Name" xml:space="preserve">
+    <value>chkShowImageEffectsWindowAfterCapture</value>
+  </data>
+  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Parent" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Name" xml:space="preserve">
+    <value>cbImageEffectOnlyRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Parent" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnImageEffects.Name" xml:space="preserve">
+    <value>btnImageEffects</value>
+  </data>
+  <data name="&gt;&gt;btnImageEffects.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnImageEffects.Parent" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;btnImageEffects.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpEffects.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpQuality.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpEffects.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpEffects.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpQuality.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpEffects.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
-    <value>tpQuality</value>
+  <data name="tpEffects.Text" xml:space="preserve">
+    <value>Effects</value>
   </data>
-  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
+    <value>tpEffects</value>
+  </data>
+  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
     <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblImageEffectsNote.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1348,32 +3159,128 @@
   <data name="&gt;&gt;btnImageEffects.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tpEffects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;cbThumbnailIfSmaller.Name" xml:space="preserve">
+    <value>cbThumbnailIfSmaller</value>
   </data>
-  <data name="tpEffects.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;cbThumbnailIfSmaller.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpEffects.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="&gt;&gt;cbThumbnailIfSmaller.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
   </data>
-  <data name="tpEffects.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cbThumbnailIfSmaller.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailNamePreview.Name" xml:space="preserve">
+    <value>lblThumbnailNamePreview</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailNamePreview.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailNamePreview.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailNamePreview.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailName.Name" xml:space="preserve">
+    <value>lblThumbnailName</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailName.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailName.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpEffects.Text" xml:space="preserve">
-    <value>Effects</value>
+  <data name="&gt;&gt;txtThumbnailName.Name" xml:space="preserve">
+    <value>txtThumbnailName</value>
   </data>
-  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
-    <value>tpEffects</value>
+  <data name="&gt;&gt;txtThumbnailName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
+  <data name="&gt;&gt;txtThumbnailName.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;txtThumbnailName.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailHeight.Name" xml:space="preserve">
+    <value>lblThumbnailHeight</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailHeight.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailHeight.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailWidth.Name" xml:space="preserve">
+    <value>lblThumbnailWidth</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailWidth.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblThumbnailWidth.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailHeight.Name" xml:space="preserve">
+    <value>nudThumbnailHeight</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailHeight.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailHeight.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailWidth.Name" xml:space="preserve">
+    <value>nudThumbnailWidth</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailWidth.Parent" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;nudThumbnailWidth.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tpThumbnail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpThumbnail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpThumbnail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpThumbnail.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpThumbnail.Text" xml:space="preserve">
+    <value>Thumbnail</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
+    <value>tpThumbnail</value>
+  </data>
+  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
     <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbThumbnailIfSmaller.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1594,83 +3501,269 @@
   <data name="&gt;&gt;nudThumbnailWidth.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="tpThumbnail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Name" xml:space="preserve">
+    <value>btnCaptureCustomRegionSelectRectangle</value>
   </data>
-  <data name="tpThumbnail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpThumbnail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Parent" xml:space="preserve">
+    <value>pCapture</value>
   </data>
-  <data name="tpThumbnail.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tpThumbnail.Text" xml:space="preserve">
-    <value>Thumbnail</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tcImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 473</value>
-  </data>
-  <data name="tcImage.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
-    <value>tcImage</value>
+  <data name="&gt;&gt;lblCaptureCustomRegion.Name" xml:space="preserve">
+    <value>lblCaptureCustomRegion</value>
   </data>
-  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblCaptureCustomRegion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
-    <value>tpImage</value>
+  <data name="&gt;&gt;lblCaptureCustomRegion.Parent" xml:space="preserve">
+    <value>pCapture</value>
   </data>
-  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpImage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpImage.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lblCaptureCustomRegion.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpImage.Text" xml:space="preserve">
-    <value>Image</value>
+  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Name" xml:space="preserve">
+    <value>lblCaptureCustomRegionWidth</value>
   </data>
-  <data name="&gt;&gt;tpImage.Name" xml:space="preserve">
-    <value>tpImage</value>
+  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Parent" xml:space="preserve">
+    <value>pCapture</value>
   </data>
-  <data name="&gt;&gt;tpImage.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpImage.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lblCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Name" xml:space="preserve">
+    <value>lblCaptureCustomRegionHeight</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionY.Name" xml:space="preserve">
+    <value>lblCaptureCustomRegionY</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionY.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionY.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionY.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionX.Name" xml:space="preserve">
+    <value>lblCaptureCustomRegionX</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionX.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionX.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureCustomRegionX.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Name" xml:space="preserve">
+    <value>nudCaptureCustomRegionHeight</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Name" xml:space="preserve">
+    <value>nudCaptureCustomRegionWidth</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionY.Name" xml:space="preserve">
+    <value>nudCaptureCustomRegionY</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionY.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionY.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionY.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionX.Name" xml:space="preserve">
+    <value>nudCaptureCustomRegionX</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionX.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionX.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureCustomRegionX.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cbShowCursor.Name" xml:space="preserve">
+    <value>cbShowCursor</value>
+  </data>
+  <data name="&gt;&gt;cbShowCursor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbShowCursor.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbShowCursor.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureShadowOffset.Name" xml:space="preserve">
+    <value>lblCaptureShadowOffset</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureShadowOffset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureShadowOffset.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;lblCaptureShadowOffset.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureTransparent.Name" xml:space="preserve">
+    <value>cbCaptureTransparent</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureTransparent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureTransparent.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureTransparent.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Name" xml:space="preserve">
+    <value>cbCaptureAutoHideTaskbar</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureShadow.Name" xml:space="preserve">
+    <value>cbCaptureShadow</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureShadow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureShadow.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureShadow.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;lblScreenshotDelayInfo.Name" xml:space="preserve">
+    <value>lblScreenshotDelayInfo</value>
+  </data>
+  <data name="&gt;&gt;lblScreenshotDelayInfo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenshotDelayInfo.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;lblScreenshotDelayInfo.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureClientArea.Name" xml:space="preserve">
+    <value>cbCaptureClientArea</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureClientArea.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureClientArea.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureClientArea.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;nudScreenshotDelay.Name" xml:space="preserve">
+    <value>nudScreenshotDelay</value>
+  </data>
+  <data name="&gt;&gt;nudScreenshotDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenshotDelay.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudScreenshotDelay.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureShadowOffset.Name" xml:space="preserve">
+    <value>nudCaptureShadowOffset</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureShadowOffset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureShadowOffset.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;nudCaptureShadowOffset.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;cbScreenshotDelay.Name" xml:space="preserve">
+    <value>cbScreenshotDelay</value>
+  </data>
+  <data name="&gt;&gt;cbScreenshotDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenshotDelay.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbScreenshotDelay.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="pCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 422</value>
+  </data>
+  <data name="pCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.Location" type="System.Drawing.Point, System.Drawing">
     <value>232, 263</value>
@@ -1800,7 +3893,6 @@
   </data>
   <data name="lblCaptureCustomRegionY.Text" xml:space="preserve">
     <value>Y</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionY.Name" xml:space="preserve">
     <value>lblCaptureCustomRegionY</value>
@@ -1831,7 +3923,6 @@
   </data>
   <data name="lblCaptureCustomRegionX.Text" xml:space="preserve">
     <value>X</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionX.Name" xml:space="preserve">
     <value>lblCaptureCustomRegionX</value>
@@ -2217,30 +4308,6 @@
   <data name="&gt;&gt;cbScreenshotDelay.ZOrder" xml:space="preserve">
     <value>19</value>
   </data>
-  <data name="pCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 422</value>
-  </data>
-  <data name="pCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
-  </data>
-  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="chkOverrideCaptureSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2277,27 +4344,6 @@
   <data name="&gt;&gt;chkOverrideCaptureSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpCaptureGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCaptureGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpCaptureGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Name" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Parent" xml:space="preserve">
-    <value>tcCapture</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="cbRegionCaptureShowFPS.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2330,6 +4376,78 @@
   </data>
   <data name="flpRegionCaptureFixedSize.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Name" xml:space="preserve">
+    <value>lblRegionCaptureFixedSizeWidth</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Parent" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Name" xml:space="preserve">
+    <value>nudRegionCaptureFixedSizeWidth</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Parent" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Name" xml:space="preserve">
+    <value>lblRegionCaptureFixedSizeHeight</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Parent" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Name" xml:space="preserve">
+    <value>nudRegionCaptureFixedSizeHeight</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Parent" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>312, 387</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>222, 26</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.WrapContents" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblRegionCaptureFixedSizeWidth.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -2444,30 +4562,6 @@
   </data>
   <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 387</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 26</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.WrapContents" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="cbRegionCaptureIsFixedSize.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2672,7 +4766,6 @@
   </data>
   <data name="btnRegionCaptureSnapSizesRemove.Text" xml:space="preserve">
     <value>-</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Name" xml:space="preserve">
     <value>btnRegionCaptureSnapSizesRemove</value>
@@ -2697,7 +4790,6 @@
   </data>
   <data name="btnRegionCaptureSnapSizesAdd.Text" xml:space="preserve">
     <value>+</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Name" xml:space="preserve">
     <value>btnRegionCaptureSnapSizesAdd</value>
@@ -3068,6 +5160,102 @@
   <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.ZOrder" xml:space="preserve">
     <value>24</value>
   </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Name" xml:space="preserve">
+    <value>btnRegionCaptureSnapSizesDialogCancel</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Name" xml:space="preserve">
+    <value>btnRegionCaptureSnapSizesDialogAdd</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Name" xml:space="preserve">
+    <value>nudRegionCaptureSnapSizesHeight</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Name" xml:space="preserve">
+    <value>RegionCaptureSnapSizesHeight</value>
+  </data>
+  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Name" xml:space="preserve">
+    <value>nudRegionCaptureSnapSizesWidth</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Name" xml:space="preserve">
+    <value>lblRegionCaptureSnapSizesWidth</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Parent" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 208</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 112</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
   <data name="btnRegionCaptureSnapSizesDialogCancel.Location" type="System.Drawing.Point, System.Drawing">
     <value>120, 80</value>
   </data>
@@ -3221,30 +5409,6 @@
   <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="pRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 208</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 112</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
   <data name="cbRegionCaptureUseDimming.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3341,551 +5505,110 @@
   <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
     <value>29</value>
   </data>
-  <data name="tpRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
+    <value>tpUploadMain</value>
   </data>
-  <data name="tpRegionCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpRegionCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpRegionCapture.Text" xml:space="preserve">
-    <value>Region capture</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.Name" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpRegionCapture.Parent" xml:space="preserve">
-    <value>tcCapture</value>
+  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
+    <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpRegionCapture.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 183</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 17</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="cbScreenRecorderConfirmAbort.Text" xml:space="preserve">
-    <value>Ask for confirmation when aborting</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderConfirmAbort.Name" xml:space="preserve">
-    <value>cbScreenRecorderConfirmAbort</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderConfirmAbort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderConfirmAbort.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderConfirmAbort.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="cbScreenRecorderShowCursor.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
+    <value>tpFileNaming</value>
   </data>
-  <data name="cbScreenRecorderShowCursor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 88</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 17</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Text" xml:space="preserve">
-    <value>Show cursor in recording</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Name" xml:space="preserve">
-    <value>cbScreenRecorderShowCursor</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>192, 24</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Text" xml:space="preserve">
-    <value>Screen recording options...</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Name" xml:space="preserve">
-    <value>btnScreenRecorderFFmpegOptions</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 114</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Text" xml:space="preserve">
-    <value>seconds</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Name" xml:space="preserve">
-    <value>lblScreenRecorderStartDelay</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 112</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 17</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Text" xml:space="preserve">
-    <value>Start recording after:</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Name" xml:space="preserve">
-    <value>chkScreenRecordAutoStart</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 138</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Text" xml:space="preserve">
-    <value>seconds</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Name" xml:space="preserve">
-    <value>lblScreenRecorderFixedDuration</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="nudScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 36</value>
-  </data>
-  <data name="nudScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="nudScreenRecordFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Name" xml:space="preserve">
-    <value>nudScreenRecordFPS</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lblScreenRecordFPS.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecordFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 40</value>
-  </data>
-  <data name="lblScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 13</value>
-  </data>
-  <data name="lblScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblScreenRecordFPS.Text" xml:space="preserve">
-    <value>Screen recording FPS:</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Name" xml:space="preserve">
-    <value>lblScreenRecordFPS</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="chkRunScreencastCLI.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkRunScreencastCLI.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkRunScreencastCLI.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 160</value>
-  </data>
-  <data name="chkRunScreencastCLI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 17</value>
-  </data>
-  <data name="chkRunScreencastCLI.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="chkRunScreencastCLI.Text" xml:space="preserve">
-    <value>Run CLI afterwards:</value>
-  </data>
-  <data name="&gt;&gt;chkRunScreencastCLI.Name" xml:space="preserve">
-    <value>chkRunScreencastCLI</value>
-  </data>
-  <data name="&gt;&gt;chkRunScreencastCLI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkRunScreencastCLI.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;chkRunScreencastCLI.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="btnEncoderConfig.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnEncoderConfig.Location" type="System.Drawing.Point, System.Drawing">
-    <value>458, 157</value>
-  </data>
-  <data name="btnEncoderConfig.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 23</value>
-  </data>
-  <data name="btnEncoderConfig.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="btnEncoderConfig.Text" xml:space="preserve">
-    <value>Profiles...</value>
-  </data>
-  <data name="&gt;&gt;btnEncoderConfig.Name" xml:space="preserve">
-    <value>btnEncoderConfig</value>
-  </data>
-  <data name="&gt;&gt;btnEncoderConfig.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnEncoderConfig.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;btnEncoderConfig.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="cboEncoder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 158</value>
-  </data>
-  <data name="cboEncoder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 21</value>
-  </data>
-  <data name="cboEncoder.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cboEncoder.Name" xml:space="preserve">
-    <value>cboEncoder</value>
-  </data>
-  <data name="&gt;&gt;cboEncoder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboEncoder.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cboEncoder.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="nudScreenRecorderDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 134</value>
-  </data>
-  <data name="nudScreenRecorderDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecorderDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="nudScreenRecorderDuration.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Name" xml:space="preserve">
-    <value>nudScreenRecorderDuration</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 110</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Name" xml:space="preserve">
-    <value>nudScreenRecorderStartDelay</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 136</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Text" xml:space="preserve">
-    <value>Fixed duration:</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Name" xml:space="preserve">
-    <value>cbScreenRecorderFixedDuration</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="nudGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 60</value>
-  </data>
-  <data name="nudGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudGIFFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="nudGIFFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Name" xml:space="preserve">
-    <value>nudGIFFPS</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="lblGIFFPS.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblGIFFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 64</value>
-  </data>
-  <data name="lblGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
-  </data>
-  <data name="lblGIFFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="lblGIFFPS.Text" xml:space="preserve">
-    <value>GIF FPS:</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Name" xml:space="preserve">
-    <value>lblGIFFPS</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="tpScreenRecorder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpScreenRecorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpScreenRecorder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpScreenRecorder.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpScreenRecorder.Text" xml:space="preserve">
-    <value>Screen recorder</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.Name" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpScreenRecorder.Parent" xml:space="preserve">
-    <value>tcCapture</value>
+  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
+    <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
+    <value>tpUploadClipboard</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
+    <value>tcUpload</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tcCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
+    <value>tcUpload</value>
+  </data>
+  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tcUpload.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tcCapture.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tcUpload.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="tcCapture.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tcUpload.Size" type="System.Drawing.Size, System.Drawing">
     <value>565, 473</value>
   </data>
-  <data name="tcCapture.TabIndex" type="System.Int32, mscorlib">
+  <data name="tcUpload.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;tcCapture.Name" xml:space="preserve">
-    <value>tcCapture</value>
+  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
+    <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tcCapture.Type" xml:space="preserve">
+  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tcCapture.Parent" xml:space="preserve">
-    <value>tpCapture</value>
+  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
+    <value>tpUpload</value>
   </data>
-  <data name="&gt;&gt;tcCapture.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpCapture.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;chkOverrideUploadSettings.Name" xml:space="preserve">
+    <value>chkOverrideUploadSettings</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideUploadSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideUploadSettings.Parent" xml:space="preserve">
+    <value>tpUploadMain</value>
+  </data>
+  <data name="&gt;&gt;chkOverrideUploadSettings.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpUploadMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="tpUploadMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
   </data>
-  <data name="tpCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
+  <data name="tpUploadMain.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
+    <value>tpUploadMain</value>
   </data>
-  <data name="tpCapture.Text" xml:space="preserve">
-    <value>Capture</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.Name" xml:space="preserve">
-    <value>tpCapture</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpCapture.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
+  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
+    <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpCapture.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="chkOverrideUploadSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3923,26 +5646,188 @@
   <data name="&gt;&gt;chkOverrideUploadSettings.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tpUploadMain.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Name" xml:space="preserve">
+    <value>cbFileUploadReplaceProblematicCharacters</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblAutoIncrementNumber.Name" xml:space="preserve">
+    <value>lblAutoIncrementNumber</value>
+  </data>
+  <data name="&gt;&gt;lblAutoIncrementNumber.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAutoIncrementNumber.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;lblAutoIncrementNumber.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Name" xml:space="preserve">
+    <value>cbRegionCaptureUseWindowPattern</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Name" xml:space="preserve">
+    <value>cbNameFormatCustomTimeZone</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatCustomTimeZone.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreview.Name" xml:space="preserve">
+    <value>lblNameFormatPatternPreview</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreview.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreview.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreview.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Name" xml:space="preserve">
+    <value>lblNameFormatPatternActiveWindow</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Name" xml:space="preserve">
+    <value>lblNameFormatPatternPreviewActiveWindow</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatTimeZone.Name" xml:space="preserve">
+    <value>cbNameFormatTimeZone</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatTimeZone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatTimeZone.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;cbNameFormatTimeZone.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Name" xml:space="preserve">
+    <value>txtNameFormatPatternActiveWindow</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnResetAutoIncrementNumber.Name" xml:space="preserve">
+    <value>btnResetAutoIncrementNumber</value>
+  </data>
+  <data name="&gt;&gt;btnResetAutoIncrementNumber.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnResetAutoIncrementNumber.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;btnResetAutoIncrementNumber.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadUseNamePattern.Name" xml:space="preserve">
+    <value>cbFileUploadUseNamePattern</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadUseNamePattern.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadUseNamePattern.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;cbFileUploadUseNamePattern.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPattern.Name" xml:space="preserve">
+    <value>lblNameFormatPattern</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPattern.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPattern.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;lblNameFormatPattern.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPattern.Name" xml:space="preserve">
+    <value>txtNameFormatPattern</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPattern.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPattern.Parent" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;txtNameFormatPattern.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="tpFileNaming.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUploadMain.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpFileNaming.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpFileNaming.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpUploadMain.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpFileNaming.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
-    <value>tpUploadMain</value>
+  <data name="tpFileNaming.Text" xml:space="preserve">
+    <value>File naming</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
+    <value>tpFileNaming</value>
+  </data>
+  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3985,7 +5870,6 @@
   </data>
   <data name="lblAutoIncrementNumber.Text" xml:space="preserve">
     <value>0</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblAutoIncrementNumber.Name" xml:space="preserve">
     <value>lblAutoIncrementNumber</value>
@@ -4296,32 +6180,80 @@
   <data name="&gt;&gt;txtNameFormatPattern.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="tpFileNaming.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;cbClipboardUploadShareURL.Name" xml:space="preserve">
+    <value>cbClipboardUploadShareURL</value>
   </data>
-  <data name="tpFileNaming.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;cbClipboardUploadShareURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpFileNaming.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="&gt;&gt;cbClipboardUploadShareURL.Parent" xml:space="preserve">
+    <value>tpUploadClipboard</value>
   </data>
-  <data name="tpFileNaming.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cbClipboardUploadShareURL.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkClipboardUploadURLContents.Name" xml:space="preserve">
+    <value>chkClipboardUploadURLContents</value>
+  </data>
+  <data name="&gt;&gt;chkClipboardUploadURLContents.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkClipboardUploadURLContents.Parent" xml:space="preserve">
+    <value>tpUploadClipboard</value>
+  </data>
+  <data name="&gt;&gt;chkClipboardUploadURLContents.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Name" xml:space="preserve">
+    <value>cbClipboardUploadAutoIndexFolder</value>
+  </data>
+  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Parent" xml:space="preserve">
+    <value>tpUploadClipboard</value>
+  </data>
+  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="tpFileNaming.Text" xml:space="preserve">
-    <value>File naming</value>
+  <data name="&gt;&gt;cbClipboardUploadShortenURL.Name" xml:space="preserve">
+    <value>cbClipboardUploadShortenURL</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
-    <value>tpFileNaming</value>
+  <data name="&gt;&gt;cbClipboardUploadShortenURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
+  <data name="&gt;&gt;cbClipboardUploadShortenURL.Parent" xml:space="preserve">
+    <value>tpUploadClipboard</value>
+  </data>
+  <data name="&gt;&gt;cbClipboardUploadShortenURL.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tpUploadClipboard.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpUploadClipboard.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpUploadClipboard.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpUploadClipboard.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpUploadClipboard.Text" xml:space="preserve">
+    <value>Clipboard upload</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
+    <value>tpUploadClipboard</value>
+  </data>
+  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbClipboardUploadShareURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4443,47 +6375,143 @@
   <data name="&gt;&gt;cbClipboardUploadShortenURL.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tpUploadClipboard.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;lvUploaderFiltersList.Name" xml:space="preserve">
+    <value>lvUploaderFiltersList</value>
   </data>
-  <data name="tpUploadClipboard.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;lvUploaderFiltersList.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="tpUploadClipboard.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="&gt;&gt;lvUploaderFiltersList.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
   </data>
-  <data name="tpUploadClipboard.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;lvUploaderFiltersList.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersRemove.Name" xml:space="preserve">
+    <value>btnUploaderFiltersRemove</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersRemove.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersRemove.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="tpUploadClipboard.Text" xml:space="preserve">
-    <value>Clipboard upload</value>
+  <data name="&gt;&gt;btnUploaderFiltersUpdate.Name" xml:space="preserve">
+    <value>btnUploaderFiltersUpdate</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
-    <value>tpUploadClipboard</value>
+  <data name="&gt;&gt;btnUploaderFiltersUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnUploaderFiltersUpdate.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersUpdate.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersAdd.Name" xml:space="preserve">
+    <value>btnUploaderFiltersAdd</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersAdd.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;btnUploaderFiltersAdd.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersDestination.Name" xml:space="preserve">
+    <value>lblUploaderFiltersDestination</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersDestination.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersDestination.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersDestination.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;cbUploaderFiltersDestination.Name" xml:space="preserve">
+    <value>cbUploaderFiltersDestination</value>
+  </data>
+  <data name="&gt;&gt;cbUploaderFiltersDestination.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbUploaderFiltersDestination.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;cbUploaderFiltersDestination.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Name" xml:space="preserve">
+    <value>lblUploaderFiltersExtensionsExample</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensions.Name" xml:space="preserve">
+    <value>lblUploaderFiltersExtensions</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensions.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;lblUploaderFiltersExtensions.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;txtUploaderFiltersExtensions.Name" xml:space="preserve">
+    <value>txtUploaderFiltersExtensions</value>
+  </data>
+  <data name="&gt;&gt;txtUploaderFiltersExtensions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtUploaderFiltersExtensions.Parent" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;txtUploaderFiltersExtensions.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tpUploaderFilters.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpUploaderFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpUploaderFilters.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpUploaderFilters.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpUploaderFilters.Text" xml:space="preserve">
+    <value>Uploader filters</value>
+  </data>
+  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
+    <value>tpUploaderFilters</value>
+  </data>
+  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lvUploaderFiltersList.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="chUploaderFiltersName.Text" xml:space="preserve">
-    <value>Uploader</value>
-  </data>
-  <data name="chUploaderFiltersName.Width" type="System.Int32, mscorlib">
-    <value>128</value>
-  </data>
-  <data name="chUploaderFiltersExtension.Text" xml:space="preserve">
-    <value>Extension</value>
-  </data>
-  <data name="chUploaderFiltersExtension.Width" type="System.Int32, mscorlib">
-    <value>98</value>
   </data>
   <data name="lvUploaderFiltersList.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 136</value>
@@ -4505,6 +6533,18 @@
   </data>
   <data name="&gt;&gt;lvUploaderFiltersList.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="chUploaderFiltersName.Text" xml:space="preserve">
+    <value>Uploader</value>
+  </data>
+  <data name="chUploaderFiltersName.Width" type="System.Int32, mscorlib">
+    <value>128</value>
+  </data>
+  <data name="chUploaderFiltersExtension.Text" xml:space="preserve">
+    <value>Extension</value>
+  </data>
+  <data name="chUploaderFiltersExtension.Width" type="System.Int32, mscorlib">
+    <value>98</value>
   </data>
   <data name="btnUploaderFiltersRemove.Location" type="System.Drawing.Point, System.Drawing">
     <value>280, 104</value>
@@ -4701,83 +6741,92 @@
   <data name="&gt;&gt;txtUploaderFiltersExtensions.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="tpUploaderFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;btnActionsDuplicate.Name" xml:space="preserve">
+    <value>btnActionsDuplicate</value>
   </data>
-  <data name="tpUploaderFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;btnActionsDuplicate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpUploaderFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="&gt;&gt;btnActionsDuplicate.Parent" xml:space="preserve">
+    <value>pActions</value>
   </data>
-  <data name="tpUploaderFilters.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;btnActionsDuplicate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnActionsAdd.Name" xml:space="preserve">
+    <value>btnActionsAdd</value>
+  </data>
+  <data name="&gt;&gt;btnActionsAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnActionsAdd.Parent" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;btnActionsAdd.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
+    <value>lvActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnActionsEdit.Name" xml:space="preserve">
+    <value>btnActionsEdit</value>
+  </data>
+  <data name="&gt;&gt;btnActionsEdit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnActionsEdit.Parent" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;btnActionsEdit.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tpUploaderFilters.Text" xml:space="preserve">
-    <value>Uploader filters</value>
+  <data name="&gt;&gt;btnActionsRemove.Name" xml:space="preserve">
+    <value>btnActionsRemove</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
-    <value>tpUploaderFilters</value>
+  <data name="&gt;&gt;btnActionsRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;btnActionsRemove.Parent" xml:space="preserve">
+    <value>pActions</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
-    <value>tcUpload</value>
+  <data name="&gt;&gt;btnActionsRemove.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tcUpload.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="pActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tcUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+  <data name="pActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
   </data>
-  <data name="tcUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 473</value>
+  <data name="pActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
-  <data name="tcUpload.TabIndex" type="System.Int32, mscorlib">
+  <data name="pActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pActions.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
-    <value>tpUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpUpload.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpUpload.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tpUpload.Text" xml:space="preserve">
-    <value>Upload</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Name" xml:space="preserve">
-    <value>tpUpload</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="btnActionsDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -4836,6 +6885,27 @@
   <data name="lvActions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="lvActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="lvActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>558, 407</value>
+  </data>
+  <data name="lvActions.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
+    <value>lvActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="chActionsName.Text" xml:space="preserve">
     <value>Name</value>
   </data>
@@ -4859,27 +6929,6 @@
   </data>
   <data name="chActionsExtensions.Width" type="System.Int32, mscorlib">
     <value>75</value>
-  </data>
-  <data name="lvActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 40</value>
-  </data>
-  <data name="lvActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>558, 407</value>
-  </data>
-  <data name="lvActions.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
-    <value>lvActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="btnActionsEdit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -4935,33 +6984,6 @@
   <data name="&gt;&gt;btnActionsRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="pActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="pActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pActions.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="chkOverrideActions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -4997,30 +7019,6 @@
   </data>
   <data name="&gt;&gt;chkOverrideActions.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="tpActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpActions.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tpActions.Text" xml:space="preserve">
-    <value>Actions</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Name" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpActions.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="btnWatchFolderEdit.Location" type="System.Drawing.Point, System.Drawing">
     <value>104, 32</value>
@@ -5079,24 +7077,6 @@
   <data name="lvWatchFolderList.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="chWatchFolderFolderPath.Text" xml:space="preserve">
-    <value>Folder path</value>
-  </data>
-  <data name="chWatchFolderFolderPath.Width" type="System.Int32, mscorlib">
-    <value>323</value>
-  </data>
-  <data name="chWatchFolderFilter.Text" xml:space="preserve">
-    <value>Filter</value>
-  </data>
-  <data name="chWatchFolderFilter.Width" type="System.Int32, mscorlib">
-    <value>43</value>
-  </data>
-  <data name="chWatchFolderIncludeSubdirectories.Text" xml:space="preserve">
-    <value>Include subdirectories</value>
-  </data>
-  <data name="chWatchFolderIncludeSubdirectories.Width" type="System.Int32, mscorlib">
-    <value>124</value>
-  </data>
   <data name="lvWatchFolderList.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -5117,6 +7097,24 @@
   </data>
   <data name="&gt;&gt;lvWatchFolderList.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="chWatchFolderFolderPath.Text" xml:space="preserve">
+    <value>Folder path</value>
+  </data>
+  <data name="chWatchFolderFolderPath.Width" type="System.Int32, mscorlib">
+    <value>323</value>
+  </data>
+  <data name="chWatchFolderFilter.Text" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="chWatchFolderFilter.Width" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="chWatchFolderIncludeSubdirectories.Text" xml:space="preserve">
+    <value>Include subdirectories</value>
+  </data>
+  <data name="chWatchFolderIncludeSubdirectories.Width" type="System.Int32, mscorlib">
+    <value>124</value>
   </data>
   <data name="btnWatchFolderRemove.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -5172,32 +7170,53 @@
   <data name="&gt;&gt;btnWatchFolderAdd.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="tpWatchFolders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Name" xml:space="preserve">
+    <value>txtToolsScreenColorPickerFormat</value>
   </data>
-  <data name="tpWatchFolders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tpWatchFolders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
+  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Parent" xml:space="preserve">
+    <value>pTools</value>
   </data>
-  <data name="tpWatchFolders.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="tpWatchFolders.Text" xml:space="preserve">
-    <value>Watch folders</value>
+  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Name" xml:space="preserve">
+    <value>lblToolsScreenColorPickerFormat</value>
   </data>
-  <data name="&gt;&gt;tpWatchFolders.Name" xml:space="preserve">
-    <value>tpWatchFolders</value>
+  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpWatchFolders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Parent" xml:space="preserve">
+    <value>pTools</value>
   </data>
-  <data name="&gt;&gt;tpWatchFolders.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
+  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tpWatchFolders.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="pTools.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pTools.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pTools.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pTools.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
+    <value>pTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="txtToolsScreenColorPickerFormat.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 24</value>
@@ -5247,30 +7266,6 @@
   <data name="&gt;&gt;lblToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="pTools.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pTools.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
-    <value>pTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="chkOverrideToolsSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -5306,30 +7301,6 @@
   </data>
   <data name="&gt;&gt;chkOverrideToolsSettings.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="tpTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpTools.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="tpTools.Text" xml:space="preserve">
-    <value>Tools</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Name" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpTools.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="pgTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -5390,60 +7361,6 @@
   </data>
   <data name="&gt;&gt;chkOverrideAdvancedSettings.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="tpAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpAdvanced.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAdvanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpAdvanced.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="tpAdvanced.Text" xml:space="preserve">
-    <value>Advanced</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Name" xml:space="preserve">
-    <value>tpAdvanced</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tcTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Right</value>
-  </data>
-  <data name="tcTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>202, 3</value>
-  </data>
-  <data name="tcTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>579, 505</value>
-  </data>
-  <data name="tcTaskSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tcTaskSettings.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Name" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="tttvMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/ShareX/Forms/TaskSettingsForm.resx
+++ b/ShareX/Forms/TaskSettingsForm.resx
@@ -297,1494 +297,6 @@
   <data name="&gt;&gt;cmsTask.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cbOverrideCustomUploader.Name" xml:space="preserve">
-    <value>cbOverrideCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;cbOverrideCustomUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbOverrideCustomUploader.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;cbOverrideCustomUploader.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCustomUploader.Name" xml:space="preserve">
-    <value>chkOverrideCustomUploader</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCustomUploader.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCustomUploader.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCustomUploader.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideFTP.Name" xml:space="preserve">
-    <value>chkOverrideFTP</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideFTP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideFTP.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideFTP.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cboFTPaccounts.Name" xml:space="preserve">
-    <value>cboFTPaccounts</value>
-  </data>
-  <data name="&gt;&gt;cboFTPaccounts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cboFTPaccounts.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;cboFTPaccounts.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnAfterCapture.Name" xml:space="preserve">
-    <value>btnAfterCapture</value>
-  </data>
-  <data name="&gt;&gt;btnAfterCapture.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnAfterCapture.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;btnAfterCapture.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnAfterUpload.Name" xml:space="preserve">
-    <value>btnAfterUpload</value>
-  </data>
-  <data name="&gt;&gt;btnAfterUpload.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnAfterUpload.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;btnAfterUpload.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;btnDestinations.Name" xml:space="preserve">
-    <value>btnDestinations</value>
-  </data>
-  <data name="&gt;&gt;btnDestinations.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnDestinations.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;btnDestinations.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;btnTask.Name" xml:space="preserve">
-    <value>btnTask</value>
-  </data>
-  <data name="&gt;&gt;btnTask.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MenuButton, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnTask.Parent" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;btnTask.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="tpTask.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTask.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpTask.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpTask.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpTask.Text" xml:space="preserve">
-    <value>Task</value>
-  </data>
-  <data name="&gt;&gt;tpTask.Name" xml:space="preserve">
-    <value>tpTask</value>
-  </data>
-  <data name="&gt;&gt;tpTask.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTask.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpTask.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
-    <value>pGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideGeneralSettings.Name" xml:space="preserve">
-    <value>chkOverrideGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideGeneralSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideGeneralSettings.Parent" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideGeneralSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="tpGeneral.Text" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
-    <value>tpImage</value>
-  </data>
-  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpImage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpImage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpImage.Text" xml:space="preserve">
-    <value>Image</value>
-  </data>
-  <data name="&gt;&gt;tpImage.Name" xml:space="preserve">
-    <value>tpImage</value>
-  </data>
-  <data name="&gt;&gt;tpImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpImage.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpImage.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
-  </data>
-  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCaptureSettings.Name" xml:space="preserve">
-    <value>chkOverrideCaptureSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCaptureSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCaptureSettings.Parent" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideCaptureSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpCaptureGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCaptureGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpCaptureGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Name" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.Parent" xml:space="preserve">
-    <value>tcCapture</value>
-  </data>
-  <data name="&gt;&gt;tpCaptureGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowFPS.Name" xml:space="preserve">
-    <value>cbRegionCaptureShowFPS</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowFPS.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowFPS.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Name" xml:space="preserve">
-    <value>cbRegionCaptureIsFixedSize</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureIsFixedSize.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Name" xml:space="preserve">
-    <value>cbRegionCaptureShowCrosshair</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowCrosshair.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Name" xml:space="preserve">
-    <value>lblRegionCaptureMagnifierPixelSize</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Name" xml:space="preserve">
-    <value>lblRegionCaptureMagnifierPixelCount</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMagnifierPixelCount.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Name" xml:space="preserve">
-    <value>cbRegionCaptureUseSquareMagnifier</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseSquareMagnifier.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Name" xml:space="preserve">
-    <value>cbRegionCaptureShowMagnifier</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowMagnifier.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowInfo.Name" xml:space="preserve">
-    <value>cbRegionCaptureShowInfo</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowInfo.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureShowInfo.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Name" xml:space="preserve">
-    <value>btnRegionCaptureSnapSizesRemove</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesRemove.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Name" xml:space="preserve">
-    <value>btnRegionCaptureSnapSizesAdd</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesAdd.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Name" xml:space="preserve">
-    <value>cbRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureSnapSizes.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Name" xml:space="preserve">
-    <value>lblRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizes.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Name" xml:space="preserve">
-    <value>cbRegionCaptureUseCustomInfoText</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseCustomInfoText.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectControls.Name" xml:space="preserve">
-    <value>cbRegionCaptureDetectControls</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectControls.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectControls.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Name" xml:space="preserve">
-    <value>cbRegionCaptureDetectWindows</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectWindows.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureDetectWindows.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Name" xml:space="preserve">
-    <value>cbRegionCaptureMouse5ClickAction</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse5ClickAction.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Name" xml:space="preserve">
-    <value>lblRegionCaptureMouse5ClickAction</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse5ClickAction.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Name" xml:space="preserve">
-    <value>cbRegionCaptureMouse4ClickAction</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouse4ClickAction.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Name" xml:space="preserve">
-    <value>lblRegionCaptureMouse4ClickAction</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouse4ClickAction.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Name" xml:space="preserve">
-    <value>cbRegionCaptureMouseMiddleClickAction</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseMiddleClickAction.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Name" xml:space="preserve">
-    <value>lblRegionCaptureMouseMiddleClickAction</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseMiddleClickAction.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Name" xml:space="preserve">
-    <value>cbRegionCaptureMouseRightClickAction</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMouseRightClickAction.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Name" xml:space="preserve">
-    <value>lblRegionCaptureMouseRightClickAction</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureMouseRightClickAction.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Name" xml:space="preserve">
-    <value>cbRegionCaptureMultiRegionMode</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseDimming.Name" xml:space="preserve">
-    <value>cbRegionCaptureUseDimming</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseDimming.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseDimming.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseDimming.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Name" xml:space="preserve">
-    <value>txtRegionCaptureCustomInfoText</value>
-  </data>
-  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;txtRegionCaptureCustomInfoText.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Name" xml:space="preserve">
-    <value>nudRegionCaptureMagnifierPixelCount</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelCount.ZOrder" xml:space="preserve">
-    <value>28</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Name" xml:space="preserve">
-    <value>nudRegionCaptureMagnifierPixelSize</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
-    <value>29</value>
-  </data>
-  <data name="tpRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpRegionCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpRegionCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpRegionCapture.Text" xml:space="preserve">
-    <value>Region capture</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.Name" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.Parent" xml:space="preserve">
-    <value>tcCapture</value>
-  </data>
-  <data name="&gt;&gt;tpRegionCapture.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="cbScreenRecordTwoPassEncoding.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecordTwoPassEncoding.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 160</value>
-  </data>
-  <data name="cbScreenRecordTwoPassEncoding.Size" type="System.Drawing.Size, System.Drawing">
-    <value>376, 17</value>
-  </data>
-  <data name="cbScreenRecordTwoPassEncoding.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="cbScreenRecordTwoPassEncoding.Text" xml:space="preserve">
-    <value>Record using lossless encoding and after that apply user encoding options</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Name" xml:space="preserve">
-    <value>cbScreenRecordTwoPassEncoding</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 207</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 17</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="cbScreenRecordConfirmAbort.Text" xml:space="preserve">
-    <value>Ask for confirmation when aborting</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Name" xml:space="preserve">
-    <value>cbScreenRecordConfirmAbort</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordConfirmAbort.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 88</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 17</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="cbScreenRecorderShowCursor.Text" xml:space="preserve">
-    <value>Show cursor in recording</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Name" xml:space="preserve">
-    <value>cbScreenRecorderShowCursor</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderShowCursor.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>192, 24</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="btnScreenRecorderFFmpegOptions.Text" xml:space="preserve">
-    <value>Screen recording options...</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Name" xml:space="preserve">
-    <value>btnScreenRecorderFFmpegOptions</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 114</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="lblScreenRecorderStartDelay.Text" xml:space="preserve">
-    <value>seconds</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Name" xml:space="preserve">
-    <value>lblScreenRecorderStartDelay</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderStartDelay.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 112</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 17</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkScreenRecordAutoStart.Text" xml:space="preserve">
-    <value>Start recording after:</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Name" xml:space="preserve">
-    <value>chkScreenRecordAutoStart</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;chkScreenRecordAutoStart.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 138</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="lblScreenRecorderFixedDuration.Text" xml:space="preserve">
-    <value>seconds</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Name" xml:space="preserve">
-    <value>lblScreenRecorderFixedDuration</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="nudScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 36</value>
-  </data>
-  <data name="nudScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="nudScreenRecordFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Name" xml:space="preserve">
-    <value>nudScreenRecordFPS</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecordFPS.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="lblScreenRecordFPS.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblScreenRecordFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 40</value>
-  </data>
-  <data name="lblScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 13</value>
-  </data>
-  <data name="lblScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblScreenRecordFPS.Text" xml:space="preserve">
-    <value>Screen recording FPS:</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Name" xml:space="preserve">
-    <value>lblScreenRecordFPS</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblScreenRecordFPS.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 184</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 17</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="cbScreenRecordRunScreencastCLI.Text" xml:space="preserve">
-    <value>Run CLI afterwards:</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Name" xml:space="preserve">
-    <value>cbScreenRecordRunScreencastCLI</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="btnScreenRecordEncoderConfig.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnScreenRecordEncoderConfig.Location" type="System.Drawing.Point, System.Drawing">
-    <value>458, 181</value>
-  </data>
-  <data name="btnScreenRecordEncoderConfig.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 23</value>
-  </data>
-  <data name="btnScreenRecordEncoderConfig.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="btnScreenRecordEncoderConfig.Text" xml:space="preserve">
-    <value>Profiles...</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Name" xml:space="preserve">
-    <value>btnScreenRecordEncoderConfig</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;btnScreenRecordEncoderConfig.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="cbScreenRecordEncoder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 182</value>
-  </data>
-  <data name="cbScreenRecordEncoder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 21</value>
-  </data>
-  <data name="cbScreenRecordEncoder.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordEncoder.Name" xml:space="preserve">
-    <value>cbScreenRecordEncoder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordEncoder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordEncoder.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecordEncoder.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="nudScreenRecorderDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 134</value>
-  </data>
-  <data name="nudScreenRecorderDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecorderDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="nudScreenRecorderDuration.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Name" xml:space="preserve">
-    <value>nudScreenRecorderDuration</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderDuration.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 110</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="nudScreenRecorderStartDelay.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Name" xml:space="preserve">
-    <value>nudScreenRecorderStartDelay</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudScreenRecorderStartDelay.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 136</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="cbScreenRecorderFixedDuration.Text" xml:space="preserve">
-    <value>Fixed duration:</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Name" xml:space="preserve">
-    <value>cbScreenRecorderFixedDuration</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;cbScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="nudGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 60</value>
-  </data>
-  <data name="nudGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
-  </data>
-  <data name="nudGIFFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="nudGIFFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Name" xml:space="preserve">
-    <value>nudGIFFPS</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;nudGIFFPS.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="lblGIFFPS.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblGIFFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 64</value>
-  </data>
-  <data name="lblGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
-  </data>
-  <data name="lblGIFFPS.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="lblGIFFPS.Text" xml:space="preserve">
-    <value>GIF FPS:</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Name" xml:space="preserve">
-    <value>lblGIFFPS</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.Parent" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;lblGIFFPS.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="tpScreenRecorder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpScreenRecorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpScreenRecorder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
-  </data>
-  <data name="tpScreenRecorder.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpScreenRecorder.Text" xml:space="preserve">
-    <value>Screen recorder</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.Name" xml:space="preserve">
-    <value>tpScreenRecorder</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.Parent" xml:space="preserve">
-    <value>tcCapture</value>
-  </data>
-  <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tcCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 473</value>
-  </data>
-  <data name="tcCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcCapture.Name" xml:space="preserve">
-    <value>tcCapture</value>
-  </data>
-  <data name="&gt;&gt;tcCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcCapture.Parent" xml:space="preserve">
-    <value>tpCapture</value>
-  </data>
-  <data name="&gt;&gt;tcCapture.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpCapture.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpCapture.Text" xml:space="preserve">
-    <value>Capture</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.Name" xml:space="preserve">
-    <value>tpCapture</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpCapture.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
-    <value>tpUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpUpload.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpUpload.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="tpUpload.Text" xml:space="preserve">
-    <value>Upload</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Name" xml:space="preserve">
-    <value>tpUpload</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpUpload.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideActions.Name" xml:space="preserve">
-    <value>chkOverrideActions</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideActions.Parent" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideActions.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpActions.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tpActions.Text" xml:space="preserve">
-    <value>Actions</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Name" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpActions.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpActions.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderEdit.Name" xml:space="preserve">
-    <value>btnWatchFolderEdit</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderEdit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderEdit.Parent" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderEdit.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbWatchFolderEnabled.Name" xml:space="preserve">
-    <value>cbWatchFolderEnabled</value>
-  </data>
-  <data name="&gt;&gt;cbWatchFolderEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbWatchFolderEnabled.Parent" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;cbWatchFolderEnabled.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lvWatchFolderList.Name" xml:space="preserve">
-    <value>lvWatchFolderList</value>
-  </data>
-  <data name="&gt;&gt;lvWatchFolderList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvWatchFolderList.Parent" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;lvWatchFolderList.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderRemove.Name" xml:space="preserve">
-    <value>btnWatchFolderRemove</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderRemove.Parent" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderRemove.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderAdd.Name" xml:space="preserve">
-    <value>btnWatchFolderAdd</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderAdd.Parent" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;btnWatchFolderAdd.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpWatchFolders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpWatchFolders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpWatchFolders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpWatchFolders.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="tpWatchFolders.Text" xml:space="preserve">
-    <value>Watch folders</value>
-  </data>
-  <data name="&gt;&gt;tpWatchFolders.Name" xml:space="preserve">
-    <value>tpWatchFolders</value>
-  </data>
-  <data name="&gt;&gt;tpWatchFolders.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpWatchFolders.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpWatchFolders.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
-    <value>pTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideToolsSettings.Name" xml:space="preserve">
-    <value>chkOverrideToolsSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideToolsSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideToolsSettings.Parent" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideToolsSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpTools.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="tpTools.Text" xml:space="preserve">
-    <value>Tools</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Name" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTools.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpTools.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;pgTaskSettings.Name" xml:space="preserve">
-    <value>pgTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;pgTaskSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PropertyGrid, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pgTaskSettings.Parent" xml:space="preserve">
-    <value>tpAdvanced</value>
-  </data>
-  <data name="&gt;&gt;pgTaskSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideAdvancedSettings.Name" xml:space="preserve">
-    <value>chkOverrideAdvancedSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideAdvancedSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideAdvancedSettings.Parent" xml:space="preserve">
-    <value>tpAdvanced</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideAdvancedSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpAdvanced.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpAdvanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 479</value>
-  </data>
-  <data name="tpAdvanced.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="tpAdvanced.Text" xml:space="preserve">
-    <value>Advanced</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Name" xml:space="preserve">
-    <value>tpAdvanced</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.Parent" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tpAdvanced.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tcTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Right</value>
-  </data>
-  <data name="tcTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>202, 3</value>
-  </data>
-  <data name="tcTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>579, 505</value>
-  </data>
-  <data name="tcTaskSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tcTaskSettings.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Name" xml:space="preserve">
-    <value>tcTaskSettings</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tcTaskSettings.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="cbOverrideCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 328</value>
   </data>
@@ -1956,6 +468,36 @@
   <metadata name="cmsDestinations.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>396, 17</value>
   </metadata>
+  <data name="tsmiImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiImageUploaders.Text" xml:space="preserve">
+    <value>Image uploaders</value>
+  </data>
+  <data name="tsmiTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiTextUploaders.Text" xml:space="preserve">
+    <value>Text uploaders</value>
+  </data>
+  <data name="tsmiFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiFileUploaders.Text" xml:space="preserve">
+    <value>File uploaders</value>
+  </data>
+  <data name="tsmiURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiURLShorteners.Text" xml:space="preserve">
+    <value>URL shorteners</value>
+  </data>
+  <data name="tsmiURLSharingServices.Size" type="System.Drawing.Size, System.Drawing">
+    <value>181, 22</value>
+  </data>
+  <data name="tsmiURLSharingServices.Text" xml:space="preserve">
+    <value>URL sharing services</value>
+  </data>
   <data name="cmsDestinations.Size" type="System.Drawing.Size, System.Drawing">
     <value>182, 114</value>
   </data>
@@ -1989,36 +531,6 @@
   <data name="&gt;&gt;btnDestinations.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="tsmiImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiImageUploaders.Text" xml:space="preserve">
-    <value>Image uploaders</value>
-  </data>
-  <data name="tsmiTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiTextUploaders.Text" xml:space="preserve">
-    <value>Text uploaders</value>
-  </data>
-  <data name="tsmiFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiFileUploaders.Text" xml:space="preserve">
-    <value>File uploaders</value>
-  </data>
-  <data name="tsmiURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiURLShorteners.Text" xml:space="preserve">
-    <value>URL shorteners</value>
-  </data>
-  <data name="tsmiURLSharingServices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
-  </data>
-  <data name="tsmiURLSharingServices.Text" xml:space="preserve">
-    <value>URL sharing services</value>
-  </data>
   <data name="btnTask.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -2049,76 +561,31 @@
   <data name="&gt;&gt;btnTask.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;lblAfterTaskNotification.Name" xml:space="preserve">
-    <value>lblAfterTaskNotification</value>
+  <data name="tpTask.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;lblAfterTaskNotification.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpTask.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;lblAfterTaskNotification.Parent" xml:space="preserve">
-    <value>pGeneral</value>
+  <data name="tpTask.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
   </data>
-  <data name="&gt;&gt;lblAfterTaskNotification.ZOrder" xml:space="preserve">
+  <data name="tpTask.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;cboPopUpNotification.Name" xml:space="preserve">
-    <value>cboPopUpNotification</value>
+  <data name="tpTask.Text" xml:space="preserve">
+    <value>Task</value>
   </data>
-  <data name="&gt;&gt;cboPopUpNotification.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpTask.Name" xml:space="preserve">
+    <value>tpTask</value>
   </data>
-  <data name="&gt;&gt;cboPopUpNotification.Parent" xml:space="preserve">
-    <value>pGeneral</value>
+  <data name="&gt;&gt;tpTask.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cboPopUpNotification.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpTask.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
   </data>
-  <data name="&gt;&gt;cbPlaySoundAfterUpload.Name" xml:space="preserve">
-    <value>cbPlaySoundAfterUpload</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterUpload.Parent" xml:space="preserve">
-    <value>pGeneral</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterUpload.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterCapture.Name" xml:space="preserve">
-    <value>cbPlaySoundAfterCapture</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterCapture.Parent" xml:space="preserve">
-    <value>pGeneral</value>
-  </data>
-  <data name="&gt;&gt;cbPlaySoundAfterCapture.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="pGeneral.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
-    <value>pGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpTask.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="lblAfterTaskNotification.AutoSize" type="System.Boolean, mscorlib">
@@ -2232,6 +699,30 @@
   <data name="&gt;&gt;cbPlaySoundAfterCapture.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="pGeneral.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Name" xml:space="preserve">
+    <value>pGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;pGeneral.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkOverrideGeneralSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2268,302 +759,29 @@
   <data name="&gt;&gt;chkOverrideGeneralSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tcImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 473</value>
-  </data>
-  <data name="tcImage.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
-    <value>tpImage</value>
-  </data>
-  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideImageSettings.Name" xml:space="preserve">
-    <value>chkOverrideImageSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideImageSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideImageSettings.Parent" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideImageSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpQuality.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 447</value>
+  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
   </data>
-  <data name="tpQuality.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
-    <value>tcImage</value>
-  </data>
-  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbImagePNGBitDepth.Name" xml:space="preserve">
-    <value>cbImagePNGBitDepth</value>
-  </data>
-  <data name="&gt;&gt;cbImagePNGBitDepth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImagePNGBitDepth.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;cbImagePNGBitDepth.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblImagePNGBitDepth.Name" xml:space="preserve">
-    <value>lblImagePNGBitDepth</value>
-  </data>
-  <data name="&gt;&gt;lblImagePNGBitDepth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImagePNGBitDepth.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImagePNGBitDepth.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbImageAutoUseJPEG.Name" xml:space="preserve">
-    <value>cbImageAutoUseJPEG</value>
-  </data>
-  <data name="&gt;&gt;cbImageAutoUseJPEG.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageAutoUseJPEG.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;cbImageAutoUseJPEG.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblImageFormat.Name" xml:space="preserve">
-    <value>lblImageFormat</value>
-  </data>
-  <data name="&gt;&gt;lblImageFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageFormat.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageFormat.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;cbImageFileExist.Name" xml:space="preserve">
-    <value>cbImageFileExist</value>
-  </data>
-  <data name="&gt;&gt;cbImageFileExist.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageFileExist.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;cbImageFileExist.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblImageFileExist.Name" xml:space="preserve">
-    <value>lblImageFileExist</value>
-  </data>
-  <data name="&gt;&gt;lblImageFileExist.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageFileExist.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageFileExist.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Name" xml:space="preserve">
-    <value>nudImageAutoUseJPEGSize</value>
-  </data>
-  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudImageAutoUseJPEGSize.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;nudImageAutoUseJPEGSize.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblImageSizeLimitHint.Name" xml:space="preserve">
-    <value>lblImageSizeLimitHint</value>
-  </data>
-  <data name="&gt;&gt;lblImageSizeLimitHint.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageSizeLimitHint.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageSizeLimitHint.ZOrder" xml:space="preserve">
+  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;nudImageJPEGQuality.Name" xml:space="preserve">
-    <value>nudImageJPEGQuality</value>
+  <data name="tpGeneral.Text" xml:space="preserve">
+    <value>General</value>
   </data>
-  <data name="&gt;&gt;nudImageJPEGQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
+    <value>tpGeneral</value>
   </data>
-  <data name="&gt;&gt;nudImageJPEGQuality.Parent" xml:space="preserve">
-    <value>pImage</value>
+  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;nudImageJPEGQuality.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
   </data>
-  <data name="&gt;&gt;cbImageFormat.Name" xml:space="preserve">
-    <value>cbImageFormat</value>
-  </data>
-  <data name="&gt;&gt;cbImageFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageFormat.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;cbImageFormat.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQualityHint.Name" xml:space="preserve">
-    <value>lblImageJPEGQualityHint</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQualityHint.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQualityHint.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQualityHint.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblImageGIFQuality.Name" xml:space="preserve">
-    <value>lblImageGIFQuality</value>
-  </data>
-  <data name="&gt;&gt;lblImageGIFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageGIFQuality.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageGIFQuality.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQuality.Name" xml:space="preserve">
-    <value>lblImageJPEGQuality</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQuality.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;lblImageJPEGQuality.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cbImageGIFQuality.Name" xml:space="preserve">
-    <value>cbImageGIFQuality</value>
-  </data>
-  <data name="&gt;&gt;cbImageGIFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageGIFQuality.Parent" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;cbImageGIFQuality.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="pImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 422</value>
-  </data>
-  <data name="pImage.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
-    <value>pImage</value>
-  </data>
-  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
-    <value>tpQuality</value>
-  </data>
-  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="cbImagePNGBitDepth.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 72</value>
@@ -2931,6 +1149,30 @@
   <data name="&gt;&gt;cbImageGIFQuality.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
+  <data name="pImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 422</value>
+  </data>
+  <data name="pImage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pImage.Name" xml:space="preserve">
+    <value>pImage</value>
+  </data>
+  <data name="&gt;&gt;pImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pImage.Parent" xml:space="preserve">
+    <value>tpQuality</value>
+  </data>
+  <data name="&gt;&gt;pImage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkOverrideImageSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2967,80 +1209,26 @@
   <data name="&gt;&gt;chkOverrideImageSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;lblImageEffectsNote.Name" xml:space="preserve">
-    <value>lblImageEffectsNote</value>
-  </data>
-  <data name="&gt;&gt;lblImageEffectsNote.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblImageEffectsNote.Parent" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;lblImageEffectsNote.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Name" xml:space="preserve">
-    <value>chkShowImageEffectsWindowAfterCapture</value>
-  </data>
-  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.Parent" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;chkShowImageEffectsWindowAfterCapture.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Name" xml:space="preserve">
-    <value>cbImageEffectOnlyRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.Parent" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;cbImageEffectOnlyRegionCapture.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnImageEffects.Name" xml:space="preserve">
-    <value>btnImageEffects</value>
-  </data>
-  <data name="&gt;&gt;btnImageEffects.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnImageEffects.Parent" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;btnImageEffects.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpEffects.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpQuality.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpEffects.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpEffects.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpQuality.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpEffects.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpEffects.Text" xml:space="preserve">
-    <value>Effects</value>
+  <data name="&gt;&gt;tpQuality.Name" xml:space="preserve">
+    <value>tpQuality</value>
   </data>
-  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
-    <value>tpEffects</value>
-  </data>
-  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpQuality.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpQuality.Parent" xml:space="preserve">
     <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpQuality.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblImageEffectsNote.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3159,128 +1347,32 @@
   <data name="&gt;&gt;btnImageEffects.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;cbThumbnailIfSmaller.Name" xml:space="preserve">
-    <value>cbThumbnailIfSmaller</value>
-  </data>
-  <data name="&gt;&gt;cbThumbnailIfSmaller.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbThumbnailIfSmaller.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;cbThumbnailIfSmaller.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailNamePreview.Name" xml:space="preserve">
-    <value>lblThumbnailNamePreview</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailNamePreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailNamePreview.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailNamePreview.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailName.Name" xml:space="preserve">
-    <value>lblThumbnailName</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailName.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailName.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;txtThumbnailName.Name" xml:space="preserve">
-    <value>txtThumbnailName</value>
-  </data>
-  <data name="&gt;&gt;txtThumbnailName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtThumbnailName.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;txtThumbnailName.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailHeight.Name" xml:space="preserve">
-    <value>lblThumbnailHeight</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailHeight.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailHeight.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailWidth.Name" xml:space="preserve">
-    <value>lblThumbnailWidth</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailWidth.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;lblThumbnailWidth.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailHeight.Name" xml:space="preserve">
-    <value>nudThumbnailHeight</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailHeight.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailHeight.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailWidth.Name" xml:space="preserve">
-    <value>nudThumbnailWidth</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailWidth.Parent" xml:space="preserve">
-    <value>tpThumbnail</value>
-  </data>
-  <data name="&gt;&gt;nudThumbnailWidth.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpThumbnail.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpEffects.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpThumbnail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpEffects.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpThumbnail.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpEffects.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpThumbnail.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpEffects.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpThumbnail.Text" xml:space="preserve">
-    <value>Thumbnail</value>
+  <data name="tpEffects.Text" xml:space="preserve">
+    <value>Effects</value>
   </data>
-  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
-    <value>tpThumbnail</value>
+  <data name="&gt;&gt;tpEffects.Name" xml:space="preserve">
+    <value>tpEffects</value>
   </data>
-  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpEffects.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpEffects.Parent" xml:space="preserve">
     <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpEffects.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="cbThumbnailIfSmaller.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3501,269 +1593,83 @@
   <data name="&gt;&gt;nudThumbnailWidth.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Name" xml:space="preserve">
-    <value>btnCaptureCustomRegionSelectRectangle</value>
+  <data name="tpThumbnail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpThumbnail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.Parent" xml:space="preserve">
-    <value>pCapture</value>
+  <data name="tpThumbnail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
   </data>
-  <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegion.Name" xml:space="preserve">
-    <value>lblCaptureCustomRegion</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegion.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegion.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Name" xml:space="preserve">
-    <value>lblCaptureCustomRegionWidth</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionWidth.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Name" xml:space="preserve">
-    <value>lblCaptureCustomRegionHeight</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionHeight.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
+  <data name="tpThumbnail.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionY.Name" xml:space="preserve">
-    <value>lblCaptureCustomRegionY</value>
+  <data name="tpThumbnail.Text" xml:space="preserve">
+    <value>Thumbnail</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpThumbnail.Name" xml:space="preserve">
+    <value>tpThumbnail</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionY.Parent" xml:space="preserve">
-    <value>pCapture</value>
+  <data name="&gt;&gt;tpThumbnail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionY.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpThumbnail.Parent" xml:space="preserve">
+    <value>tcImage</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionX.Name" xml:space="preserve">
-    <value>lblCaptureCustomRegionX</value>
+  <data name="&gt;&gt;tpThumbnail.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionX.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureCustomRegionX.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Name" xml:space="preserve">
-    <value>nudCaptureCustomRegionHeight</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionHeight.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Name" xml:space="preserve">
-    <value>nudCaptureCustomRegionWidth</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionWidth.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionY.Name" xml:space="preserve">
-    <value>nudCaptureCustomRegionY</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionY.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionY.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionY.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionX.Name" xml:space="preserve">
-    <value>nudCaptureCustomRegionX</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionX.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureCustomRegionX.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cbShowCursor.Name" xml:space="preserve">
-    <value>cbShowCursor</value>
-  </data>
-  <data name="&gt;&gt;cbShowCursor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbShowCursor.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbShowCursor.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureShadowOffset.Name" xml:space="preserve">
-    <value>lblCaptureShadowOffset</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureShadowOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureShadowOffset.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblCaptureShadowOffset.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureTransparent.Name" xml:space="preserve">
-    <value>cbCaptureTransparent</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureTransparent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureTransparent.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureTransparent.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Name" xml:space="preserve">
-    <value>cbCaptureAutoHideTaskbar</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureAutoHideTaskbar.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureShadow.Name" xml:space="preserve">
-    <value>cbCaptureShadow</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureShadow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureShadow.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureShadow.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;lblScreenshotDelayInfo.Name" xml:space="preserve">
-    <value>lblScreenshotDelayInfo</value>
-  </data>
-  <data name="&gt;&gt;lblScreenshotDelayInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblScreenshotDelayInfo.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;lblScreenshotDelayInfo.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureClientArea.Name" xml:space="preserve">
-    <value>cbCaptureClientArea</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureClientArea.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureClientArea.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbCaptureClientArea.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;nudScreenshotDelay.Name" xml:space="preserve">
-    <value>nudScreenshotDelay</value>
-  </data>
-  <data name="&gt;&gt;nudScreenshotDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudScreenshotDelay.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudScreenshotDelay.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureShadowOffset.Name" xml:space="preserve">
-    <value>nudCaptureShadowOffset</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureShadowOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureShadowOffset.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;nudCaptureShadowOffset.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;cbScreenshotDelay.Name" xml:space="preserve">
-    <value>cbScreenshotDelay</value>
-  </data>
-  <data name="&gt;&gt;cbScreenshotDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbScreenshotDelay.Parent" xml:space="preserve">
-    <value>pCapture</value>
-  </data>
-  <data name="&gt;&gt;cbScreenshotDelay.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="pCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="tcImage.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="pCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+  <data name="tcImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="pCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 422</value>
+  <data name="tcImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 473</value>
   </data>
-  <data name="pCapture.TabIndex" type="System.Int32, mscorlib">
+  <data name="tcImage.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Name" xml:space="preserve">
+    <value>tcImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcImage.Parent" xml:space="preserve">
+    <value>tpImage</value>
+  </data>
+  <data name="&gt;&gt;tcImage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpImage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpImage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpImage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpImage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
-    <value>pCapture</value>
+  <data name="tpImage.Text" xml:space="preserve">
+    <value>Image</value>
   </data>
-  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpImage.Name" xml:space="preserve">
+    <value>tpImage</value>
   </data>
-  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
-    <value>tpCaptureGeneral</value>
+  <data name="&gt;&gt;tpImage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpImage.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpImage.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.Location" type="System.Drawing.Point, System.Drawing">
     <value>232, 263</value>
@@ -4308,6 +2214,30 @@
   <data name="&gt;&gt;cbScreenshotDelay.ZOrder" xml:space="preserve">
     <value>19</value>
   </data>
+  <data name="pCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 422</value>
+  </data>
+  <data name="pCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Name" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pCapture.Parent" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;pCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkOverrideCaptureSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -4344,6 +2274,27 @@
   <data name="&gt;&gt;chkOverrideCaptureSettings.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="tpCaptureGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCaptureGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpCaptureGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Name" xml:space="preserve">
+    <value>tpCaptureGeneral</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpCaptureGeneral.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbRegionCaptureShowFPS.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -4376,78 +2327,6 @@
   </data>
   <data name="flpRegionCaptureFixedSize.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Name" xml:space="preserve">
-    <value>lblRegionCaptureFixedSizeWidth</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.Parent" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeWidth.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Name" xml:space="preserve">
-    <value>nudRegionCaptureFixedSizeWidth</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.Parent" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeWidth.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Name" xml:space="preserve">
-    <value>lblRegionCaptureFixedSizeHeight</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.Parent" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Name" xml:space="preserve">
-    <value>nudRegionCaptureFixedSizeHeight</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.Parent" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 387</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 26</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="flpRegionCaptureFixedSize.WrapContents" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
-    <value>flpRegionCaptureFixedSize</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="lblRegionCaptureFixedSizeWidth.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -4562,6 +2441,30 @@
   </data>
   <data name="&gt;&gt;nudRegionCaptureFixedSizeHeight.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>312, 387</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>222, 26</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.WrapContents" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Name" xml:space="preserve">
+    <value>flpRegionCaptureFixedSize</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;flpRegionCaptureFixedSize.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="cbRegionCaptureIsFixedSize.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5160,102 +3063,6 @@
   <data name="&gt;&gt;cbRegionCaptureMultiRegionMode.ZOrder" xml:space="preserve">
     <value>24</value>
   </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Name" xml:space="preserve">
-    <value>btnRegionCaptureSnapSizesDialogCancel</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogCancel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Name" xml:space="preserve">
-    <value>btnRegionCaptureSnapSizesDialogAdd</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;btnRegionCaptureSnapSizesDialogAdd.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Name" xml:space="preserve">
-    <value>nudRegionCaptureSnapSizesHeight</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesHeight.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Name" xml:space="preserve">
-    <value>RegionCaptureSnapSizesHeight</value>
-  </data>
-  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;RegionCaptureSnapSizesHeight.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Name" xml:space="preserve">
-    <value>nudRegionCaptureSnapSizesWidth</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;nudRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Name" xml:space="preserve">
-    <value>lblRegionCaptureSnapSizesWidth</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.Parent" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 208</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 112</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="pRegionCaptureSnapSizes.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
-    <value>pRegionCaptureSnapSizes</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
-    <value>tpRegionCapture</value>
-  </data>
-  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
   <data name="btnRegionCaptureSnapSizesDialogCancel.Location" type="System.Drawing.Point, System.Drawing">
     <value>120, 80</value>
   </data>
@@ -5409,6 +3216,30 @@
   <data name="&gt;&gt;lblRegionCaptureSnapSizesWidth.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="pRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 208</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 112</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Name" xml:space="preserve">
+    <value>pRegionCaptureSnapSizes</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.Parent" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;pRegionCaptureSnapSizes.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
   <data name="cbRegionCaptureUseDimming.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -5505,110 +3336,578 @@
   <data name="&gt;&gt;nudRegionCaptureMagnifierPixelSize.ZOrder" xml:space="preserve">
     <value>29</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
-    <value>tpUploadMain</value>
-  </data>
-  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
-    <value>tpUploadClipboard</value>
-  </data>
-  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tcUpload.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 473</value>
-  </data>
-  <data name="tcUpload.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
-    <value>tcUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
-    <value>tpUpload</value>
-  </data>
-  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideUploadSettings.Name" xml:space="preserve">
-    <value>chkOverrideUploadSettings</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideUploadSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideUploadSettings.Parent" xml:space="preserve">
-    <value>tpUploadMain</value>
-  </data>
-  <data name="&gt;&gt;chkOverrideUploadSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tpUploadMain.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUploadMain.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpRegionCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpUploadMain.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="tpRegionCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
-    <value>tpUploadMain</value>
+  <data name="tpRegionCapture.Text" xml:space="preserve">
+    <value>Region capture</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpRegionCapture.Name" xml:space="preserve">
+    <value>tpRegionCapture</value>
+  </data>
+  <data name="&gt;&gt;tpRegionCapture.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
-    <value>tcUpload</value>
+  <data name="&gt;&gt;tpRegionCapture.Parent" xml:space="preserve">
+    <value>tcCapture</value>
   </data>
-  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tpRegionCapture.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 160</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Size" type="System.Drawing.Size, System.Drawing">
+    <value>332, 17</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Text" xml:space="preserve">
+    <value>Record using lossless encoding, then apply user encoding option</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Name" xml:space="preserve">
+    <value>cbScreenRecordTwoPassEncoding</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordTwoPassEncoding.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 207</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 17</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Text" xml:space="preserve">
+    <value>Ask for confirmation when aborting</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Name" xml:space="preserve">
+    <value>cbScreenRecordConfirmAbort</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordConfirmAbort.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 88</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 17</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Text" xml:space="preserve">
+    <value>Show cursor in recording</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Name" xml:space="preserve">
+    <value>cbScreenRecorderShowCursor</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderShowCursor.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 24</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Text" xml:space="preserve">
+    <value>Screen recording options...</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Name" xml:space="preserve">
+    <value>btnScreenRecorderFFmpegOptions</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecorderFFmpegOptions.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 114</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 13</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Text" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Name" xml:space="preserve">
+    <value>lblScreenRecorderStartDelay</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderStartDelay.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 112</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 17</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="chkScreenRecordAutoStart.Text" xml:space="preserve">
+    <value>Start recording after:</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Name" xml:space="preserve">
+    <value>chkScreenRecordAutoStart</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;chkScreenRecordAutoStart.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>304, 138</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 13</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Text" xml:space="preserve">
+    <value>seconds</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Name" xml:space="preserve">
+    <value>lblScreenRecorderFixedDuration</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="nudScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 36</value>
+  </data>
+  <data name="nudScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="nudScreenRecordFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Name" xml:space="preserve">
+    <value>nudScreenRecordFPS</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecordFPS.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblScreenRecordFPS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScreenRecordFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="lblScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 13</value>
+  </data>
+  <data name="lblScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="lblScreenRecordFPS.Text" xml:space="preserve">
+    <value>Screen recording FPS:</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Name" xml:space="preserve">
+    <value>lblScreenRecordFPS</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblScreenRecordFPS.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 184</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 17</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="cbScreenRecordRunScreencastCLI.Text" xml:space="preserve">
+    <value>Run CLI afterwards:</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Name" xml:space="preserve">
+    <value>cbScreenRecordRunScreencastCLI</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordRunScreencastCLI.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Location" type="System.Drawing.Point, System.Drawing">
+    <value>458, 181</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 23</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="btnScreenRecordEncoderConfig.Text" xml:space="preserve">
+    <value>Profiles...</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Name" xml:space="preserve">
+    <value>btnScreenRecordEncoderConfig</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;btnScreenRecordEncoderConfig.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="cbScreenRecordEncoder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 182</value>
+  </data>
+  <data name="cbScreenRecordEncoder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 21</value>
+  </data>
+  <data name="cbScreenRecordEncoder.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Name" xml:space="preserve">
+    <value>cbScreenRecordEncoder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecordEncoder.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="nudScreenRecorderDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 134</value>
+  </data>
+  <data name="nudScreenRecorderDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecorderDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="nudScreenRecorderDuration.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Name" xml:space="preserve">
+    <value>nudScreenRecorderDuration</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderDuration.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 110</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Name" xml:space="preserve">
+    <value>nudScreenRecorderStartDelay</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudScreenRecorderStartDelay.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 136</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 17</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Text" xml:space="preserve">
+    <value>Fixed duration:</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Name" xml:space="preserve">
+    <value>cbScreenRecorderFixedDuration</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;cbScreenRecorderFixedDuration.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="nudGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>232, 60</value>
+  </data>
+  <data name="nudGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudGIFFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="nudGIFFPS.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Name" xml:space="preserve">
+    <value>nudGIFFPS</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;nudGIFFPS.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="lblGIFFPS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGIFFPS.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 64</value>
+  </data>
+  <data name="lblGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="lblGIFFPS.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblGIFFPS.Text" xml:space="preserve">
+    <value>GIF FPS:</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Name" xml:space="preserve">
+    <value>lblGIFFPS</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.Parent" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;lblGIFFPS.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="tpScreenRecorder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpScreenRecorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpScreenRecorder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpScreenRecorder.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpScreenRecorder.Text" xml:space="preserve">
+    <value>Screen recorder</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Name" xml:space="preserve">
+    <value>tpScreenRecorder</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tcCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 473</value>
+  </data>
+  <data name="tcCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Name" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.Parent" xml:space="preserve">
+    <value>tpCapture</value>
+  </data>
+  <data name="&gt;&gt;tcCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpCapture.Text" xml:space="preserve">
+    <value>Capture</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Name" xml:space="preserve">
+    <value>tpCapture</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpCapture.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="chkOverrideUploadSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5646,188 +3945,26 @@
   <data name="&gt;&gt;chkOverrideUploadSettings.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Name" xml:space="preserve">
-    <value>cbFileUploadReplaceProblematicCharacters</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadReplaceProblematicCharacters.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblAutoIncrementNumber.Name" xml:space="preserve">
-    <value>lblAutoIncrementNumber</value>
-  </data>
-  <data name="&gt;&gt;lblAutoIncrementNumber.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAutoIncrementNumber.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;lblAutoIncrementNumber.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Name" xml:space="preserve">
-    <value>cbRegionCaptureUseWindowPattern</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;cbRegionCaptureUseWindowPattern.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Name" xml:space="preserve">
-    <value>cbNameFormatCustomTimeZone</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatCustomTimeZone.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatCustomTimeZone.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreview.Name" xml:space="preserve">
-    <value>lblNameFormatPatternPreview</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreview.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreview.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Name" xml:space="preserve">
-    <value>lblNameFormatPatternActiveWindow</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternActiveWindow.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Name" xml:space="preserve">
-    <value>lblNameFormatPatternPreviewActiveWindow</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPatternPreviewActiveWindow.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatTimeZone.Name" xml:space="preserve">
-    <value>cbNameFormatTimeZone</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatTimeZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatTimeZone.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;cbNameFormatTimeZone.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Name" xml:space="preserve">
-    <value>txtNameFormatPatternActiveWindow</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPatternActiveWindow.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;btnResetAutoIncrementNumber.Name" xml:space="preserve">
-    <value>btnResetAutoIncrementNumber</value>
-  </data>
-  <data name="&gt;&gt;btnResetAutoIncrementNumber.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnResetAutoIncrementNumber.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;btnResetAutoIncrementNumber.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadUseNamePattern.Name" xml:space="preserve">
-    <value>cbFileUploadUseNamePattern</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadUseNamePattern.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadUseNamePattern.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;cbFileUploadUseNamePattern.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPattern.Name" xml:space="preserve">
-    <value>lblNameFormatPattern</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPattern.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPattern.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;lblNameFormatPattern.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPattern.Name" xml:space="preserve">
-    <value>txtNameFormatPattern</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPattern.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPattern.Parent" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;txtNameFormatPattern.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="tpFileNaming.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpUploadMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpFileNaming.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpFileNaming.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpUploadMain.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpFileNaming.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpUploadMain.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="tpFileNaming.Text" xml:space="preserve">
-    <value>File naming</value>
+  <data name="&gt;&gt;tpUploadMain.Name" xml:space="preserve">
+    <value>tpUploadMain</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
-    <value>tpFileNaming</value>
-  </data>
-  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadMain.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadMain.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpUploadMain.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6180,80 +4317,32 @@
   <data name="&gt;&gt;txtNameFormatPattern.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="&gt;&gt;cbClipboardUploadShareURL.Name" xml:space="preserve">
-    <value>cbClipboardUploadShareURL</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShareURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShareURL.Parent" xml:space="preserve">
-    <value>tpUploadClipboard</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShareURL.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkClipboardUploadURLContents.Name" xml:space="preserve">
-    <value>chkClipboardUploadURLContents</value>
-  </data>
-  <data name="&gt;&gt;chkClipboardUploadURLContents.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkClipboardUploadURLContents.Parent" xml:space="preserve">
-    <value>tpUploadClipboard</value>
-  </data>
-  <data name="&gt;&gt;chkClipboardUploadURLContents.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Name" xml:space="preserve">
-    <value>cbClipboardUploadAutoIndexFolder</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.Parent" xml:space="preserve">
-    <value>tpUploadClipboard</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadAutoIndexFolder.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShortenURL.Name" xml:space="preserve">
-    <value>cbClipboardUploadShortenURL</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShortenURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShortenURL.Parent" xml:space="preserve">
-    <value>tpUploadClipboard</value>
-  </data>
-  <data name="&gt;&gt;cbClipboardUploadShortenURL.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tpUploadClipboard.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpFileNaming.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUploadClipboard.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpFileNaming.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpUploadClipboard.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpFileNaming.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpUploadClipboard.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="tpFileNaming.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="tpUploadClipboard.Text" xml:space="preserve">
-    <value>Clipboard upload</value>
+  <data name="tpFileNaming.Text" xml:space="preserve">
+    <value>File naming</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
-    <value>tpUploadClipboard</value>
+  <data name="&gt;&gt;tpFileNaming.Name" xml:space="preserve">
+    <value>tpFileNaming</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpFileNaming.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;tpFileNaming.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="cbClipboardUploadShareURL.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6375,143 +4464,47 @@
   <data name="&gt;&gt;cbClipboardUploadShortenURL.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;lvUploaderFiltersList.Name" xml:space="preserve">
-    <value>lvUploaderFiltersList</value>
-  </data>
-  <data name="&gt;&gt;lvUploaderFiltersList.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvUploaderFiltersList.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;lvUploaderFiltersList.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersRemove.Name" xml:space="preserve">
-    <value>btnUploaderFiltersRemove</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersRemove.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersRemove.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersUpdate.Name" xml:space="preserve">
-    <value>btnUploaderFiltersUpdate</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersUpdate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersUpdate.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersUpdate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersAdd.Name" xml:space="preserve">
-    <value>btnUploaderFiltersAdd</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersAdd.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;btnUploaderFiltersAdd.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersDestination.Name" xml:space="preserve">
-    <value>lblUploaderFiltersDestination</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersDestination.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersDestination.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersDestination.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbUploaderFiltersDestination.Name" xml:space="preserve">
-    <value>cbUploaderFiltersDestination</value>
-  </data>
-  <data name="&gt;&gt;cbUploaderFiltersDestination.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbUploaderFiltersDestination.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;cbUploaderFiltersDestination.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Name" xml:space="preserve">
-    <value>lblUploaderFiltersExtensionsExample</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensionsExample.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensions.Name" xml:space="preserve">
-    <value>lblUploaderFiltersExtensions</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensions.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;lblUploaderFiltersExtensions.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;txtUploaderFiltersExtensions.Name" xml:space="preserve">
-    <value>txtUploaderFiltersExtensions</value>
-  </data>
-  <data name="&gt;&gt;txtUploaderFiltersExtensions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUploaderFiltersExtensions.Parent" xml:space="preserve">
-    <value>tpUploaderFilters</value>
-  </data>
-  <data name="&gt;&gt;txtUploaderFiltersExtensions.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="tpUploaderFilters.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpUploadClipboard.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="tpUploaderFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpUploadClipboard.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpUploaderFilters.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpUploadClipboard.Size" type="System.Drawing.Size, System.Drawing">
     <value>557, 447</value>
   </data>
-  <data name="tpUploaderFilters.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="tpUploadClipboard.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpUploaderFilters.Text" xml:space="preserve">
-    <value>Uploader filters</value>
+  <data name="tpUploadClipboard.Text" xml:space="preserve">
+    <value>Clipboard upload</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
-    <value>tpUploaderFilters</value>
+  <data name="&gt;&gt;tpUploadClipboard.Name" xml:space="preserve">
+    <value>tpUploadClipboard</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadClipboard.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpUploadClipboard.Parent" xml:space="preserve">
     <value>tcUpload</value>
   </data>
-  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tpUploadClipboard.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="lvUploaderFiltersList.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="chUploaderFiltersName.Text" xml:space="preserve">
+    <value>Uploader</value>
+  </data>
+  <data name="chUploaderFiltersName.Width" type="System.Int32, mscorlib">
+    <value>128</value>
+  </data>
+  <data name="chUploaderFiltersExtension.Text" xml:space="preserve">
+    <value>Extension</value>
+  </data>
+  <data name="chUploaderFiltersExtension.Width" type="System.Int32, mscorlib">
+    <value>98</value>
   </data>
   <data name="lvUploaderFiltersList.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 136</value>
@@ -6533,18 +4526,6 @@
   </data>
   <data name="&gt;&gt;lvUploaderFiltersList.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="chUploaderFiltersName.Text" xml:space="preserve">
-    <value>Uploader</value>
-  </data>
-  <data name="chUploaderFiltersName.Width" type="System.Int32, mscorlib">
-    <value>128</value>
-  </data>
-  <data name="chUploaderFiltersExtension.Text" xml:space="preserve">
-    <value>Extension</value>
-  </data>
-  <data name="chUploaderFiltersExtension.Width" type="System.Int32, mscorlib">
-    <value>98</value>
   </data>
   <data name="btnUploaderFiltersRemove.Location" type="System.Drawing.Point, System.Drawing">
     <value>280, 104</value>
@@ -6741,92 +4722,83 @@
   <data name="&gt;&gt;txtUploaderFiltersExtensions.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;btnActionsDuplicate.Name" xml:space="preserve">
-    <value>btnActionsDuplicate</value>
+  <data name="tpUploaderFilters.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;btnActionsDuplicate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpUploaderFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;btnActionsDuplicate.Parent" xml:space="preserve">
-    <value>pActions</value>
+  <data name="tpUploaderFilters.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
   </data>
-  <data name="&gt;&gt;btnActionsDuplicate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnActionsAdd.Name" xml:space="preserve">
-    <value>btnActionsAdd</value>
-  </data>
-  <data name="&gt;&gt;btnActionsAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnActionsAdd.Parent" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;btnActionsAdd.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
-    <value>lvActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnActionsEdit.Name" xml:space="preserve">
-    <value>btnActionsEdit</value>
-  </data>
-  <data name="&gt;&gt;btnActionsEdit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnActionsEdit.Parent" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;btnActionsEdit.ZOrder" xml:space="preserve">
+  <data name="tpUploaderFilters.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;btnActionsRemove.Name" xml:space="preserve">
-    <value>btnActionsRemove</value>
+  <data name="tpUploaderFilters.Text" xml:space="preserve">
+    <value>Uploader filters</value>
   </data>
-  <data name="&gt;&gt;btnActionsRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpUploaderFilters.Name" xml:space="preserve">
+    <value>tpUploaderFilters</value>
   </data>
-  <data name="&gt;&gt;btnActionsRemove.Parent" xml:space="preserve">
-    <value>pActions</value>
+  <data name="&gt;&gt;tpUploaderFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnActionsRemove.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpUploaderFilters.Parent" xml:space="preserve">
+    <value>tcUpload</value>
   </data>
-  <data name="pActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="&gt;&gt;tpUploaderFilters.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tcUpload.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="pActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+  <data name="tcUpload.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="pActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="tcUpload.Size" type="System.Drawing.Size, System.Drawing">
+    <value>565, 473</value>
   </data>
-  <data name="pActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pActions.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
-    <value>tpActions</value>
-  </data>
-  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
+  <data name="tcUpload.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Name" xml:space="preserve">
+    <value>tcUpload</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.Parent" xml:space="preserve">
+    <value>tpUpload</value>
+  </data>
+  <data name="&gt;&gt;tcUpload.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tpUpload.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpUpload.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpUpload.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpUpload.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="tpUpload.Text" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Name" xml:space="preserve">
+    <value>tpUpload</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpUpload.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="btnActionsDuplicate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6885,27 +4857,6 @@
   <data name="lvActions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="lvActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 40</value>
-  </data>
-  <data name="lvActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>558, 407</value>
-  </data>
-  <data name="lvActions.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
-    <value>lvActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
-    <value>pActions</value>
-  </data>
-  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="chActionsName.Text" xml:space="preserve">
     <value>Name</value>
   </data>
@@ -6929,6 +4880,27 @@
   </data>
   <data name="chActionsExtensions.Width" type="System.Int32, mscorlib">
     <value>75</value>
+  </data>
+  <data name="lvActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="lvActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>558, 407</value>
+  </data>
+  <data name="lvActions.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Name" xml:space="preserve">
+    <value>lvActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvActions.Parent" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;lvActions.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="btnActionsEdit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6984,6 +4956,33 @@
   <data name="&gt;&gt;btnActionsRemove.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="pActions.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="pActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pActions.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pActions.Name" xml:space="preserve">
+    <value>pActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pActions.Parent" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;pActions.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkOverrideActions.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -7019,6 +5018,30 @@
   </data>
   <data name="&gt;&gt;chkOverrideActions.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="tpActions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpActions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpActions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpActions.Text" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Name" xml:space="preserve">
+    <value>tpActions</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpActions.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpActions.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="btnWatchFolderEdit.Location" type="System.Drawing.Point, System.Drawing">
     <value>104, 32</value>
@@ -7077,6 +5100,24 @@
   <data name="lvWatchFolderList.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="chWatchFolderFolderPath.Text" xml:space="preserve">
+    <value>Folder path</value>
+  </data>
+  <data name="chWatchFolderFolderPath.Width" type="System.Int32, mscorlib">
+    <value>323</value>
+  </data>
+  <data name="chWatchFolderFilter.Text" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="chWatchFolderFilter.Width" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <data name="chWatchFolderIncludeSubdirectories.Text" xml:space="preserve">
+    <value>Include subdirectories</value>
+  </data>
+  <data name="chWatchFolderIncludeSubdirectories.Width" type="System.Int32, mscorlib">
+    <value>124</value>
+  </data>
   <data name="lvWatchFolderList.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 64</value>
   </data>
@@ -7097,24 +5138,6 @@
   </data>
   <data name="&gt;&gt;lvWatchFolderList.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="chWatchFolderFolderPath.Text" xml:space="preserve">
-    <value>Folder path</value>
-  </data>
-  <data name="chWatchFolderFolderPath.Width" type="System.Int32, mscorlib">
-    <value>323</value>
-  </data>
-  <data name="chWatchFolderFilter.Text" xml:space="preserve">
-    <value>Filter</value>
-  </data>
-  <data name="chWatchFolderFilter.Width" type="System.Int32, mscorlib">
-    <value>43</value>
-  </data>
-  <data name="chWatchFolderIncludeSubdirectories.Text" xml:space="preserve">
-    <value>Include subdirectories</value>
-  </data>
-  <data name="chWatchFolderIncludeSubdirectories.Width" type="System.Int32, mscorlib">
-    <value>124</value>
   </data>
   <data name="btnWatchFolderRemove.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -7170,53 +5193,32 @@
   <data name="&gt;&gt;btnWatchFolderAdd.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Name" xml:space="preserve">
-    <value>txtToolsScreenColorPickerFormat</value>
+  <data name="tpWatchFolders.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tpWatchFolders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
-  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.Parent" xml:space="preserve">
-    <value>pTools</value>
+  <data name="tpWatchFolders.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
   </data>
-  <data name="&gt;&gt;txtToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="tpWatchFolders.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Name" xml:space="preserve">
-    <value>lblToolsScreenColorPickerFormat</value>
+  <data name="tpWatchFolders.Text" xml:space="preserve">
+    <value>Watch folders</value>
   </data>
-  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tpWatchFolders.Name" xml:space="preserve">
+    <value>tpWatchFolders</value>
   </data>
-  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.Parent" xml:space="preserve">
-    <value>pTools</value>
+  <data name="&gt;&gt;tpWatchFolders.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpWatchFolders.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
   </data>
-  <data name="pTools.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="pTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
-  </data>
-  <data name="pTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 454</value>
-  </data>
-  <data name="pTools.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
-    <value>pTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
-    <value>tpTools</value>
-  </data>
-  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;tpWatchFolders.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="txtToolsScreenColorPickerFormat.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 24</value>
@@ -7266,6 +5268,30 @@
   <data name="&gt;&gt;lblToolsScreenColorPickerFormat.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="pTools.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pTools.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 25</value>
+  </data>
+  <data name="pTools.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 454</value>
+  </data>
+  <data name="pTools.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pTools.Name" xml:space="preserve">
+    <value>pTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pTools.Parent" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;pTools.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkOverrideToolsSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -7301,6 +5327,30 @@
   </data>
   <data name="&gt;&gt;chkOverrideToolsSettings.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="tpTools.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTools.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpTools.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tpTools.Text" xml:space="preserve">
+    <value>Tools</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Name" xml:space="preserve">
+    <value>tpTools</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTools.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpTools.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="pgTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -7361,6 +5411,60 @@
   </data>
   <data name="&gt;&gt;chkOverrideAdvancedSettings.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="tpAdvanced.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpAdvanced.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpAdvanced.Size" type="System.Drawing.Size, System.Drawing">
+    <value>571, 479</value>
+  </data>
+  <data name="tpAdvanced.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="tpAdvanced.Text" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Name" xml:space="preserve">
+    <value>tpAdvanced</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.Parent" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tpAdvanced.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="tcTaskSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="tcTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>202, 3</value>
+  </data>
+  <data name="tcTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>579, 505</value>
+  </data>
+  <data name="tcTaskSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tcTaskSettings.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Name" xml:space="preserve">
+    <value>tcTaskSettings</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tcTaskSettings.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="tttvMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/ShareX/ScreenRecordManager.cs
+++ b/ShareX/ScreenRecordManager.cs
@@ -260,8 +260,6 @@ namespace ShareX
                         {
                             path = Path.Combine(taskSettings.CaptureFolder, TaskHelpers.GetFilename(taskSettings, taskSettings.CaptureSettings.FFmpegOptions.Extension));
                             screenRecorder.FFmpegEncodeVideo(input, path);
-                            DebugHelper.WriteLine("Two pass encoding result:\nInput file size: {0}\nOutput file size: {1}",
-                                new FileInfo(input).Length.ToSizeString(), new FileInfo(path).Length.ToSizeString());
                         }
 
                         if (taskSettings.CaptureSettings.RunScreencastCLI && !taskSettings.CaptureSettings.ScreenRecordTwoPassEncoding)

--- a/ShareX/ScreenRecordManager.cs
+++ b/ShareX/ScreenRecordManager.cs
@@ -88,6 +88,7 @@ namespace ShareX
             else
             {
                 DebugHelper.WriteLine("Starting screen recording. FPS: {0}", taskSettings.CaptureSettings.GIFFPS);
+                taskSettings.CaptureSettings.FFmpegOptions.VideoCodec = FFmpegVideoCodec.gif;
             }
 
             if (taskSettings.CaptureSettings.RunScreencastCLI)
@@ -106,12 +107,6 @@ namespace ShareX
                         "ShareX", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return;
                 }
-            }
-
-            if (outputType == ScreenRecordOutput.GIF)
-            {
-                taskSettings.CaptureSettings.FFmpegOptions.VideoCodec = FFmpegVideoCodec.gif;
-                taskSettings.CaptureSettings.FFmpegOptions.UseCustomCommands = false;
             }
 
             if (!TaskHelpers.CheckFFmpeg(taskSettings))
@@ -218,9 +213,10 @@ namespace ShareX
                         {
                             ScreencastOptions options = new ScreencastOptions()
                             {
+                                IsRecording = true,
+                                IsLossless = outputType == ScreenRecordOutput.GIF || taskSettings.CaptureSettings.ScreenRecordTwoPassEncoding,
                                 FFmpeg = taskSettings.CaptureSettings.FFmpegOptions,
-                                ScreenRecordFPS = taskSettings.CaptureSettings.ScreenRecordFPS,
-                                GIFFPS = taskSettings.CaptureSettings.GIFFPS,
+                                FPS = outputType == ScreenRecordOutput.GIF ? taskSettings.CaptureSettings.GIFFPS : taskSettings.CaptureSettings.ScreenRecordFPS,
                                 Duration = duration,
                                 OutputPath = path,
                                 CaptureArea = captureRectangle,
@@ -253,19 +249,26 @@ namespace ShareX
                     {
                         recordForm.ChangeState(ScreenRecordState.AfterStop);
 
-                        string sourceFilePath = path;
+                        string input = path;
 
                         if (outputType == ScreenRecordOutput.GIF)
                         {
                             path = Path.Combine(taskSettings.CaptureFolder, TaskHelpers.GetFilename(taskSettings, "gif"));
-                            screenRecorder.FFmpegEncodeAsGIF(sourceFilePath, path, Program.ToolsFolder);
+                            screenRecorder.FFmpegEncodeAsGIF(input, path, Program.ToolsFolder);
+                        }
+                        else if (taskSettings.CaptureSettings.ScreenRecordTwoPassEncoding)
+                        {
+                            path = Path.Combine(taskSettings.CaptureFolder, TaskHelpers.GetFilename(taskSettings, taskSettings.CaptureSettings.FFmpegOptions.Extension));
+                            screenRecorder.FFmpegEncodeVideo(input, path);
+                            DebugHelper.WriteLine("Two pass encoding result:\nInput file size: {0}\nOutput file size: {1}",
+                                new FileInfo(input).Length.ToSizeString(), new FileInfo(path).Length.ToSizeString());
                         }
 
-                        if (taskSettings.CaptureSettings.RunScreencastCLI)
+                        if (taskSettings.CaptureSettings.RunScreencastCLI && !taskSettings.CaptureSettings.ScreenRecordTwoPassEncoding)
                         {
                             VideoEncoder encoder = Program.Settings.VideoEncoders[taskSettings.CaptureSettings.VideoEncoderSelected];
                             path = Path.Combine(taskSettings.CaptureFolder, TaskHelpers.GetFilename(taskSettings, encoder.OutputExtension));
-                            screenRecorder.EncodeUsingCommandLine(encoder, sourceFilePath, path);
+                            screenRecorder.EncodeUsingCommandLine(encoder, input, path);
                         }
                     }
                 }
@@ -283,7 +286,7 @@ namespace ShareX
 
                     if (screenRecorder != null)
                     {
-                        if ((outputType == ScreenRecordOutput.GIF || taskSettings.CaptureSettings.RunScreencastCLI) &&
+                        if ((outputType == ScreenRecordOutput.GIF || taskSettings.CaptureSettings.RunScreencastCLI || taskSettings.CaptureSettings.ScreenRecordTwoPassEncoding) &&
                             !string.IsNullOrEmpty(screenRecorder.CachePath) && File.Exists(screenRecorder.CachePath))
                         {
                             File.Delete(screenRecorder.CachePath);

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -349,6 +349,7 @@ namespace ShareX
         public float ScreenRecordStartDelay = 0f;
         public bool ScreenRecordFixedDuration = false;
         public float ScreenRecordDuration = 3f;
+        public bool ScreenRecordTwoPassEncoding = false;
         public bool RunScreencastCLI = false;
         public int VideoEncoderSelected = 0;
 


### PR DESCRIPTION
Added option to record with lossless encoding and then after recording is complete using user configured encoding options to encode second time. This way user can select slow encoding preset and be able to get lower file size without affecting screen recording performance. Fixes issue #2265.