### PR TITLE
Use current screen location for ImageViewer

### DIFF
--- a/ShareX.HelpersLib/Forms/ImageViewer.cs
+++ b/ShareX.HelpersLib/Forms/ImageViewer.cs
@@ -39,9 +39,6 @@ namespace ShareX.HelpersLib
             screenshot = image;
             InitializeComponent();
             Icon = ShareXResources.Icon;
-            var currentScreen = Screen.FromPoint(Cursor.Position);
-            StartPosition = FormStartPosition.CenterScreen;
-            Location = currentScreen.Bounds.Location;
         }
 
         public static void ShowImage(Image img)
@@ -127,12 +124,13 @@ namespace ShareX.HelpersLib
             this.SuspendLayout();
 
             this.BackColor = SystemColors.Window;
-            this.Bounds = CaptureHelpers.GetScreenBounds();
+            this.Bounds = CaptureHelpers.GetActiveScreenBounds();
             this.DoubleBuffered = true;
             this.FormBorderStyle = FormBorderStyle.None;
             this.Text = "ShareX - Image viewer";
             this.TopMost = true;
             this.WindowState = FormWindowState.Maximized;
+            this.StartPosition = FormStartPosition.CenterScreen;
 
             this.pbPreview.Cursor = Cursors.Hand;
             this.pbPreview.Dock = System.Windows.Forms.DockStyle.Fill;

--- a/ShareX.HelpersLib/Forms/ImageViewer.cs
+++ b/ShareX.HelpersLib/Forms/ImageViewer.cs
@@ -39,6 +39,9 @@ namespace ShareX.HelpersLib
             screenshot = image;
             InitializeComponent();
             Icon = ShareXResources.Icon;
+            var currentScreen = Screen.FromPoint(Cursor.Position);
+            StartPosition = FormStartPosition.CenterScreen;
+            Location = currentScreen.Bounds.Location;
         }
 
         public static void ShowImage(Image img)

--- a/ShareX.HelpersLib/Forms/ImageViewer.cs
+++ b/ShareX.HelpersLib/Forms/ImageViewer.cs
@@ -129,8 +129,8 @@ namespace ShareX.HelpersLib
             this.FormBorderStyle = FormBorderStyle.None;
             this.Text = "ShareX - Image viewer";
             this.TopMost = true;
-            this.WindowState = FormWindowState.Maximized;
-            this.StartPosition = FormStartPosition.CenterScreen;
+            this.WindowState = FormWindowState.Normal;
+            this.StartPosition = FormStartPosition.Manual;
 
             this.pbPreview.Cursor = Cursors.Hand;
             this.pbPreview.Dock = System.Windows.Forms.DockStyle.Fill;


### PR DESCRIPTION
On multiple monitors it was a problem, that the ImageViewer would always use the default monitor and not the current monitor.