### PR TITLE
 Add new settings to OCR and enhancements - Fixes #3712, #3601, #2848

### DIFF
--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.Designer.cs
@@ -56,6 +56,7 @@
             // 
             resources.ApplyResources(this.txtResult, "txtResult");
             this.txtResult.Name = "txtResult";
+            this.txtResult.ReadOnly = true;
             // 
             // lblResult
             // 

--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
@@ -143,5 +143,6 @@ namespace ShareX.UploadersLib
     {
         public OCRSpaceLanguages DefaultLanguage = OCRSpaceLanguages.eng;
         public bool Silent = false;
+        public bool ProcessOnLoad = true;
     }
 }

--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.cs
@@ -25,6 +25,7 @@
 
 using ShareX.HelpersLib;
 using ShareX.UploadersLib.OtherServices;
+using ShareX.UploadersLib.Properties;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -34,24 +35,28 @@ namespace ShareX.UploadersLib
 {
     public partial class OCRSpaceForm : Form
     {
-        public OCRSpaceLanguages Language { get; set; } = OCRSpaceLanguages.eng;
+        public OCRSpaceLanguages Language { get; set; }
         public string Result { get; private set; }
 
         private Stream data;
         private string filename;
+        private OCROptions ocrOptions;
 
-        public OCRSpaceForm()
+        public OCRSpaceForm(OCROptions ocrOptions)
         {
             InitializeComponent();
             Icon = ShareXResources.Icon;
             cbLanguages.Items.AddRange(Helpers.GetEnumDescriptions<OCRSpaceLanguages>());
+            cbLanguages.SelectedIndex = (int)ocrOptions.DefaultLanguage;
+            Language = ocrOptions.DefaultLanguage;
             txtResult.SupportSelectAll();
         }
 
-        public OCRSpaceForm(Stream data, string filename) : this()
+        public OCRSpaceForm(Stream data, string filename, OCROptions ocrOptions) : this(ocrOptions)
         {
             this.data = data;
             this.filename = filename;
+            this.ocrOptions = ocrOptions;
         }
 
         private async void OCRSpaceResultForm_Shown(object sender, EventArgs e)
@@ -76,7 +81,7 @@ namespace ShareX.UploadersLib
             btnStartOCR.Visible = data != null && data.Length > 0 && !string.IsNullOrEmpty(filename);
         }
 
-        private async Task StartOCR(Stream stream, string filename)
+        public async Task StartOCR(Stream stream, string filename)
         {
             if (stream != null && stream.Length > 0 && !string.IsNullOrEmpty(filename))
             {
@@ -132,5 +137,11 @@ namespace ShareX.UploadersLib
             URLHelpers.OpenURL("https://translate.google.com/#auto/en/" + Uri.EscapeDataString(txtResult.Text));
             Close();
         }
+    }
+
+    public class OCROptions
+    {
+        public OCRSpaceLanguages DefaultLanguage = OCRSpaceLanguages.eng;
+        public bool Silent = false;
     }
 }

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -284,12 +284,6 @@ namespace ShareX
 
         #endregion Webpage Capture Form
 
-        #region OCR Form
-
-        public OCRSpaceLanguages OCRLanguage = OCRSpaceLanguages.eng;
-
-        #endregion OCR Form
-
         #region Actions toolbar
 
         public List<HotkeyType> ActionsToolbarList = new List<HotkeyType>() { HotkeyType.RectangleRegion, HotkeyType.PrintScreen, HotkeyType.ScreenRecorder,

--- a/ShareX/Forms/TaskSettingsForm.Designer.cs
+++ b/ShareX/Forms/TaskSettingsForm.Designer.cs
@@ -175,6 +175,10 @@
             this.cbScreenRecorderFixedDuration = new System.Windows.Forms.CheckBox();
             this.nudGIFFPS = new System.Windows.Forms.NumericUpDown();
             this.lblGIFFPS = new System.Windows.Forms.Label();
+            this.tpOCR = new System.Windows.Forms.TabPage();
+            this.cbCaptureOCRSilent = new System.Windows.Forms.CheckBox();
+            this.lblOCRDefaultLanguage = new System.Windows.Forms.Label();
+            this.cbCaptureOCRDefaultLanguage = new System.Windows.Forms.ComboBox();
             this.tpUpload = new System.Windows.Forms.TabPage();
             this.tcUpload = new System.Windows.Forms.TabControl();
             this.tpUploadMain = new System.Windows.Forms.TabPage();
@@ -279,6 +283,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudScreenRecorderDuration)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudScreenRecorderStartDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudGIFFPS)).BeginInit();
+            this.tpOCR.SuspendLayout();
             this.tpUpload.SuspendLayout();
             this.tcUpload.SuspendLayout();
             this.tpUploadMain.SuspendLayout();
