### PR TITLE
Version-lock Windows.winmd assembly reference

### DIFF
--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -118,13 +118,9 @@
           <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
           <Private>False</Private>
         </Reference>
-        <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
+        <Reference Include="windows">
           <SpecificVersion>False</SpecificVersion>
-          <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Facade\Windows.WinMD</HintPath>
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Windows.ApplicationModel.Activation.ActivatedEventsContract">
-          <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0\Windows.ApplicationModel.Activation.ActivatedEventsContract\1.0.0.0\Windows.ApplicationModel.Activation.ActivatedEventsContract.winmd</HintPath>
+          <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.17763.0\Facade\windows.winmd</HintPath>
           <Private>False</Private>
         </Reference>
         <Reference Include="Windows.ApplicationModel.StartupTaskContract">


### PR DESCRIPTION
Avoids potential version conflicts if a newer SDK is installed