### PR TITLE
Create Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,8 +11,8 @@ Mention your current ShareX version and the OS you are on (eg. ShareX 12.3 from 
 **What happened**
 Describe the bug you are facing here.
 
-**Expected behavior**
-What did you expect to happen?
+**Steps to reproduce the error**
+Please tell us the steps you followed until you faced that problem so that we can recreate it on our end and find a solution.
 
 **Screenshots (Optional)**
 If you want, add screenshots to help us understand better your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels:
 ---
 
 **ShareX version and OS**
-Mention your current ShareX version and the OS you are on (eg. Windows)
+Mention your current ShareX version and the OS you are on (eg. ShareX 12.3 from Microsoft Store on Windows 10 v1607 64 bit)
 
 **Describe the bug**
 Describe the bug you are facing here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us fix any issues ShareX might have
+labels: 
+
+---
+
+**ShareX version and OS**
+Mention your current ShareX version and the OS you are on (eg. Windows)
+
+**Describe the bug**
+Describe the bug you are facing here.
+
+**Expected behavior**
+What did you expect to happen?
+
+**Screenshots (Optional)**
+If you want, add screenshots to help us understand better your problem.
+
+**Additional Content (Optional)**
+Add whatever else related to the bug you want to mention here!

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ labels:
 **ShareX version and OS**
 Mention your current ShareX version and the OS you are on (eg. ShareX 12.3 from Microsoft Store on Windows 10 v1607 64 bit)
 
-**Describe the bug**
+**What happened**
 Describe the bug you are facing here.
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,10 +5,10 @@ labels:
 
 ---
 
-**Description of Feature Request**
+**Description**
 Here you can describe what the feature request is and if it is related to a problem you had experienced before.
 
-**Describe alternatives (Optional)**
+**Alternatives/workarounds (Optional)**
 If you have considered alternative ideas for your feature request, you can mention them here.
 
 **Additional Content (Optional)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for ShareX to help us improve it
+labels: 
+
+---
+
+**Description of Feature Request**
+Here you can describe what the feature request is and if it is related to a problem you had experienced before.
+
+**Describe alternatives (Optional)**
+If you have considered alternative ideas for your feature request, you can mention them here.
+
+**Additional Content (Optional)**
+Add whatever else related to your idea you want to mention here!


### PR DESCRIPTION
Since I saw what you said on #3730, about not preferring long issue templates, I created my own version of simple issue templates that might help a new user with submitting an issue and not confuse him.

I added as little as I could as so to keep it brief and not long per your instructions to the submitter of the issue mentioned before.

I have allowed edit from maintainers and so if you find something too long or something that would prevent users from submitting an issue, tell me to remove it and I will. I am open to any change.

_If you want, you can remove it too, no need to tell me_