### PR TITLE
Add support for Intel QuickSync

### DIFF
--- a/ShareX.ScreenCaptureLib/Enums.cs
+++ b/ShareX.ScreenCaptureLib/Enums.cs
@@ -105,7 +105,11 @@ namespace ShareX.ScreenCaptureLib
         [Description("H.264 AMF (mp4)")]
         h264_amf,
         [Description("HEVC AMF (mp4)")]
-        hevc_amf
+        hevc_amf,
+        [Description("H.264 QuickSync (mp4)")]
+        h264_qsv,
+        [Description("HEVC QuickSync (mp4)")]
+        hevc_qsv
     }
 
     public enum FFmpegPreset
@@ -178,6 +182,24 @@ namespace ShareX.ScreenCaptureLib
         balanced = 1,
         [Description("Prefer Quality")]
         quality = 2
+    }
+
+    public enum FFmpegQSVPreset
+    {
+        [Description("Very fast")]
+        veryfast,
+        [Description("Faster")]
+        faster,
+        [Description("Fast")]
+        fast,
+        [Description("Medium")]
+        medium,
+        [Description("Slow")]
+        slow,
+        [Description("Slower")]
+        slower,
+        [Description("Very slow")]
+        veryslow
     }
 
     public enum FFmpegTune

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
@@ -71,6 +71,11 @@
             this.tpGIF = new System.Windows.Forms.TabPage();
             this.lblGIFDither = new System.Windows.Forms.Label();
             this.lblGIFStatsMode = new System.Windows.Forms.Label();
+            this.tbAMF = new System.Windows.Forms.TabPage();
+            this.cbAMFQuality = new System.Windows.Forms.ComboBox();
+            this.lblAMFQuality = new System.Windows.Forms.Label();
+            this.cbAMFUsage = new System.Windows.Forms.ComboBox();
+            this.lblAMFUsage = new System.Windows.Forms.Label();
             this.btnTest = new System.Windows.Forms.Button();
             this.btnCopyPreview = new System.Windows.Forms.Button();
             this.tcFFmpegAudioCodecs = new System.Windows.Forms.TabControl();
@@ -93,11 +98,11 @@
             this.btnRefreshSources = new System.Windows.Forms.Button();
             this.gbCodecs = new System.Windows.Forms.GroupBox();
             this.eiFFmpeg = new ShareX.HelpersLib.ExportImportControl();
-            this.tbAMF = new System.Windows.Forms.TabPage();
-            this.cbAMFUsage = new System.Windows.Forms.ComboBox();
-            this.lblAMFUsage = new System.Windows.Forms.Label();
-            this.cbAMFQuality = new System.Windows.Forms.ComboBox();
-            this.lblAMFQuality = new System.Windows.Forms.Label();
+            this.tbQSV = new System.Windows.Forms.TabPage();
+            this.cbQSVPreset = new System.Windows.Forms.ComboBox();
+            this.lblQSVPreset = new System.Windows.Forms.Label();
+            this.nudQSVBitrate = new System.Windows.Forms.NumericUpDown();
+            this.lblQSVBitrate = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nudx264CRF)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudXvidQscale)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.tbVorbis_qscale)).BeginInit();
@@ -116,13 +121,15 @@
             this.tpNVENC.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNVENCBitrate)).BeginInit();
             this.tpGIF.SuspendLayout();
+            this.tbAMF.SuspendLayout();
             this.tcFFmpegAudioCodecs.SuspendLayout();
             this.tpAAC.SuspendLayout();
             this.tpVorbis.SuspendLayout();
             this.tpMP3.SuspendLayout();
             this.gbSource.SuspendLayout();
             this.gbCodecs.SuspendLayout();
-            this.tbAMF.SuspendLayout();
+            this.tbQSV.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQSVBitrate)).BeginInit();
             this.SuspendLayout();
             // 
             // lblx264CRF
