### PR TITLE
Parallelize matrix convolution and consider transparency in gaussian blurs

### DIFF
--- a/ShareX.HelpersLib/ConvolutionMatrix.cs
+++ b/ShareX.HelpersLib/ConvolutionMatrix.cs
@@ -33,6 +33,8 @@ namespace ShareX.HelpersLib
         public int Height => matrix.GetLength(0);
         public byte Offset { get; set; }
 
+        public bool ConsiderAlpha { get; set; }
+
         public ConvolutionMatrix() : this(3)
         {
         }

--- a/ShareX.ImageEffectsLib/Filters/GaussianBlur.cs
+++ b/ShareX.ImageEffectsLib/Filters/GaussianBlur.cs
@@ -67,7 +67,11 @@ namespace ShareX.ImageEffectsLib
         {
             ConvolutionMatrix kernelHoriz = ConvolutionMatrixManager.GaussianBlur(1, size, sigma);
 
-            ConvolutionMatrix kernelVert = new ConvolutionMatrix(size, 1);
+            ConvolutionMatrix kernelVert = new ConvolutionMatrix(size, 1)
+            {
+                ConsiderAlpha = kernelHoriz.ConsiderAlpha
+            };
+
             for (int i = 0; i < size; i++)
             {
                 kernelVert[i, 0] = kernelHoriz[0, i];


### PR DESCRIPTION
This increases performance massively when applying matrices on high resolution images: doing a Gaussian blur with size 3 on a 6550x4371 image reduced processing time from 41 seconds to 22 seconds on my dual core laptop CPU, probably even more on quad, hexa or octo core.

The second changes fixes blur being unexpectedly cut off on the normal image frame instead of extending over it when you had a strong blur effect on an image which included alpha:
![image](https://user-images.githubusercontent.com/6440374/56873823-29c91180-6a03-11e9-9e82-52957d685aaa.png)
![image](https://user-images.githubusercontent.com/6440374/56873782-e2db1c00-6a02-11e9-8b15-342faa21bc8e.png)
