### PR TITLE
Make code prettier

### DIFF
--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -302,7 +302,7 @@ namespace ShareX
         {
             if (m.Msg == (int)WindowsMessages.QUERYENDSESSION)
             {
-                // Calling ToInt64 because the int conversion operator (called when irectly casting the IntPtr to the enum)
+                // Calling ToInt64 because the int conversion operator (called when directly casting the IntPtr to the enum)
                 // enforces checked semantics thus crashes any 64 bits build. ToInt64() and long -> enum conversion doesn't.
                 EndSessionReasons reason = (EndSessionReasons)m.LParam.ToInt64();
                 if (reason.HasFlag(EndSessionReasons.ENDSESSION_CLOSEAPP))

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -302,7 +302,7 @@ namespace ShareX
         {
             if (m.Msg == (int)WindowsMessages.QUERYENDSESSION)
             {
-                EndSessionReasons reason = (EndSessionReasons)(m.LParam.ToInt64() & 0xFFFFFFFF);
+                EndSessionReasons reason = (EndSessionReasons)(long)(m.LParam);
                 if (reason.HasFlag(EndSessionReasons.ENDSESSION_CLOSEAPP))
                 {
                     // Register for restart. This allows our application to automatically restart when it is installing an update from the Store.

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -302,9 +302,9 @@ namespace ShareX
         {
             if (m.Msg == (int)WindowsMessages.QUERYENDSESSION)
             {
-                // Casting to long before because the int conversion operator enforces checked semantics
-                // thus crashes any 64 bits build. IntPtr -> long and long -> enum doesn't.
-                EndSessionReasons reason = (EndSessionReasons)(long)(m.LParam);
+                // Calling ToInt64 because the int conversion operator (called when irectly casting the IntPtr to the enum)
+                // enforces checked semantics thus crashes any 64 bits build. ToInt64() and long -> enum conversion doesn't.
+                EndSessionReasons reason = (EndSessionReasons)m.LParam.ToInt64();
                 if (reason.HasFlag(EndSessionReasons.ENDSESSION_CLOSEAPP))
                 {
                     // Register for restart. This allows our application to automatically restart when it is installing an update from the Store.

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -302,6 +302,8 @@ namespace ShareX
         {
             if (m.Msg == (int)WindowsMessages.QUERYENDSESSION)
             {
+                // Casting to long before because the int conversion operator enforces checked semantics
+                // thus crashes any 64 bits build. IntPtr -> long and long -> enum doesn't.
                 EndSessionReasons reason = (EndSessionReasons)(long)(m.LParam);
                 if (reason.HasFlag(EndSessionReasons.ENDSESSION_CLOSEAPP))
                 {


### PR DESCRIPTION
`operator int` enforces checked semantics but `operator long` does not