### PR TITLE
Don't generate direct download links when PreviewLink is checked

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -181,9 +181,9 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         OwnCloudShareResponseData data = ((JObject)result.ocs.data).ToObject<OwnCloudShareResponseData>();
                         string link = data.url;
-                        if (PreviewLink)
+                        if (PreviewLink) && Helpers.IsImageFile(path)
                         {
-                            link += Helpers.IsImageFile(path) ? "/preview" : (IsCompatibility81 ? "/" : "&") + "download";
+                            link += "/preview";
                         }
                         else if (DirectLink)
                         {

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -181,7 +181,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         OwnCloudShareResponseData data = ((JObject)result.ocs.data).ToObject<OwnCloudShareResponseData>();
                         string link = data.url;
-                        if ((PreviewLink) && (Helpers.IsImageFile(path)))
+                        if (PreviewLink && Helpers.IsImageFile(path))
                         {
                             link += "/preview";
                         }

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -181,7 +181,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         OwnCloudShareResponseData data = ((JObject)result.ocs.data).ToObject<OwnCloudShareResponseData>();
                         string link = data.url;
-                        if (PreviewLink && Helpers.IsImageFile(path))
+                        if ((PreviewLink) && (Helpers.IsImageFile(path)))
                         {
                             link += "/preview";
                         }

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -183,7 +183,7 @@ namespace ShareX.UploadersLib.FileUploaders
                         string link = data.url;
                         if (PreviewLink)
                         {
-                            link += Helpers.IsImageFile(path) ? "/preview" : "/download";
+                            link += Helpers.IsImageFile(path) ? "/preview" : (IsCompatibility81 ? "/" : "&") + "download";
                         }
                         else if (DirectLink)
                         {

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -181,7 +181,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         OwnCloudShareResponseData data = ((JObject)result.ocs.data).ToObject<OwnCloudShareResponseData>();
                         string link = data.url;
-                        if (PreviewLink) && Helpers.IsImageFile(path)
+                        if (PreviewLink && Helpers.IsImageFile(path))
                         {
                             link += "/preview";
                         }


### PR DESCRIPTION
See issue: https://github.com/ShareX/ShareX/issues/3868
Not adding either /preview or /download to URL generates links that show a preview of a file. /preview only works for images (showing literally only the image in the browser). This change makes sure the logic is right.

Note: The logic is right so it should work. But I'm not sure if the syntax is right.