### PR TITLE
Fix issues for select tool 

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
@@ -106,6 +106,22 @@ namespace ShareX.ScreenCaptureLib
         private Point tempNodePos, tempStartPos, tempEndPos;
         private Rectangle tempRectangle;
 
+
+        public bool IsHandledBySelectTool
+        {
+            get
+            {
+                switch (ShapeCategory)
+                {
+                    case ShapeCategory.Drawing:
+                    case ShapeCategory.Effect:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
         public virtual bool Intersects(Point position)
         {
             return Rectangle.Contains(position);

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -93,7 +93,8 @@ namespace ShareX.ScreenCaptureLib
                     ClearTools();
                 }
 
-                if (previousTool != ShapeType.ToolSelect && currentTool != ShapeType.ToolSelect)
+                if (previousTool != ShapeType.ToolSelect && currentTool != ShapeType.ToolSelect
+                    && CurrentShape != null && !CurrentShape.IsHandledBySelectTool)
                 {
                     DeselectCurrentShape();
                 }
@@ -879,7 +880,7 @@ namespace ShareX.ScreenCaptureLib
 
                             SelectCurrentShape();
 
-                            if (Options.SwitchToSelectionToolAfterDrawing && (shape.ShapeCategory == ShapeCategory.Drawing || shape.ShapeCategory == ShapeCategory.Effect))
+                            if (Options.SwitchToSelectionToolAfterDrawing && shape.IsHandledBySelectTool)
                             {
                                 CurrentTool = ShapeType.ToolSelect;
                             }


### PR DESCRIPTION
This is the follow up PR of #4058 where the select tool was added. This PR is supposed to fix: 

- [ ] [Bug] Crop-Tool Selection must be cleared when switching to the select tool 
- [ ] [Bug] Select-Tool Selection must be cleared when switching to any other tool 
- [ ] [Change] Make the auto-selection of tools disabled by default
- [ ] [Bug] Improper behavior regarding resizable and not resizable shapes. 