### PR TITLE
Pushbullet upgrade

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Pushbullet.cs
+++ b/ShareX.UploadersLib/FileUploaders/Pushbullet.cs
@@ -109,6 +109,7 @@ namespace ShareX.UploadersLib.FileUploaders
             pushArgs.Add("type", "file");
             pushArgs.Add("file_url", fileInfo.file_url);
             pushArgs.Add("body", "Sent via ShareX");
+            pushArgs.Add("file_type", fileInfo.file_type);
 
             string pushResult = SendRequestMultiPart(apiSendPushURL, pushArgs, headers);
 


### PR DESCRIPTION
Adds information about filetype to push. Pushbullet on android can then open the Image/File easily, and also shows a preview for images. Text can now be opened, but is currently sent as a textfile instead of actual text. Should we maybe change that too?

#3771