### PR TITLE
Allow hash result to be selected via Ctrl-A (Fixes #3792) and fix UI bug with progress bar

### DIFF
--- a/ShareX.HelpersLib/Forms/HashCheckForm.Designer.cs
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.Designer.cs
@@ -126,6 +126,7 @@
             this.txtResult.Name = "txtResult";
             this.txtResult.ReadOnly = true;
             this.txtResult.TextChanged += new System.EventHandler(this.txtResult_TextChanged);
+            this.txtResult.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtResult_KeyDown);
             // 
             // txtTarget
             // 

--- a/ShareX.HelpersLib/Forms/HashCheckForm.cs
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.cs
@@ -89,6 +89,7 @@ namespace ShareX.HelpersLib
                 if (hashCheck.Start(txtFilePath.Text, hashType))
                 {
                     btnStartHashCheck.Text = Resources.Stop;
+                    pbProgress.Value = 0;
                     txtResult.Text = "";
                 }
             }
@@ -122,6 +123,14 @@ namespace ShareX.HelpersLib
             }
 
             UpdateResult();
+        }
+
+        private void txtResult_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.A)
+            {
+                txtResult.SelectAll();
+            }
         }
 
         private void tpFileHashCheck_DragEnter(object sender, DragEventArgs e)


### PR DESCRIPTION
Regarding the UI bug, the progress bar is not being reset to 0% when a file hash is being calculated causing the bar to jump from 100% down to whatever percentage the file is at, not start from 0%.