@@ -805,6 +810,7 @@
             this.tcCapture.Controls.Add(this.tpCaptureGeneral);
             this.tcCapture.Controls.Add(this.tpRegionCapture);
             this.tcCapture.Controls.Add(this.tpScreenRecorder);
+            this.tcCapture.Controls.Add(this.tpOCR);
             resources.ApplyResources(this.tcCapture, "tcCapture");
             this.tcCapture.Name = "tcCapture";
             this.tcCapture.SelectedIndex = 0;
@@ -1576,6 +1582,35 @@
             resources.ApplyResources(this.lblGIFFPS, "lblGIFFPS");
             this.lblGIFFPS.Name = "lblGIFFPS";
             // 
+            // tpOCR
+            // 
+            this.tpOCR.Controls.Add(this.cbCaptureOCRSilent);
+            this.tpOCR.Controls.Add(this.lblOCRDefaultLanguage);
+            this.tpOCR.Controls.Add(this.cbCaptureOCRDefaultLanguage);
+            resources.ApplyResources(this.tpOCR, "tpOCR");
+            this.tpOCR.Name = "tpOCR";
+            this.tpOCR.UseVisualStyleBackColor = true;
+            // 
+            // cbCaptureOCRSilent
+            // 
+            resources.ApplyResources(this.cbCaptureOCRSilent, "cbCaptureOCRSilent");
+            this.cbCaptureOCRSilent.Name = "cbCaptureOCRSilent";
+            this.cbCaptureOCRSilent.UseVisualStyleBackColor = true;
+            this.cbCaptureOCRSilent.CheckedChanged += new System.EventHandler(this.cbCaptureOCRSilent_CheckedChanged);
+            // 
+            // lblOCRDefaultLanguage
+            // 
+            resources.ApplyResources(this.lblOCRDefaultLanguage, "lblOCRDefaultLanguage");
+            this.lblOCRDefaultLanguage.Name = "lblOCRDefaultLanguage";
+            // 
+            // cbCaptureOCRDefaultLanguage
+            // 
+            this.cbCaptureOCRDefaultLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbCaptureOCRDefaultLanguage.FormattingEnabled = true;
+            resources.ApplyResources(this.cbCaptureOCRDefaultLanguage, "cbCaptureOCRDefaultLanguage");
+            this.cbCaptureOCRDefaultLanguage.Name = "cbCaptureOCRDefaultLanguage";
+            this.cbCaptureOCRDefaultLanguage.SelectedIndexChanged += new System.EventHandler(this.cbCaptureOCRDefaultLanguage_SelectedIndexChanged);
+            // 
             // tpUpload
             // 
             this.tpUpload.BackColor = System.Drawing.SystemColors.Window;
@@ -2117,6 +2152,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudScreenRecorderDuration)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudScreenRecorderStartDelay)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudGIFFPS)).EndInit();
+            this.tpOCR.ResumeLayout(false);
+            this.tpOCR.PerformLayout();
             this.tpUpload.ResumeLayout(false);
             this.tcUpload.ResumeLayout(false);
             this.tpUploadMain.ResumeLayout(false);
@@ -2354,5 +2391,9 @@
         private System.Windows.Forms.CheckBox cbScreenRecordConfirmAbort;
         private System.Windows.Forms.CheckBox cbFileUploadReplaceProblematicCharacters;
         private System.Windows.Forms.CheckBox cbScreenRecordTwoPassEncoding;