@@ -363,6 +370,7 @@
             this.tcFFmpegVideoCodecs.Controls.Add(this.tpNVENC);
             this.tcFFmpegVideoCodecs.Controls.Add(this.tpGIF);
             this.tcFFmpegVideoCodecs.Controls.Add(this.tbAMF);
+            this.tcFFmpegVideoCodecs.Controls.Add(this.tbQSV);
             resources.ApplyResources(this.tcFFmpegVideoCodecs, "tcFFmpegVideoCodecs");
             this.tcFFmpegVideoCodecs.Name = "tcFFmpegVideoCodecs";
             this.tcFFmpegVideoCodecs.SelectedIndex = 0;
@@ -499,6 +507,42 @@
             // 
             resources.ApplyResources(this.lblGIFStatsMode, "lblGIFStatsMode");
             this.lblGIFStatsMode.Name = "lblGIFStatsMode";
+            // 
+            // tbAMF
+            // 
+            this.tbAMF.Controls.Add(this.cbAMFQuality);
+            this.tbAMF.Controls.Add(this.lblAMFQuality);
+            this.tbAMF.Controls.Add(this.cbAMFUsage);
+            this.tbAMF.Controls.Add(this.lblAMFUsage);
+            resources.ApplyResources(this.tbAMF, "tbAMF");
+            this.tbAMF.Name = "tbAMF";
+            this.tbAMF.UseVisualStyleBackColor = true;
+            // 
+            // cbAMFQuality
+            // 
+            this.cbAMFQuality.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbAMFQuality.FormattingEnabled = true;
+            resources.ApplyResources(this.cbAMFQuality, "cbAMFQuality");
+            this.cbAMFQuality.Name = "cbAMFQuality";
+            this.cbAMFQuality.SelectedIndexChanged += new System.EventHandler(this.cbAMFQuality_SelectedIndexChanged);
+            // 
+            // lblAMFQuality
+            // 
+            resources.ApplyResources(this.lblAMFQuality, "lblAMFQuality");
+            this.lblAMFQuality.Name = "lblAMFQuality";
+            // 
+            // cbAMFUsage
+            // 
+            this.cbAMFUsage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbAMFUsage.FormattingEnabled = true;
+            resources.ApplyResources(this.cbAMFUsage, "cbAMFUsage");
+            this.cbAMFUsage.Name = "cbAMFUsage";
+            this.cbAMFUsage.SelectedIndexChanged += new System.EventHandler(this.cbAMFUsage_SelectedIndexChanged);
+            // 
+            // lblAMFUsage
+            // 
+            resources.ApplyResources(this.lblAMFUsage, "lblAMFUsage");
+            this.lblAMFUsage.Name = "lblAMFUsage";
             // 
             // btnTest
             // 
@@ -663,41 +707,54 @@
             this.eiFFmpeg.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFFmpeg_ExportRequested);
             this.eiFFmpeg.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFFmpeg_ImportRequested);
             // 
-            // tbAMF
+            // tbQSV
             // 
-            this.tbAMF.Controls.Add(this.cbAMFQuality);
-            this.tbAMF.Controls.Add(this.lblAMFQuality);
-            this.tbAMF.Controls.Add(this.cbAMFUsage);
-            this.tbAMF.Controls.Add(this.lblAMFUsage);
-            resources.ApplyResources(this.tbAMF, "tbAMF");
-            this.tbAMF.Name = "tbAMF";
-            this.tbAMF.UseVisualStyleBackColor = true;
+            this.tbQSV.Controls.Add(this.cbQSVPreset);
+            this.tbQSV.Controls.Add(this.lblQSVPreset);
+            this.tbQSV.Controls.Add(this.nudQSVBitrate);
+            this.tbQSV.Controls.Add(this.lblQSVBitrate);
+            resources.ApplyResources(this.tbQSV, "tbQSV");
+            this.tbQSV.Name = "tbQSV";
+            this.tbQSV.UseVisualStyleBackColor = true;
             // 
-            // cbAMFUsage
+            // cbQSVPreset
             // 
