### PR TITLE
Add support for Edge webview in website capture

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.Designer.cs
@@ -100,7 +100,7 @@
             // 
             resources.ApplyResources(this.nudWebpageWidth, "nudWebpageWidth");
             this.nudWebpageWidth.Maximum = new decimal(new int[] {
-            10000,
+            15000,
             0,
             0,
             0});
@@ -121,7 +121,7 @@
             // 
             resources.ApplyResources(this.nudWebpageHeight, "nudWebpageHeight");
             this.nudWebpageHeight.Maximum = new decimal(new int[] {
-            10000,
+            15000,
             0,
             0,
             0});

--- a/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.cs
@@ -25,6 +25,7 @@
 
 using ShareX.HelpersLib;
 using ShareX.ScreenCaptureLib.Properties;
+using ShareX.ScreenCaptureLib.WebpageCapture;
 using System;
 using System.Drawing;
 using System.Windows.Forms;
@@ -39,7 +40,7 @@ namespace ShareX.ScreenCaptureLib
         public WebpageCaptureOptions Options { get; set; }
         public bool IsBusy { get; private set; }
 
-        private WebpageCapture webpageCapture;
+        private WebpageCaptureBase webpageCapture;
         private bool stopRequested;
 
         public WebpageCaptureForm(WebpageCaptureOptions options)
@@ -48,7 +49,7 @@ namespace ShareX.ScreenCaptureLib
             Icon = ShareXResources.Icon;
             Options = options;
             LoadSettings();
-            webpageCapture = new WebpageCapture();
+            webpageCapture = WebpageCaptureBase.Create();
             webpageCapture.CaptureCompleted += webpageCapture_CaptureCompleted;
         }
 
@@ -133,7 +134,7 @@ namespace ShareX.ScreenCaptureLib
             }
 
             webpageCapture.CaptureDelay = (int)nudCaptureDelay.Value * 1000;
-            webpageCapture.CapturePage(txtURL.Text, new Size((int)nudWebpageWidth.Value, (int)nudWebpageWidth.Value));
+            webpageCapture.CapturePage(txtURL.Text, new Size((int)nudWebpageWidth.Value, (int)nudWebpageHeight.Value));
         }
 
         private void StopCapture()

--- a/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.resx
@@ -158,7 +158,7 @@
   </data>
   <data name="lblURL.Text" xml:space="preserve">
     <value>URL:</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblURL.Name" xml:space="preserve">
     <value>lblURL</value>
   </data>
@@ -338,7 +338,7 @@
   </data>
   <data name="lblWebpageX.Text" xml:space="preserve">
     <value>x</value>
-  <comment>@Invariant</comment></data>
+  </data>
   <data name="&gt;&gt;lblWebpageX.Name" xml:space="preserve">
     <value>lblWebpageX</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/WebpageCaptureForm.resx
@@ -158,7 +158,7 @@
   </data>
   <data name="lblURL.Text" xml:space="preserve">
     <value>URL:</value>
-  </data>
+  <comment>@Invariant</comment></data>
   <data name="&gt;&gt;lblURL.Name" xml:space="preserve">
     <value>lblURL</value>
   </data>
@@ -338,7 +338,7 @@
   </data>
   <data name="lblWebpageX.Text" xml:space="preserve">
     <value>x</value>
-  </data>
+  <comment>@Invariant</comment></data>
   <data name="&gt;&gt;lblWebpageX.Name" xml:space="preserve">
     <value>lblWebpageX</value>
   </data>

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -78,17 +78,21 @@
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="windows">
       <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Facade\windows.winmd</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Windows.Foundation.FoundationContract">
       <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Windows.Foundation.UniversalApiContract">
       <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -75,8 +75,21 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="windows">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Facade\windows.winmd</HintPath>
+    </Reference>
+    <Reference Include="Windows.Foundation.FoundationContract">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+    </Reference>
+    <Reference Include="Windows.Foundation.UniversalApiContract">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">
@@ -85,6 +98,7 @@
     <Compile Include="Animations\BaseAnimation.cs" />
     <Compile Include="Animations\PointAnimation.cs" />
     <Compile Include="Animations\RectangleAnimation.cs" />
+    <Compile Include="WebpageCapture\EdgeWebpageCapture.cs" />
     <Compile Include="Forms\CanvasSizeForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -223,8 +237,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Screenshot_Transparent.cs" />
     <Compile Include="Animations\TextAnimation.cs" />
