### PR TITLE
Performance/CPU enhancements on region capture forms and image editor

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -131,7 +131,7 @@ namespace ShareX.ScreenCaptureLib
             timerFPS = new Stopwatch();
             regionAnimation = new RectangleAnimation()
             {
-                Duration = TimeSpan.FromMilliseconds(1000)
+                Duration = TimeSpan.FromMilliseconds(200)
             };
 
             if (IsEditorMode && Options.ShowEditorPanTip)

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -620,7 +620,6 @@ namespace ShareX.ScreenCaptureLib
             idleTimer.Start();
         }
 
-
         private void MonitorKey(int index)
         {
             if (index == 0)

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureLightForm.cs
@@ -181,10 +181,15 @@ namespace ShareX.ScreenCaptureLib
 
         private void timer_Tick(object sender, EventArgs e)
         {
+            var previousSelectionRectangle = SelectionRectangle;
             currentPosition = CaptureHelpers.GetCursorPosition();
             SelectionRectangle = CaptureHelpers.CreateRectangle(positionOnClick.X, positionOnClick.Y, currentPosition.X, currentPosition.Y);
 
-            Refresh();
+            // Only refresh if the selection has changed
+            if (previousSelectionRectangle != SelectionRectangle)
+            {
+                Refresh();
+            }
         }
 
         protected override void OnPaintBackground(PaintEventArgs e)

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureTransparentForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureTransparentForm.cs
@@ -180,6 +180,12 @@ namespace ShareX.ScreenCaptureLib
 
         private void UpdateBackgroundImage()
         {
+            if (PreviousSelectionRectangle0Based == SelectionRectangle0Based)
+            {
+                // Don't update if the selection hasn't changed
+                return;
+            }
+
             // Clear previous rectangle selection
             gBackgroundImage.DrawRectangleProper(clearPen, PreviousSelectionRectangle0Based);
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -397,6 +397,8 @@ namespace ShareX.ScreenCaptureLib
                 tsmiShowMagnifier.Checked = Options.ShowMagnifier;
                 tslnudMagnifierPixelCount.Content.Value = Options.MagnifierPixelCount;
             }
+
+            Form.RegionCaptureForm_MouseMove(sender, e);
         }
 
         private void form_KeyDown(object sender, KeyEventArgs e)

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -78,6 +78,7 @@ namespace ShareX.ScreenCaptureLib
             menuForm.LocationChanged += MenuForm_LocationChanged;
             menuForm.GotFocus += MenuForm_GotFocus;
             menuForm.LostFocus += MenuForm_LostFocus;
+            menuForm.MouseMove += Form.RegionCaptureForm_MouseMove;
 
             menuForm.SuspendLayout();
 
@@ -97,6 +98,7 @@ namespace ShareX.ScreenCaptureLib
             };
 
             tsMain.MouseLeave += TsMain_MouseLeave;
+            tsMain.MouseMove += Form.RegionCaptureForm_MouseMove;
 
             tsMain.SuspendLayout();
 
@@ -1021,6 +1023,7 @@ namespace ShareX.ScreenCaptureLib
                     };
 
                     tsi.MouseLeave += TsMain_MouseLeave;
+                    tsi.MouseMove += Form.RegionCaptureForm_MouseMove;
                 }
             }
 


### PR DESCRIPTION
### Region Capture Form & Image Editor
Instead of invalidating the form repeatedly on every OnPaint (a high intensity infinite loop, which chews up an entire CPU core) this change throttles invalidate calls to a maximum of once every 16ms (~60fps) when there is user input, and once every 250ms (~4fps) when there is no user input and repainting is not necessary.

The Pause and Resume on lost/got focus events still work as they did before.

### Light & Transparent Region Capture**
By checking if the selected region has changed, we can avoid reprocessing/redrawing the screen, saving CPU usage too.

---

I realize these changes slightly affect the display of the dotted border, but I think the CPU reduction is worth it for users who use slow devices or rely on battery power. Let me know if you think any amendments are needed.