-            this.cbAMFUsage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbAMFUsage.FormattingEnabled = true;
-            resources.ApplyResources(this.cbAMFUsage, "cbAMFUsage");
-            this.cbAMFUsage.Name = "cbAMFUsage";
-            this.cbAMFUsage.SelectedIndexChanged += new System.EventHandler(this.cbAMFUsage_SelectedIndexChanged);
+            this.cbQSVPreset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbQSVPreset.FormattingEnabled = true;
+            resources.ApplyResources(this.cbQSVPreset, "cbQSVPreset");
+            this.cbQSVPreset.Name = "cbQSVPreset";
+            this.cbQSVPreset.SelectedIndexChanged += new System.EventHandler(this.cbQSVPreset_SelectedIndexChanged);
             // 
-            // lblAMFUsage
+            // lblQSVPreset
             // 
-            resources.ApplyResources(this.lblAMFUsage, "lblAMFUsage");
-            this.lblAMFUsage.Name = "lblAMFUsage";
+            resources.ApplyResources(this.lblQSVPreset, "lblQSVPreset");
+            this.lblQSVPreset.Name = "lblQSVPreset";
             // 
-            // cbAMFQuality
+            // nudQSVBitrate
             // 
-            this.cbAMFQuality.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbAMFQuality.FormattingEnabled = true;
-            resources.ApplyResources(this.cbAMFQuality, "cbAMFQuality");
-            this.cbAMFQuality.Name = "cbAMFQuality";
-            this.cbAMFQuality.SelectedIndexChanged += new System.EventHandler(this.cbAMFQuality_SelectedIndexChanged);
+            resources.ApplyResources(this.nudQSVBitrate, "nudQSVBitrate");
+            this.nudQSVBitrate.Maximum = new decimal(new int[] {
+            50000,
+            0,
+            0,
+            0});
+            this.nudQSVBitrate.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.nudQSVBitrate.Name = "nudQSVBitrate";
+            this.nudQSVBitrate.Value = new decimal(new int[] {
+            3000,
+            0,
+            0,
+            0});
+            this.nudQSVBitrate.ValueChanged += new System.EventHandler(this.nudQSVBitrate_ValueChanged);
             // 
-            // lblAMFQuality
+            // lblQSVBitrate
             // 
-            resources.ApplyResources(this.lblAMFQuality, "lblAMFQuality");
-            this.lblAMFQuality.Name = "lblAMFQuality";
+            resources.ApplyResources(this.lblQSVBitrate, "lblQSVBitrate");
+            this.lblQSVBitrate.Name = "lblQSVBitrate";
             // 
             // FFmpegOptionsForm
             // 
@@ -745,6 +802,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudNVENCBitrate)).EndInit();
             this.tpGIF.ResumeLayout(false);
             this.tpGIF.PerformLayout();
+            this.tbAMF.ResumeLayout(false);
+            this.tbAMF.PerformLayout();
             this.tcFFmpegAudioCodecs.ResumeLayout(false);
             this.tpAAC.ResumeLayout(false);
             this.tpAAC.PerformLayout();
@@ -756,8 +815,9 @@
             this.gbSource.PerformLayout();
             this.gbCodecs.ResumeLayout(false);
             this.gbCodecs.PerformLayout();
-            this.tbAMF.ResumeLayout(false);
-            this.tbAMF.PerformLayout();
+            this.tbQSV.ResumeLayout(false);
+            this.tbQSV.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQSVBitrate)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -833,5 +893,10 @@
         private System.Windows.Forms.Label lblAMFUsage;
         private System.Windows.Forms.ComboBox cbAMFQuality;
         private System.Windows.Forms.Label lblAMFQuality;