-    <Compile Include="WebpageCapture.cs" />
-    <Compile Include="WebpageCaptureOptions.cs" />
+    <Compile Include="WebpageCapture\InternetExplorerWebpageCapture.cs" />
+    <Compile Include="WebpageCapture\WebpageCaptureBase.cs" />
+    <Compile Include="WebpageCapture\WebpageCaptureOptions.cs" />
     <Compile Include="RegionHelpers\WindowsList.cs" />
     <Compile Include="RegionHelpers\WindowsRectangleList.cs" />
   </ItemGroup>

--- a/ShareX.ScreenCaptureLib/WebpageCapture/EdgeWebpageCapture.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/EdgeWebpageCapture.cs
@@ -1,4 +1,29 @@
-﻿using System;
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2018 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using System;
 using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
@@ -68,7 +93,11 @@ namespace ShareX.ScreenCaptureLib.WebpageCapture
         {
             webView.Close();
             viewHost.Dispose();
-            viewProcess.Terminate();
+
+            if (viewProcess.ProcessId != 0)
+            {
+                viewProcess.Terminate();
+            }
         }
     }
 }

--- a/ShareX.ScreenCaptureLib/WebpageCapture/EdgeWebpageCapture.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/EdgeWebpageCapture.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Windows.Foundation;
+using Windows.Storage.Streams;
+using Windows.Web.UI;
+using Windows.Web.UI.Interop;
+
+namespace ShareX.ScreenCaptureLib.WebpageCapture
+{
+    public class EdgeWebpageCapture : WebpageCaptureBase
+    {
+        private WebViewControl webView;
+        private WebViewControlProcess viewProcess;
+        private Control viewHost;
+
+        public EdgeWebpageCapture()
+        {
+            viewProcess = new WebViewControlProcess();
+            viewHost = new Control();
+
+            webView = viewProcess.CreateWebViewControlAsync(viewHost.Handle.ToInt64(), new Rect()).GetAwaiter().GetResult();
+            webView.LongRunningScriptDetected += (s, e) => e.StopPageScriptExecution = true;
+            webView.NavigationCompleted += webView_NavigationCompleted;
+        }
+
+        public override void CapturePage(string url, System.Drawing.Size browserSize)
+        {
+            if (!string.IsNullOrEmpty(url))
+            {
+                webView.Bounds = new Rect(0, 0, browserSize.Width, browserSize.Height);
+
+                if (string.IsNullOrEmpty(url))
+                {
+                    url = "about:blank";
+                }
+
+                webView.Navigate(new Uri(url, UriKind.Absolute));
+            }
+        }
+
+        public override void Stop()
+        {
+            webView.Stop();
+        }
+
+        private async void webView_NavigationCompleted(object sender, WebViewControlNavigationCompletedEventArgs e)
+        {
+            if (e.IsSuccess)
+            {
+                await Task.Delay(CaptureDelay);
+
+                using (IRandomAccessStream stream = new InMemoryRandomAccessStream())
+                {
+                    await webView.CapturePreviewToStreamAsync(stream);
+                    OnCaptureCompleted(new Bitmap(stream.AsStream()));
+                }
+            }
+            else
+            {
+                OnCaptureCompleted(null);
+            }
+        }
+
+        public override void Dispose()
+        {
+            webView.Close();
+            viewHost.Dispose();
+            viewProcess.Terminate();
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/WebpageCapture/InternetExplorerWebpageCapture.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/InternetExplorerWebpageCapture.cs
@@ -29,17 +29,13 @@ using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace ShareX.ScreenCaptureLib
+namespace ShareX.ScreenCaptureLib.WebpageCapture
 {
-    public class WebpageCapture : IDisposable
+    public class InternetExplorerWebpageCapture : WebpageCaptureBase
     {
-        public event Action<Bitmap> CaptureCompleted;
-
-        public int CaptureDelay { get; set; }
-
         private WebBrowser webBrowser;
 
-        public WebpageCapture()
+        public InternetExplorerWebpageCapture()
         {
             webBrowser = new WebBrowser();
             webBrowser.AllowNavigation = true;
@@ -48,12 +44,7 @@ namespace ShareX.ScreenCaptureLib
             webBrowser.DocumentCompleted += webBrowser_DocumentCompleted;
         }
 
-        public void CapturePage(string url)
-        {
-            CapturePage(url, Screen.PrimaryScreen.Bounds.Size);
-        }
-
-        public void CapturePage(string url, Size browserSize)
+        public override void CapturePage(string url, Size browserSize)
         {
             if (!string.IsNullOrEmpty(url))
             {
@@ -62,7 +53,7 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
-        public void Stop()
+        public override void Stop()
         {
             webBrowser.Stop();
         }
@@ -131,19 +122,7 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
-        protected void OnCaptureCompleted(Bitmap bmp)
-        {
-            if (CaptureCompleted != null)
-            {
-                CaptureCompleted(bmp);
-            }
-            else if (bmp != null)
-            {
-                bmp.Dispose();
-            }
-        }
-
-        public void Dispose()
+        public override void Dispose()
         {
             if (webBrowser != null)
             {

--- a/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureBase.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureBase.cs
@@ -1,4 +1,29 @@
-﻿using ShareX.HelpersLib;
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2018 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using ShareX.HelpersLib;
 using System;
 using System.Drawing;
 using System.IO;
@@ -14,7 +39,9 @@ namespace ShareX.ScreenCaptureLib.WebpageCapture
         public int CaptureDelay { get; set; }
 
         public abstract void CapturePage(string url, Size browserSize);
+
         public abstract void Stop();
+
         public abstract void Dispose();
 
         public void CapturePage(string url)
@@ -36,14 +63,13 @@ namespace ShareX.ScreenCaptureLib.WebpageCapture
 
         private static bool WebViewSupported()
         {
-            return Helpers.IsWindows10OrGreater() &&
-                ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 6) && // 6th API contract is minimum for WebView support.
+            return ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 6) && // 6th API contract is minimum for WebView support.
                 File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "edgehtml.dll")); // Make sure EdgeHTML is present.
         }
 
         public static WebpageCaptureBase Create()
         {
-            if (WebViewSupported())
+            if (Helpers.IsWindows10OrGreater() && WebViewSupported())
             {
                 try
                 {

--- a/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureBase.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureBase.cs
@@ -1,0 +1,58 @@
+﻿using ShareX.HelpersLib;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using Windows.Foundation.Metadata;
+
+namespace ShareX.ScreenCaptureLib.WebpageCapture
+{
+    public abstract class WebpageCaptureBase : IDisposable
+    {
+        public event Action<Bitmap> CaptureCompleted;
+
+        public int CaptureDelay { get; set; }
+
+        public abstract void CapturePage(string url, Size browserSize);
+        public abstract void Stop();
+        public abstract void Dispose();
+
+        public void CapturePage(string url)
+        {
+            CapturePage(url, Screen.PrimaryScreen.Bounds.Size);
+        }
+
+        protected void OnCaptureCompleted(Bitmap bmp)
+        {
+            if (CaptureCompleted != null)
+            {
+                CaptureCompleted(bmp);
+            }
+            else if (bmp != null)
+            {
+                bmp.Dispose();
+            }
+        }
+
+        private static bool WebViewSupported()
+        {
+            return Helpers.IsWindows10OrGreater() &&
+                ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 6) && // 6th API contract is minimum for WebView support.
+                File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "edgehtml.dll")); // Make sure EdgeHTML is present.
+        }
+
+        public static WebpageCaptureBase Create()
+        {
+            if (WebViewSupported())
+            {
+                try
+                {
+                    return new EdgeWebpageCapture();
+                }
+                catch { }
+            }
+
+            return new InternetExplorerWebpageCapture();
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureOptions.cs
+++ b/ShareX.ScreenCaptureLib/WebpageCapture/WebpageCaptureOptions.cs
@@ -25,7 +25,7 @@
 
 using System.Drawing;
 
-namespace ShareX.ScreenCaptureLib
+namespace ShareX.ScreenCaptureLib.WebpageCapture
 {
     public class WebpageCaptureOptions
     {

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -25,7 +25,7 @@
 
 using ShareX.HelpersLib;
 using ShareX.HistoryLib;
-using ShareX.ScreenCaptureLib;
+using ShareX.ScreenCaptureLib.WebpageCapture;
 using ShareX.UploadersLib;
 using System;
 using System.Collections.Generic;

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -118,7 +118,7 @@
           <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
           <Private>False</Private>
         </Reference>
-        <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
+        <Reference Include="windows">
           <SpecificVersion>False</SpecificVersion>
           <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Facade\windows.winmd</HintPath>
           <Private>False</Private>

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -120,7 +120,7 @@
         </Reference>
         <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
           <SpecificVersion>False</SpecificVersion>
-          <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
+          <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Facade\windows.winmd</HintPath>
           <Private>False</Private>
         </Reference>
         <Reference Include="Windows.ApplicationModel.Activation.ActivatedEventsContract">


### PR DESCRIPTION
This allows, on machines that run the April 2018 update or higher, to take screenshots of websites that don't work anymore on IE. (Fixes #3634)