+        private System.Windows.Forms.TabPage tpOCR;
+        private System.Windows.Forms.Label lblOCRDefaultLanguage;
+        private System.Windows.Forms.ComboBox cbCaptureOCRDefaultLanguage;
+        private System.Windows.Forms.CheckBox cbCaptureOCRSilent;
     }
 }

--- a/ShareX/Forms/TaskSettingsForm.Designer.cs
+++ b/ShareX/Forms/TaskSettingsForm.Designer.cs
@@ -244,6 +244,7 @@
             this.pgTaskSettings = new System.Windows.Forms.PropertyGrid();
             this.chkOverrideAdvancedSettings = new System.Windows.Forms.CheckBox();
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
+            this.cbCaptureOCRProcessOnLoad = new System.Windows.Forms.CheckBox();
             this.tcTaskSettings.SuspendLayout();
             this.tpTask.SuspendLayout();
             this.cmsDestinations.SuspendLayout();
@@ -1584,6 +1585,7 @@
             // 
             // tpOCR
             // 
+            this.tpOCR.Controls.Add(this.cbCaptureOCRProcessOnLoad);
             this.tpOCR.Controls.Add(this.cbCaptureOCRSilent);
             this.tpOCR.Controls.Add(this.lblOCRDefaultLanguage);
             this.tpOCR.Controls.Add(this.cbCaptureOCRDefaultLanguage);
@@ -2090,6 +2092,13 @@
             this.tttvMain.TreeViewSize = 190;
             this.tttvMain.TabChanged += new ShareX.HelpersLib.TabToTreeView.TabChangedEventHandler(this.tttvMain_TabChanged);
             // 
+            // cbCaptureOCRProcessOnLoad
+            // 
+            resources.ApplyResources(this.cbCaptureOCRProcessOnLoad, "cbCaptureOCRProcessOnLoad");
+            this.cbCaptureOCRProcessOnLoad.Name = "cbCaptureOCRProcessOnLoad";
+            this.cbCaptureOCRProcessOnLoad.UseVisualStyleBackColor = true;
+            this.cbCaptureOCRProcessOnLoad.CheckedChanged += new System.EventHandler(this.cbCaptureOCRProcessOnLoad_CheckedChanged);
+            // 
             // TaskSettingsForm
             // 
             resources.ApplyResources(this, "$this");
@@ -2395,5 +2404,6 @@
         private System.Windows.Forms.Label lblOCRDefaultLanguage;
         private System.Windows.Forms.ComboBox cbCaptureOCRDefaultLanguage;
         private System.Windows.Forms.CheckBox cbCaptureOCRSilent;
+        private System.Windows.Forms.CheckBox cbCaptureOCRProcessOnLoad;
     }
 }

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -28,6 +28,7 @@ using ShareX.ImageEffectsLib;
 using ShareX.Properties;
 using ShareX.ScreenCaptureLib;
 using ShareX.UploadersLib;
+using ShareX.UploadersLib.OtherServices;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -295,6 +296,17 @@ namespace ShareX
             cbScreenRecordTwoPassEncoding.Checked = TaskSettings.CaptureSettings.ScreenRecordTwoPassEncoding;
 
             #endregion Screen recorder
+
+            #region OCR
+
+            OCROptions ocrOptions = TaskSettings.CaptureSettings.OCROptions;
+
+            cbCaptureOCRDefaultLanguage.Items.AddRange(Helpers.GetEnumDescriptions<OCRSpaceLanguages>());
+            cbCaptureOCRDefaultLanguage.SelectedIndex = (int)ocrOptions.DefaultLanguage;
+
+            cbCaptureOCRSilent.Checked = ocrOptions.Silent;
+
+            #endregion
 
             #endregion Capture
 
@@ -1096,6 +1108,20 @@ namespace ShareX
         }
 
         #endregion Screen recorder
