### PR TITLE
Fixes unexpected clipboard content viewer behavior 

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -36,6 +36,14 @@ namespace ShareX.HelpersLib
         URL
     }
 
+    public enum EClipboardContentType
+    {
+        Default,
+        Image,
+        Text,
+        Files
+    }
+
     public enum PNGBitDepth // Localized
     {
         Default,

--- a/ShareX.HelpersLib/Forms/ClipboardContentViewer.cs
+++ b/ShareX.HelpersLib/Forms/ClipboardContentViewer.cs
@@ -35,6 +35,8 @@ namespace ShareX.HelpersLib
     {
         public bool IsClipboardContentValid { get; private set; }
         public bool DontShowThisWindow { get; private set; }
+        public EClipboardContentType ClipboardContentType { get; private set; }
+        public object ClipboardContent { get; private set; }
 
         public ClipboardContentViewer(bool showCheckBox = false)
         {
@@ -59,6 +61,8 @@ namespace ShareX.HelpersLib
                 {
                     if (img != null)
                     {
+                        ClipboardContentType = EClipboardContentType.Image;
+                        ClipboardContent = img.Clone();
                         pbClipboard.LoadImage(img);
                         pbClipboard.Visible = true;
                         lblQuestion.Text = string.Format(Resources.ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__Image__Size___0_x_1__, img.Width, img.Height);
@@ -72,6 +76,8 @@ namespace ShareX.HelpersLib
 
                 if (!string.IsNullOrEmpty(text))
                 {
+                    ClipboardContentType = EClipboardContentType.Text;
+                    ClipboardContent = text;
                     txtClipboard.Text = text;
                     txtClipboard.Visible = true;
                     lblQuestion.Text = string.Format(Resources.ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__Text__Length___0__, text.Length);
@@ -84,6 +90,8 @@ namespace ShareX.HelpersLib
 
                 if (files.Length > 0)
                 {
+                    ClipboardContentType = EClipboardContentType.Files;
+                    ClipboardContent = files;
                     lbClipboard.Items.AddRange(files);
                     lbClipboard.Visible = true;
                     lblQuestion.Text = string.Format(Resources.ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__File__Count___0__, files.Length);

--- a/ShareX/UploadManager.cs
+++ b/ShareX/UploadManager.cs
@@ -211,6 +211,74 @@ namespace ShareX
             }
         }
 
+        public static void ClipboardUploadCached(ClipboardContentViewer ccv, TaskSettings taskSettings = null)
+        {
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
+            if (ccv.ClipboardContentType == EClipboardContentType.Image)
+            {
+                Image img = (Image)ccv.ClipboardContent;
+
+                if (img != null)
+                {
+                    if (!taskSettings.AdvancedSettings.ProcessImagesDuringClipboardUpload)
+                    {
+                        taskSettings.AfterCaptureJob = AfterCaptureTasks.UploadImageToHost;
+                    }
+
+                    RunImageTask(img, taskSettings);
+                }
+            }
+            else if (ccv.ClipboardContentType == EClipboardContentType.Text)
+            {
+                string text = (string)ccv.ClipboardContent;
+
+                if (!string.IsNullOrEmpty(text))
+                {
+                    string url = text.Trim();
+
+                    if (URLHelpers.IsValidURL(url))
+                    {
+                        if (taskSettings.UploadSettings.ClipboardUploadURLContents)
+                        {
+                            DownloadAndUploadFile(url, taskSettings);
+                            return;
+                        }
+
+                        if (taskSettings.UploadSettings.ClipboardUploadShortenURL)
+                        {
+                            ShortenURL(url, taskSettings);
+                            return;
+                        }
+
+                        if (taskSettings.UploadSettings.ClipboardUploadShareURL)
+                        {
+                            ShareURL(url, taskSettings);
+                            return;
+                        }
+                    }
+
+                    if (taskSettings.UploadSettings.ClipboardUploadAutoIndexFolder && text.Length <= 260 && Directory.Exists(text))
+                    {
+                        IndexFolder(text, taskSettings);
+                    }
+                    else
+                    {
+                        UploadText(text, taskSettings, true);
+                    }
+                }
+            }
+            else if (ccv.ClipboardContentType == EClipboardContentType.Files)
+            {
+                string[] files = (string[])ccv.ClipboardContent;
+
+                if (files.Length > 0)
+                {
+                    UploadFile(files, taskSettings);
+                }
+            }
+        }
+
         public static void ClipboardUploadWithContentViewer(TaskSettings taskSettings = null)
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
@@ -219,7 +287,14 @@ namespace ShareX
             {
                 if (ccv.ShowDialog() == DialogResult.OK && ccv.IsClipboardContentValid)
                 {
-                    ClipboardUpload(taskSettings);
+                    if (ccv.ClipboardContentType != EClipboardContentType.Default)
+                    {
+                        ClipboardUploadCached(ccv, taskSettings);
+                    }
+                    else
+                    {
+                        ClipboardUpload(taskSettings);
+                    }
                 }
             }
         }
@@ -234,7 +309,14 @@ namespace ShareX
                 {
                     if (ccv.ShowDialog() == DialogResult.OK && ccv.IsClipboardContentValid)
                     {
-                        ClipboardUpload(taskSettings);
+                        if (ccv.ClipboardContentType != EClipboardContentType.Default)
+                        {
+                            ClipboardUploadCached(ccv, taskSettings);
+                        }
+                        else
+                        {
+                            ClipboardUpload(taskSettings);
+                        }
                     }
 
                     Program.Settings.ShowClipboardContentViewer = !ccv.DontShowThisWindow;

--- a/ShareX/UploadManager.cs
+++ b/ShareX/UploadManager.cs
@@ -296,6 +296,10 @@ namespace ShareX
                         ClipboardUpload(taskSettings);
                     }
                 }
+                else if (ccv.ClipboardContentType == EClipboardContentType.Image)
+                {
+                    ((Image)ccv.ClipboardContent).Dispose();
+                }
             }
         }
 
@@ -317,6 +321,10 @@ namespace ShareX
                         {
                             ClipboardUpload(taskSettings);
                         }
+                    }
+                    else if (ccv.ClipboardContentType == EClipboardContentType.Image)
+                    {
+                        ((Image)ccv.ClipboardContent).Dispose();
                     }
 
                     Program.Settings.ShowClipboardContentViewer = !ccv.DontShowThisWindow;


### PR DESCRIPTION
Fixes #1769.
Clipboard content displayed in ClipboardContentViewer is now cached with it's type. It allows clipboard to be freely used, while ClipboardContentViewer form is opened. When "OK" button is pressed, cached content is uploaded.