+        private System.Windows.Forms.TabPage tbQSV;
+        private System.Windows.Forms.ComboBox cbQSVPreset;
+        private System.Windows.Forms.Label lblQSVPreset;
+        private System.Windows.Forms.NumericUpDown nudQSVBitrate;
+        private System.Windows.Forms.Label lblQSVBitrate;
     }
 }

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
@@ -58,6 +58,7 @@ namespace ShareX.ScreenCaptureLib
             cbGIFDither.Items.AddRange(Helpers.GetEnumDescriptions<FFmpegPaletteUseDither>());
             cbAMFUsage.Items.AddRange(Helpers.GetEnums<FFmpegAMFUsage>().Select(x => $"{x} ({x.GetDescription()})").ToArray());
             cbAMFQuality.Items.AddRange(Helpers.GetEnums<FFmpegAMFQuality>().Select(x => $"{x} ({x.GetDescription()})").ToArray());
+            cbQSVPreset.Items.AddRange(Helpers.GetEnumDescriptions<FFmpegQSVPreset>());
         }
 
         private async Task SettingsLoad()
@@ -110,6 +111,10 @@ namespace ShareX.ScreenCaptureLib
             // AMF
             cbAMFUsage.SelectedIndex = (int)Options.FFmpeg.AMF_usage;
             cbAMFQuality.SelectedIndex = (int)Options.FFmpeg.AMF_quality;
+
+            // QuickSync
+            nudQSVBitrate.SetValue(Options.FFmpeg.QSV_bitrate);
+            cbQSVPreset.SelectedIndex = (int)Options.FFmpeg.QSV_preset;
 
             // AAC
             tbAACBitrate.Value = Options.FFmpeg.AAC_bitrate / 32;
@@ -351,6 +356,10 @@ namespace ShareX.ScreenCaptureLib
                     case FFmpegVideoCodec.hevc_amf:
                         tcFFmpegVideoCodecs.SelectedIndex = 5;
                         break;
+                    case FFmpegVideoCodec.h264_qsv:
+                    case FFmpegVideoCodec.hevc_qsv:
+                        tcFFmpegVideoCodecs.SelectedIndex = 6;
+                        break;
                 }
             }
 
@@ -438,6 +447,18 @@ namespace ShareX.ScreenCaptureLib
         private void cbAMFQuality_SelectedIndexChanged(object sender, EventArgs e)
         {
             Options.FFmpeg.AMF_quality = (FFmpegAMFQuality)cbAMFQuality.SelectedIndex;
+            UpdateUI();
+        }
+
+        private void cbQSVPreset_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.QSV_preset = (FFmpegQSVPreset)cbQSVPreset.SelectedIndex;
+            UpdateUI();
+        }
+
+        private void nudQSVBitrate_ValueChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.QSV_bitrate = (int)nudQSVBitrate.Value;
             UpdateUI();
         }
 

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
@@ -1147,6 +1147,138 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
   <data name="&gt;&gt;tbAMF.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="cbQSVPreset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 13</value>
