### PR TITLE
Added Google Cloud Storage bucket policy only support

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/GoogleCloudStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/GoogleCloudStorage.cs
@@ -54,7 +54,8 @@ namespace ShareX.UploadersLib.FileUploaders
                 Prefix = config.GoogleCloudStorageObjectPrefix,
                 RemoveExtensionImage = config.GoogleCloudStorageRemoveExtensionImage,
                 RemoveExtensionText = config.GoogleCloudStorageRemoveExtensionText,
-                RemoveExtensionVideo = config.GoogleCloudStorageRemoveExtensionVideo
+                RemoveExtensionVideo = config.GoogleCloudStorageRemoveExtensionVideo,
+                BucketPolicyOnly = config.GoogleCloudStorageBucketPolicyOnly
             };
         }
 
@@ -69,6 +70,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public bool RemoveExtensionImage { get; set; }
         public bool RemoveExtensionText { get; set; }
         public bool RemoveExtensionVideo { get; set; }
+        public bool BucketPolicyOnly { get; set; }
 
         public OAuth2Info AuthInfo => googleAuth.AuthInfo;
 
@@ -112,16 +114,20 @@ namespace ShareX.UploadersLib.FileUploaders
 
             GoogleCloudStorageMetadata googleCloudStorageMetadata = new GoogleCloudStorageMetadata
             {
-                name = uploadPath,
-                acl = new GoogleCloudStorageAcl[]
+                name = uploadPath
+            };
+
+            if (!BucketPolicyOnly)
+            {
+                googleCloudStorageMetadata.acl = new GoogleCloudStorageAcl[]
                 {
                     new GoogleCloudStorageAcl
                     {
                         entity = "allUsers",
                         role = "READER"
                     }
-                }
-            };
+                };
+            }
 
             string serializedGoogleCloudStorageMetadata = JsonConvert.SerializeObject(googleCloudStorageMetadata);
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -5661,6 +5661,8 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblGoogleCloudStorageDomain;
         private System.Windows.Forms.TextBox txtGoogleCloudStorageObjectPrefix;
         private System.Windows.Forms.Label lblGoogleCloudStorageObjectPrefix;
+        private System.Windows.Forms.CheckBox cbGoogleCloudStorageBucketPolicyOnly;
+        private System.Windows.Forms.Label lblGoogleCloudStorageBucketPolicyOnly;
         private System.Windows.Forms.Button btnSharedFolderDuplicate;
         private System.Windows.Forms.Button btnSharedFolderRemove;
         private System.Windows.Forms.Button btnSharedFolderAdd;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -765,6 +765,7 @@ namespace ShareX.UploadersLib
             cbGoogleCloudStorageStripExtensionImage.Checked = Config.GoogleCloudStorageRemoveExtensionImage;
             cbGoogleCloudStorageStripExtensionVideo.Checked = Config.GoogleCloudStorageRemoveExtensionVideo;
             cbGoogleCloudStorageStripExtensionText.Checked = Config.GoogleCloudStorageRemoveExtensionText;
+            cbGoogleCloudStorageBucketPolicyOnly.Checked = Config.GoogleCloudStorageBucketPolicyOnly;
 
             #endregion Google Cloud Storage
         }

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -429,6 +429,7 @@ namespace ShareX.UploadersLib
         public bool GoogleCloudStorageRemoveExtensionImage = false;
         public bool GoogleCloudStorageRemoveExtensionVideo = false;
         public bool GoogleCloudStorageRemoveExtensionText = false;
+        public bool GoogleCloudStorageBucketPolicyOnly = false;
 
         #endregion Google Cloud Storage
 


### PR DESCRIPTION
This PR adds support for Google Cloud Storage's [bucket policy only](https://cloud.google.com/storage/docs/bucket-policy-only) feature.

First time working with this codebase, be gentle 😉 