+
+        #region OCR
+
+        private void cbCaptureOCRDefaultLanguage_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            TaskSettings.CaptureSettings.OCROptions.DefaultLanguage = (OCRSpaceLanguages)cbCaptureOCRDefaultLanguage.SelectedIndex;
+        }
+
+        private void cbCaptureOCRSilent_CheckedChanged(object sender, EventArgs e)
+        {
+            TaskSettings.CaptureSettings.OCROptions.Silent = cbCaptureOCRSilent.Checked;
+        }
+
+        #endregion
 
         #endregion Capture
 

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -305,6 +305,7 @@ namespace ShareX
             cbCaptureOCRDefaultLanguage.SelectedIndex = (int)ocrOptions.DefaultLanguage;
 
             cbCaptureOCRSilent.Checked = ocrOptions.Silent;
+            cbCaptureOCRProcessOnLoad.Checked = ocrOptions.ProcessOnLoad;
 
             #endregion
 
@@ -1119,6 +1120,11 @@ namespace ShareX
         private void cbCaptureOCRSilent_CheckedChanged(object sender, EventArgs e)
         {
             TaskSettings.CaptureSettings.OCROptions.Silent = cbCaptureOCRSilent.Checked;
+        }
+
+        private void cbCaptureOCRProcessOnLoad_CheckedChanged(object sender, EventArgs e)
+        {
+            TaskSettings.CaptureSettings.OCROptions.ProcessOnLoad = cbCaptureOCRProcessOnLoad.Checked;
         }
 
         #endregion

--- a/ShareX/Forms/TaskSettingsForm.resx
+++ b/ShareX/Forms/TaskSettingsForm.resx
@@ -3780,6 +3780,114 @@
   <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbCaptureOCRSilent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCaptureOCRSilent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCaptureOCRSilent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 60</value>
+  </data>
+  <data name="cbCaptureOCRSilent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>124, 17</value>
+  </data>
+  <data name="cbCaptureOCRSilent.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="cbCaptureOCRSilent.Text" xml:space="preserve">
+    <value>Process OCR silently</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRSilent.Name" xml:space="preserve">
+    <value>cbCaptureOCRSilent</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRSilent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRSilent.Parent" xml:space="preserve">
+    <value>tpOCR</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRSilent.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 8</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 13</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.Text" xml:space="preserve">
+    <value>Default language:</value>
+  </data>
+  <data name="&gt;&gt;lblOCRDefaultLanguage.Name" xml:space="preserve">
+    <value>lblOCRDefaultLanguage</value>
+  </data>
+  <data name="&gt;&gt;lblOCRDefaultLanguage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOCRDefaultLanguage.Parent" xml:space="preserve">
+    <value>tpOCR</value>
+  </data>
+  <data name="&gt;&gt;lblOCRDefaultLanguage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbCaptureOCRDefaultLanguage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 24</value>
+  </data>
+  <data name="cbCaptureOCRDefaultLanguage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 21</value>
+  </data>
+  <data name="cbCaptureOCRDefaultLanguage.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRDefaultLanguage.Name" xml:space="preserve">
+    <value>cbCaptureOCRDefaultLanguage</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRDefaultLanguage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRDefaultLanguage.Parent" xml:space="preserve">
+    <value>tpOCR</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRDefaultLanguage.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpOCR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpOCR.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpOCR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 447</value>
+  </data>
+  <data name="tpOCR.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tpOCR.Text" xml:space="preserve">
+    <value>OCR</value>
+  </data>
+  <data name="&gt;&gt;tpOCR.Name" xml:space="preserve">
+    <value>tpOCR</value>
+  </data>
+  <data name="&gt;&gt;tpOCR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpOCR.Parent" xml:space="preserve">
+    <value>tcCapture</value>
+  </data>
+  <data name="&gt;&gt;tpOCR.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="tcCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>

--- a/ShareX/Forms/TaskSettingsForm.resx
+++ b/ShareX/Forms/TaskSettingsForm.resx
@@ -3780,6 +3780,36 @@
   <data name="&gt;&gt;tpScreenRecorder.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbCaptureOCRProcessOnLoad.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 83</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.Size" type="System.Drawing.Size, System.Drawing">