+  </data>
+  <data name="cbQSVPreset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 21</value>
+  </data>
+  <data name="cbQSVPreset.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;cbQSVPreset.Name" xml:space="preserve">
+    <value>cbQSVPreset</value>
+  </data>
+  <data name="&gt;&gt;cbQSVPreset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbQSVPreset.Parent" xml:space="preserve">
+    <value>tbQSV</value>
+  </data>
+  <data name="&gt;&gt;cbQSVPreset.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblQSVPreset.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblQSVPreset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblQSVPreset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 17</value>
+  </data>
+  <data name="lblQSVPreset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="lblQSVPreset.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblQSVPreset.Text" xml:space="preserve">
+    <value>Preset:</value>
+  </data>
+  <data name="&gt;&gt;lblQSVPreset.Name" xml:space="preserve">
+    <value>lblQSVPreset</value>
+  </data>
+  <data name="&gt;&gt;lblQSVPreset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQSVPreset.Parent" xml:space="preserve">
+    <value>tbQSV</value>
+  </data>
+  <data name="&gt;&gt;lblQSVPreset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="nudQSVBitrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 37</value>
+  </data>
+  <data name="nudQSVBitrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 20</value>
+  </data>
+  <data name="nudQSVBitrate.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="nudQSVBitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudQSVBitrate.Name" xml:space="preserve">
+    <value>nudQSVBitrate</value>
+  </data>
+  <data name="&gt;&gt;nudQSVBitrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudQSVBitrate.Parent" xml:space="preserve">
+    <value>tbQSV</value>
+  </data>
+  <data name="&gt;&gt;nudQSVBitrate.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblQSVBitrate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblQSVBitrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblQSVBitrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 41</value>
+  </data>
+  <data name="lblQSVBitrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="lblQSVBitrate.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblQSVBitrate.Text" xml:space="preserve">
+    <value>Bitrate:</value>
+  </data>
+  <data name="&gt;&gt;lblQSVBitrate.Name" xml:space="preserve">
+    <value>lblQSVBitrate</value>
+  </data>
+  <data name="&gt;&gt;lblQSVBitrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQSVBitrate.Parent" xml:space="preserve">
+    <value>tbQSV</value>
+  </data>
+  <data name="&gt;&gt;lblQSVBitrate.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tbQSV.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tbQSV.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tbQSV.Size" type="System.Drawing.Size, System.Drawing">
+    <value>304, 70</value>
+  </data>
+  <data name="tbQSV.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tbQSV.Text" xml:space="preserve">
+    <value>QuickSync</value>
+  </data>
+  <data name="&gt;&gt;tbQSV.Name" xml:space="preserve">
+    <value>tbQSV</value>
+  </data>
+  <data name="&gt;&gt;tbQSV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbQSV.Parent" xml:space="preserve">
+    <value>tcFFmpegVideoCodecs</value>
+  </data>
+  <data name="&gt;&gt;tbQSV.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <data name="tcFFmpegVideoCodecs.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 56</value>
   </data>
@@ -1832,7 +1964,7 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>eiFFmpeg</value>
   </data>
   <data name="&gt;&gt;eiFFmpeg.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.3.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=12.4.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;eiFFmpeg.Parent" xml:space="preserve">
     <value>$this</value>

--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
@@ -53,6 +53,8 @@ namespace ShareX.ScreenCaptureLib
         public FFmpegPaletteUseDither GIFDither { get; set; } = FFmpegPaletteUseDither.sierra2_4a;
         public FFmpegAMFUsage AMF_usage { get; set; } = FFmpegAMFUsage.transcoding;
         public FFmpegAMFQuality AMF_quality { get; set; } = FFmpegAMFQuality.speed;
+        public FFmpegQSVPreset QSV_preset { get; set; } = FFmpegQSVPreset.fast;
+        public int QSV_bitrate { get; set; } = 3000;
 
         // Audio
         public int AAC_bitrate { get; set; } = 128; // kbit/s
@@ -100,6 +102,8 @@ namespace ShareX.ScreenCaptureLib
                         case FFmpegVideoCodec.hevc_nvenc:
                         case FFmpegVideoCodec.h264_amf:
                         case FFmpegVideoCodec.hevc_amf:
+                        case FFmpegVideoCodec.h264_qsv:
+                        case FFmpegVideoCodec.hevc_qsv:
                             return "mp4";
                         case FFmpegVideoCodec.libvpx:
                             return "webm";

--- a/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/ScreencastOptions.cs
@@ -214,6 +214,11 @@ namespace ShareX.ScreenCaptureLib
                             args.AppendFormat("-quality {0} ", FFmpeg.AMF_quality);
                             args.AppendFormat("-pix_fmt {0} ", "yuv420p");
                             break;
+                        case FFmpegVideoCodec.h264_qsv: // https://trac.ffmpeg.org/wiki/Hardware/QuickSync
+                        case FFmpegVideoCodec.hevc_qsv:
+                            args.AppendFormat("-preset {0} ", FFmpeg.QSV_preset);
+                            args.AppendFormat("-b:v {0}k ", FFmpeg.QSV_bitrate);
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
Intel QuickSync provides hardware H.264 encoding on Intel Sandy Bridge CPUs and up and hardware H.265 encoding on Skylake CPUs and up via a dedicated die on the processor chip, being faster than CPU encoding and more power efficient than GPU encoding