### PR TITLE
Fix issues for select tool

### DIFF
--- a/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
@@ -73,7 +73,7 @@ namespace ShareX.ScreenCaptureLib
         public bool MenuCollapsed = false;
         public Point MenuPosition = Point.Empty;
 
-        public bool SwitchToDrawingToolAfterSelection = true;
+        public bool SwitchToDrawingToolAfterSelection = false;
         public bool SwitchToSelectionToolAfterDrawing = false;
 
         // Annotation

--- a/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
@@ -106,7 +106,6 @@ namespace ShareX.ScreenCaptureLib
         private Point tempNodePos, tempStartPos, tempEndPos;
         private Rectangle tempRectangle;
 
-
         public bool IsHandledBySelectTool
         {
             get

--- a/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
@@ -106,6 +106,22 @@ namespace ShareX.ScreenCaptureLib
         private Point tempNodePos, tempStartPos, tempEndPos;
         private Rectangle tempRectangle;
 
+
+        public bool IsHandledBySelectTool
+        {
+            get
+            {
+                switch (ShapeCategory)
+                {
+                    case ShapeCategory.Drawing:
+                    case ShapeCategory.Effect:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
         public virtual bool Intersects(Point position)
         {
             return Rectangle.Contains(position);

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -72,7 +72,6 @@ namespace ShareX.ScreenCaptureLib
             {
                 if (currentTool == value) return;
 
-                ShapeType previousTool = currentTool;
                 currentTool = value;
 
                 if (Form.IsAnnotationMode)
@@ -96,9 +95,12 @@ namespace ShareX.ScreenCaptureLib
                 if (CurrentShape != null)
                 {
                     // do not keep selection if select tool does not handle it
-                    if (currentTool == ShapeType.ToolSelect && !CurrentShape.IsHandledBySelectTool)
+                    if (currentTool == ShapeType.ToolSelect)
                     {
-                        DeselectCurrentShape();
+                        if (!CurrentShape.IsHandledBySelectTool)
+                        {
+                            DeselectCurrentShape();
+                        }
                     }
                     // do not keep selection if we switch away from a tool and the selected shape does not match the new type
                     else if (CurrentShape.ShapeType != currentTool)

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -96,12 +96,12 @@ namespace ShareX.ScreenCaptureLib
                 if (CurrentShape != null)
                 {
                     // do not keep selection if select tool does not handle it
-                    if ((currentTool == ShapeType.ToolSelect && !CurrentShape.IsHandledBySelectTool))
+                    if (currentTool == ShapeType.ToolSelect && !CurrentShape.IsHandledBySelectTool)
                     {
                         DeselectCurrentShape();
                     }
-                    // do not keep selection if we switch away from select tool and the selected shape does not match the new type
-                    else if (previousTool == ShapeType.ToolSelect && CurrentShape.ShapeType != currentTool)
+                    // do not keep selection if we switch away from a tool and the selected shape does not match the new type
+                    else if (CurrentShape.ShapeType != currentTool)
                     {
                         DeselectCurrentShape();
                     }
@@ -820,6 +820,7 @@ namespace ShareX.ScreenCaptureLib
 
             if (shape != null && shape.IsSelectable) // Select shape
             {
+                DeselectCurrentShape();
                 IsMoving = true;
                 shape.OnMoving();
                 Form.Cursor = Cursors.SizeAll;

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -93,10 +93,18 @@ namespace ShareX.ScreenCaptureLib
                     ClearTools();
                 }
 
-                if (previousTool != ShapeType.ToolSelect && currentTool != ShapeType.ToolSelect
-                    && CurrentShape != null && !CurrentShape.IsHandledBySelectTool)
+                if (CurrentShape != null)
                 {
-                    DeselectCurrentShape();
+                    // do not keep selection if select tool does not handle it
+                    if ((currentTool == ShapeType.ToolSelect && !CurrentShape.IsHandledBySelectTool))
+                    {
+                        DeselectCurrentShape();
+                    }
+                    // do not keep selection if we switch away from select tool and the selected shape does not match the new type
+                    else if (previousTool == ShapeType.ToolSelect && CurrentShape.ShapeType != currentTool)
+                    {
+                        DeselectCurrentShape();
+                    }
                 }
 
                 OnCurrentShapeTypeChanged(currentTool);

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -93,7 +93,8 @@ namespace ShareX.ScreenCaptureLib
                     ClearTools();
                 }
 
-                if (previousTool != ShapeType.ToolSelect && currentTool != ShapeType.ToolSelect)
+                if (previousTool != ShapeType.ToolSelect && currentTool != ShapeType.ToolSelect
+                    && CurrentShape != null && !CurrentShape.IsHandledBySelectTool)
                 {
                     DeselectCurrentShape();
                 }
@@ -879,7 +880,7 @@ namespace ShareX.ScreenCaptureLib
 
                             SelectCurrentShape();
 
-                            if (Options.SwitchToSelectionToolAfterDrawing && (shape.ShapeCategory == ShapeCategory.Drawing || shape.ShapeCategory == ShapeCategory.Effect))
+                            if (Options.SwitchToSelectionToolAfterDrawing && shape.IsHandledBySelectTool)
                             {
                                 CurrentTool = ShapeType.ToolSelect;
                             }


### PR DESCRIPTION
This is the follow up PR of #4058 where the select tool was added. This PR is supposed to fix: 

- [x] [Bug] Crop-Tool Selection must be cleared when switching to the select tool 
- [x] [Bug] Select-Tool Selection must be cleared when switching to any other tool 
- [x] [Bug] Improper behavior regarding resizable and not resizable shapes. 
- [x] [Change] Make the auto-selection of tools disabled by default
- [x] [Bug] Auto-Switch to Select tool after drawing: Shape should stay selected after drawing. 

**Tested Scenarios:**

1.  _with switch to select tool option active_: Fully use crop tool -> Cropping not cancelled while drawing region 
2. _with switch to select tool option active_: Cancel crop tool -> Crop selection is removed when switching to any other tool. 
3. Switching to matching shape tool after selection of a shape with select tool -> Selection is kept
4. Switching to another shape tool after selection of a shape with select tool -> Selection is cleared
5. Switching to another shape tool after selection of a shape with matching tool  -> Selection is cleared
6. Selecting different shape types (resizable/not-resizable) -> resize nodes are properly cleared. 
7. _with switch to select tool option active_: Draw any shaped -> Selection is kept and select tool is activated. 