+    <value>163, 17</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.Text" xml:space="preserve">
+    <value>Process OCR on dialog open</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRProcessOnLoad.Name" xml:space="preserve">
+    <value>cbCaptureOCRProcessOnLoad</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRProcessOnLoad.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRProcessOnLoad.Parent" xml:space="preserve">
+    <value>tpOCR</value>
+  </data>
+  <data name="&gt;&gt;cbCaptureOCRProcessOnLoad.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbCaptureOCRSilent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>

--- a/ShareX/Properties/Resources.Designer.cs
+++ b/ShareX/Properties/Resources.Designer.cs
@@ -1906,6 +1906,33 @@ namespace ShareX.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The OCR output has been copied to your clipboard..
+        /// </summary>
+        public static string OCRForm_AutoComplete {
+            get {
+                return ResourceManager.GetString("OCRForm_AutoComplete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error occurred during OCR processing, or no text was returned..
+        /// </summary>
+        public static string OCRForm_AutoCompleteFail {
+            get {
+                return ResourceManager.GetString("OCRForm_AutoCompleteFail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OCR is processing..
+        /// </summary>
+        public static string OCRForm_AutoProcessing {
+            get {
+                return ResourceManager.GetString("OCRForm_AutoProcessing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap Patreon_Button_01 {

--- a/ShareX/Properties/Resources.resx
+++ b/ShareX/Properties/Resources.resx
@@ -985,4 +985,13 @@ Middle click to close</value>
   <data name="AboutForm_AboutForm_Language_es_MX" xml:space="preserve">
     <value>Mexican Spanish</value>
   </data>
+  <data name="OCRForm_AutoComplete" xml:space="preserve">
+    <value>The OCR output has been copied to your clipboard.</value>
+  </data>
+  <data name="OCRForm_AutoCompleteFail" xml:space="preserve">
+    <value>Error occurred during OCR processing, or no text was returned.</value>
+  </data>
+  <data name="OCRForm_AutoProcessing" xml:space="preserve">
+    <value>OCR is processing.</value>
+  </data>
 </root>

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -30,6 +30,7 @@ using ShareX.IndexerLib;
 using ShareX.MediaLib;
 using ShareX.ScreenCaptureLib;
 using ShareX.UploadersLib;
+using ShareX.UploadersLib.OtherServices;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -358,6 +359,12 @@ namespace ShareX
         public ScrollingCaptureOptions ScrollingCaptureOptions = new ScrollingCaptureOptions();
 
         #endregion Capture / Scrolling capture
+
+        #region Capture / OCR
+
+        public OCROptions OCROptions = new OCROptions();
+
+        #endregion
     }
 
     public class TaskSettingsUpload

--- a/ShareX/UploadInfoManager.cs
+++ b/ShareX/UploadInfoManager.cs
@@ -364,7 +364,7 @@ namespace ShareX
 
         public void OCRImage()
         {
-            if (IsItemSelected && SelectedItem.IsImageFile) TaskHelpers.OCRImage(SelectedItem.Info.FilePath);
+            if (IsItemSelected && SelectedItem.IsImageFile) TaskHelpers.OCRImage(SelectedItem.Info.FilePath, Program.DefaultTaskSettings);
         }
 
         public void CombineImages()

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -1009,7 +1009,7 @@ namespace ShareX
         {
             if (Data != null && Info.DataType == EDataType.Image)
             {
-                TaskHelpers.OCRImage(Data, Info.FileName, Info.FilePath);
+                TaskHelpers.OCRImage(Data, Info.FileName, Info.TaskSettings, Info.FilePath);
             }
         }
 


### PR DESCRIPTION
To improve the OCR experience and to tackle the tickets mentioned previously, some new settings and modes have been added to the OCR tool.

**New Settings**
Introduces a "silent" operation mode and default language selection.
![image](https://user-images.githubusercontent.com/1522389/49143219-8045fd00-f34a-11e8-8a04-fe452762591a.png)

I have also tested and confirmed the custom hotkey settings can be applied to the OCR task.

**UI Change**
The text box has been made read only as users should not be modifying the text. 