### PR TITLE
Indicate in debug logs if ShareX is running as an elevated process

### DIFF
--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -283,6 +283,7 @@ namespace ShareX
                 DebugHelper.WriteLine("Personal path detection method: " + PersonalPathDetectionMethod);
             }
             DebugHelper.WriteLine("Operating system: " + Helpers.GetOperatingSystemProductName(true));
+            DebugHelper.WriteLine("Running as elevated process: " + Helpers.IsAdministrator());
 
             SilentRun = CLI.IsCommandExist("silent", "s");
 #if WindowsStore


### PR DESCRIPTION
Improves debug logging to indicate if ShareX is running as an elevated process