### PR TITLE
Fix album list pollution

### DIFF
--- a/ShareX.UploadersLib/ImageUploaders/GooglePhotos.cs
+++ b/ShareX.UploadersLib/ImageUploaders/GooglePhotos.cs
@@ -143,7 +143,10 @@ namespace ShareX.UploadersLib.ImageUploaders
                                 Name = album.title
                             };
 
-                            albumList.Add(AlbumInfo);
+                            if (album.shareInfo == null)
+                            {
+                                albumList.Add(AlbumInfo);
+                            }
                         }
                         pageToken = albums.nextPageToken;
                     }
@@ -233,6 +236,7 @@ namespace ShareX.UploadersLib.ImageUploaders
         public string coverPhotoBaseUrl { get; set; }
         public string coverPhotoMediaItemId { get; set; }
         public string isWriteable { get; set; }
+        public GooglePhotosShareInfo shareInfo { get; set; }
         public string mediaItemsCount { get; set; }
     }
 


### PR DESCRIPTION
Album list will become polluted with redundant single album share images, we can assume that no shared albums other than ones used for public links will be made.

This will not fix long pagination responses due to many shared albums.