### PR TITLE
Updated Simplified Chinese Translation.

### DIFF
--- a/ShareX.HelpersLib/Controls/ExportImportControl.zh-CN.resx
+++ b/ShareX.HelpersLib/Controls/ExportImportControl.zh-CN.resx
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -138,6 +139,6 @@
     <value>从文件...</value>
   </data>
   <data name="tsmiImportURL.Text" xml:space="preserve">
-    <value>从URL...</value>
+    <value>从 URL...</value>
   </data>
 </root>

--- a/ShareX.HelpersLib/Forms/ColorPickerForm.zh-CN.resx
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.zh-CN.resx
@@ -126,47 +126,44 @@
   <data name="btnOK.Text" xml:space="preserve">
     <value>确定</value>
   </data>
-  <data name="lblAlpha.Text" xml:space="preserve">
-    <value>Alpha:</value>
-  </data>
   <data name="lblCyan.Text" xml:space="preserve">
-    <value>青色:</value>
+    <value>青色：</value>
   </data>
   <data name="lblDecimal.Text" xml:space="preserve">
-    <value>十进制:</value>
+    <value>十进制：</value>
   </data>
   <data name="lblKey.Text" xml:space="preserve">
-    <value>键:</value>
+    <value>键：</value>
   </data>
   <data name="lblMagenta.Text" xml:space="preserve">
-    <value>品红:</value>
+    <value>品红：</value>
   </data>
   <data name="lblNew.Text" xml:space="preserve">
-    <value>新:</value>
+    <value>新：</value>
   </data>
   <data name="lblOld.Text" xml:space="preserve">
-    <value>旧:</value>
+    <value>原：</value>
   </data>
   <data name="lblYellow.Text" xml:space="preserve">
-    <value>黄色:</value>
+    <value>黄色：</value>
   </data>
   <data name="rbBlue.Text" xml:space="preserve">
-    <value>蓝色:</value>
+    <value>蓝色：</value>
   </data>
   <data name="rbBrightness.Text" xml:space="preserve">
-    <value>亮度:</value>
+    <value>亮度：</value>
   </data>
   <data name="rbGreen.Text" xml:space="preserve">
-    <value>绿色:</value>
+    <value>绿色：</value>
   </data>
   <data name="rbHue.Text" xml:space="preserve">
-    <value>色调:</value>
+    <value>色调：</value>
   </data>
   <data name="rbRed.Text" xml:space="preserve">
-    <value>红色:</value>
+    <value>红色：</value>
   </data>
   <data name="rbSaturation.Text" xml:space="preserve">
-    <value>饱和度:</value>
+    <value>饱和度：</value>
   </data>
   <data name="cbTransparent.ToolTip" xml:space="preserve">
     <value>透明</value>
@@ -181,28 +178,28 @@
     <value>从屏幕选取颜色</value>
   </data>
   <data name="lblHex.Text" xml:space="preserve">
-    <value>16进制：</value>
+    <value>十六进制：</value>
   </data>
   <data name="lblCursorPosition.Text" xml:space="preserve">
     <value>指针位置：</value>
   </data>
   <data name="tsmiCopyRGB.Text" xml:space="preserve">
-    <value>复制RGB</value>
+    <value>复制 RGB</value>
   </data>
   <data name="tsmiCopyPosition.Text" xml:space="preserve">
     <value>复制位置</value>
   </data>
   <data name="tsmiCopyHSB.Text" xml:space="preserve">
-    <value>复制HSB</value>
+    <value>复制 HSB</value>
   </data>
   <data name="tsmiCopyHexadecimal.Text" xml:space="preserve">
-    <value>复制16进制</value>
+    <value>复制十六进制</value>
   </data>
   <data name="tsmiCopyDecimal.Text" xml:space="preserve">
     <value>复制十进制</value>
   </data>
   <data name="tsmiCopyCMYK.Text" xml:space="preserve">
-    <value>复制CMYK</value>
+    <value>复制 CMYK</value>
   </data>
   <data name="tsmiCopyAll.Text" xml:space="preserve">
     <value>复制全部</value>
@@ -212,5 +209,8 @@
   </data>
   <data name="btnClose.Text" xml:space="preserve">
     <value>关闭</value>
+  </data>
+  <data name="lblAlpha.Text" xml:space="preserve">
+    <value>Alpha：</value>
   </data>
 </root>

--- a/ShareX.HelpersLib/Forms/DebugForm.zh-CN.resx
+++ b/ShareX.HelpersLib/Forms/DebugForm.zh-CN.resx
@@ -132,4 +132,7 @@
   <data name="lblRunningFrom.Text" xml:space="preserve">
     <value>启动路径：</value>
   </data>
+  <data name="btnUploadLog.Text" xml:space="preserve">
+    <value>上传日志...</value>
+  </data>
 </root>

--- a/ShareX.HelpersLib/Forms/ErrorForm.zh-CN.resx
+++ b/ShareX.HelpersLib/Forms/ErrorForm.zh-CN.resx
@@ -127,14 +127,14 @@
     <value>确定</value>
   </data>
   <data name="btnOpenLogFile.Text" xml:space="preserve">
-    <value>打开日志文件</value>
+    <value>打开日志文件...</value>
   </data>
   <data name="btnSendBugReport.Text" xml:space="preserve">
-    <value>发送错误报告</value>
+    <value>发送错误报告...</value>
   </data>
   <data name="lblErrorMessage.Text" xml:space="preserve">
     <value>错误
-错误2</value>
+错误 2</value>
   </data>
   <data name="btnOK.Text" xml:space="preserve">
     <value>OK</value>

--- a/ShareX.HelpersLib/Forms/MonitorTestForm.zh-CN.resx
+++ b/ShareX.HelpersLib/Forms/MonitorTestForm.zh-CN.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>显示器测试</value>
+    <value>ShareX - 显示器测试</value>
   </data>
   <data name="btnClose.Text" xml:space="preserve">
     <value>关闭</value>
@@ -127,19 +127,19 @@
     <value>颜色对话框...</value>
   </data>
   <data name="btnGradientColor1.Text" xml:space="preserve">
-    <value>颜色1</value>
+    <value>颜色 1</value>
   </data>
   <data name="btnGradientColor2.Text" xml:space="preserve">
-    <value>颜色2</value>
+    <value>颜色 2</value>
   </data>
   <data name="cbShapes.Items" xml:space="preserve">
-    <value>检查</value>
-  </data>
-  <data name="cbShapes.Items1" xml:space="preserve">
     <value>水平线</value>
   </data>
-  <data name="cbShapes.Items2" xml:space="preserve">
+  <data name="cbShapes.Items1" xml:space="preserve">
     <value>垂直线</value>
+  </data>
+  <data name="cbShapes.Items2" xml:space="preserve">
+    <value>网格</value>
   </data>
   <data name="lblShapeSize.Text" xml:space="preserve">
     <value>尺寸：</value>
@@ -148,7 +148,7 @@
     <value>您可以点击外侧隐藏/显示此面板</value>
   </data>
   <data name="rbBlackWhite.Text" xml:space="preserve">
-    <value>黑色,  白色：</value>
+    <value>黑色，白色：</value>
   </data>
   <data name="rbGradient.Text" xml:space="preserve">
     <value>梯度：</value>

--- a/ShareX.HelpersLib/Forms/PrintForm.zh-CN.resx
+++ b/ShareX.HelpersLib/Forms/PrintForm.zh-CN.resx
@@ -130,7 +130,7 @@
     <value>预览...</value>
   </data>
   <data name="cbAllowEnlarge.Text" xml:space="preserve">
-    <value>运行图像被放大</value>
+    <value>允许图像被放大</value>
   </data>
   <data name="cbAutoRotate.Text" xml:space="preserve">
     <value>自动旋转图像</value>

--- a/ShareX.HelpersLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.HelpersLib/Properties/Resources.zh-CN.resx
@@ -121,28 +121,28 @@
     <value>文件路径</value>
   </data>
   <data name="ActionsCodeMenuEntry_OutputFilePath_File_path_without_extension____Output_file_name_extension_" xml:space="preserve">
-    <value>文件路径没有扩展名+"输出文件的扩展名"</value>
+    <value>无扩展名的路径 + "输出文件的扩展名"</value>
   </data>
   <data name="CssFileNameEditor_EditValue_Browse_for_a_Cascading_Style_Sheet___" xml:space="preserve">
-    <value>浏览层叠样式表...</value>
+    <value>浏览 CSS...</value>
   </data>
   <data name="Stop" xml:space="preserve">
     <value>停止</value>
   </data>
   <data name="ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__Image__Size___0_x_1__" xml:space="preserve">
-    <value>剪贴板中的内容:图片（尺寸大小: {0} X {1}）</value>
+    <value>剪贴板中的内容：图片（尺寸大小: {0} X {1}）</value>
   </data>
   <data name="ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__Text__Length___0__" xml:space="preserve">
-    <value>剪贴板中的内容:文本（长度: {0}）</value>
+    <value>剪贴板中的内容：文本（长度: {0}）</value>
   </data>
   <data name="ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_content__File__Count___0__" xml:space="preserve">
-    <value>剪贴板中的内容:文件（计数: {0}）</value>
+    <value>剪贴板中的内容：文件（计数: {0}）</value>
   </data>
   <data name="ClipboardContentViewer_ClipboardContentViewer_Load_Clipboard_is_empty_or_contains_unknown_data_" xml:space="preserve">
     <value>剪贴板为空或包含未知数据</value>
   </data>
   <data name="PrintTextForm_LoadSettings_Name___0___Size___1_" xml:space="preserve">
-    <value>名称: {0}, 大小: {1}</value>
+    <value>名称: {0}，大小: {1}</value>
   </data>
   <data name="UpdateCheckerLabel_UpdateControls_Update_check_failed" xml:space="preserve">
     <value>检查更新失败</value>
@@ -193,22 +193,22 @@
     <value>否</value>
   </data>
   <data name="HSB_ToString_" xml:space="preserve">
-    <value>色调: {0:0.0}度, 饱和度: {1:0.0}%, 亮度: {2:0.0}%</value>
+    <value>色调: {0:0.0}度，饱和度: {1:0.0}%，亮度: {2:0.0}%</value>
   </data>
   <data name="CMYK_ToString_Cyan___0_0_0____Magenta___1_0_0____Yellow___2_0_0____Key___3_0_0__" xml:space="preserve">
-    <value>青色: {0:0.0}%, 品红: {1:0.0}%, 黄色: {2:0.0}%, 键: {3:0.0}%</value>
+    <value>青色: {0:0.0}%，品红: {1:0.0}%，黄色: {2:0.0}%, 键: {3:0.0}%</value>
   </data>
   <data name="ExportImportControl_Deserialize_Import_failed_" xml:space="preserve">
     <value>导入失败</value>
   </data>
   <data name="DNSChangerForm_btnSave_Click_DNS_successfully_set_" xml:space="preserve">
-    <value>DNS设置成功。</value>
+    <value>DNS 设置成功。</value>
   </data>
   <data name="DNSChangerForm_btnSave_Click_DNS_successfully_set__Reboot_is_required_" xml:space="preserve">
     <value>DNS设置成功，需要重新启动。</value>
   </data>
   <data name="DNSChangerForm_btnSave_Click_Setting_DNS_failed_with_error_code_" xml:space="preserve">
-    <value>DNS设置失败，错误代码:</value>
+    <value>DNS设置失败，错误代码：</value>
   </data>
   <data name="DNSChangerForm_btnSave_Click_Setting_DNS_failed_" xml:space="preserve">
     <value>DNS设置失败。</value>
@@ -217,9 +217,9 @@
     <value>状态: {0}</value>
   </data>
   <data name="DownloaderForm_ChangeProgress_Progress" xml:space="preserve">
-    <value>进度: {0:0.0}%
-下载速度: {1:0.0} KB/s
-文件大小: {2:n0} / {3:n0} KB</value>
+    <value>进度：{0:0.0}%
+下载速度：{1:0.0} KB/s
+文件大小：{2:n0} / {3:n0} KB</value>
   </data>
   <data name="MyPictureBox_LoadImageAsync_Loading_image___" xml:space="preserve">
     <value>图片加载中...</value>
@@ -243,10 +243,10 @@
     <value>下载中</value>
   </data>
   <data name="DownloaderForm_StartDownload_Getting_file_size_" xml:space="preserve">
-    <value>获取文件大小中</value>
+    <value>正在文件大小。</value>
   </data>
   <data name="MyPictureBox_pbMain_LoadProgressChanged_Loading_image___0__" xml:space="preserve">
-    <value>加载图像:{0}%</value>
+    <value>加载图像：{0}%</value>
   </data>
   <data name="DownloaderForm_fileDownloader_DownloadCompleted_Download_completed_" xml:space="preserve">
     <value>下载完成</value>
@@ -255,22 +255,22 @@
     <value>安装</value>
   </data>
   <data name="Helpers_OpenFolder_Folder_not_exist_" xml:space="preserve">
-    <value>文件夹不存在:</value>
+    <value>文件夹不存在：</value>
   </data>
   <data name="Helpers_DownloadString_Download_failed_" xml:space="preserve">
     <value>下载失败:</value>
   </data>
   <data name="GIFQuality_Bit4" xml:space="preserve">
-    <value>16色</value>
+    <value>16 色（八叉树色彩量化）</value>
   </data>
   <data name="GIFQuality_Bit8" xml:space="preserve">
-    <value>256色（编码慢, 但质量更好）</value>
+    <value>256 色（编码慢，但质量更好）</value>
   </data>
   <data name="GIFQuality_Default" xml:space="preserve">
-    <value>默认.NET编码（编码快速，但质量一般）</value>
+    <value>默认 .NET 编码（编码快速，但质量一般）</value>
   </data>
   <data name="GIFQuality_Grayscale" xml:space="preserve">
-    <value>灰度256色</value>
+    <value>灰度 256 色（调色板色彩量化）</value>
   </data>
   <data name="ProxyMethod_Automatic" xml:space="preserve">
     <value>自动</value>
@@ -297,7 +297,7 @@
     <value>从剪贴板内容查看器上传</value>
   </data>
   <data name="HotkeyType_DragDropUpload" xml:space="preserve">
-    <value>拖拽上传</value>
+    <value>拖放上传</value>
   </data>
   <data name="HotkeyType_FileUpload" xml:space="preserve">
     <value>上传文件</value>
@@ -306,7 +306,7 @@
     <value>上传文件夹</value>
   </data>
   <data name="HotkeyType_FTPClient" xml:space="preserve">
-    <value>FTP客户端</value>
+    <value>FTP 客户端</value>
   </data>
   <data name="HotkeyType_HashCheck" xml:space="preserve">
     <value>哈希（Hash）检查</value>
@@ -351,16 +351,16 @@
     <value>停止所有活动上传</value>
   </data>
   <data name="HotkeyType_TweetMessage" xml:space="preserve">
-    <value>Tweet消息</value>
+    <value>Tweet 消息</value>
   </data>
   <data name="HotkeyType_UploadURL" xml:space="preserve">
-    <value>从URL上传</value>
+    <value>从 URL 上传</value>
   </data>
   <data name="FileDestination_CustomFileUploader" xml:space="preserve">
     <value>自定义文件上传</value>
   </data>
   <data name="FileDestination_Email" xml:space="preserve">
-    <value>邮箱</value>
+    <value>电子邮箱</value>
   </data>
   <data name="FileDestination_SharedFolder" xml:space="preserve">
     <value>共享文件夹</value>
@@ -375,7 +375,7 @@
     <value>响应头</value>
   </data>
   <data name="ResponseType_RedirectionURL" xml:space="preserve">
-    <value>重定向URL</value>
+    <value>重定向 URL</value>
   </data>
   <data name="ResponseType_Text" xml:space="preserve">
     <value>响应文本</value>
@@ -387,7 +387,7 @@
     <value>文件上传</value>
   </data>
   <data name="URLSharingServices_Email" xml:space="preserve">
-    <value>邮箱</value>
+    <value>电子邮箱</value>
   </data>
   <data name="UrlShortenerType_CustomURLShortener" xml:space="preserve">
     <value>自定义URL短链</value>
@@ -432,22 +432,22 @@
     <value>上传图片</value>
   </data>
   <data name="AfterUploadTasks_CopyURLToClipboard" xml:space="preserve">
-    <value>URL复制到剪贴板</value>
+    <value>URL 复制到剪贴板</value>
   </data>
   <data name="AfterUploadTasks_OpenURL" xml:space="preserve">
     <value>打开网址</value>
   </data>
   <data name="AfterUploadTasks_ShareURL" xml:space="preserve">
-    <value>分享网址</value>
+    <value>分享 URL</value>
   </data>
   <data name="AfterUploadTasks_ShowQRCode" xml:space="preserve">
-    <value>显示二维码</value>
+    <value>显示二维码窗口</value>
   </data>
   <data name="AfterUploadTasks_UseURLShortener" xml:space="preserve">
-    <value>缩短URL</value>
+    <value>缩短 URL</value>
   </data>
   <data name="FileExistAction_Ask" xml:space="preserve">
-    <value>请问该怎么办</value>
+    <value>询问</value>
   </data>
   <data name="FileExistAction_Cancel" xml:space="preserve">
     <value>不保存</value>
@@ -465,7 +465,7 @@
     <value>不显示任何内容</value>
   </data>
   <data name="PopUpNotificationType_ToastNotification" xml:space="preserve">
-    <value>显示与预览Toast通知</value>
+    <value>显示并预览 Toast 通知</value>
   </data>
   <data name="SupportedLanguage_Automatic" xml:space="preserve">
     <value>自动</value>
@@ -508,7 +508,7 @@
     <value>.NET（低质量）</value>
   </data>
   <data name="ScreenRecordGIFEncoding_OctreeQuantizer" xml:space="preserve">
-    <value>Octree quantizer（中等质量）</value>
+    <value>八叉树色彩量化（中等质量）</value>
   </data>
   <data name="HotkeyType_ActiveMonitor_Category" xml:space="preserve">
     <value>屏幕捕捉</value>
@@ -649,7 +649,7 @@
     <value>其他</value>
   </data>
   <data name="ReplCodeMenuEntry_guid_Random_guid" xml:space="preserve">
-    <value>随机GUID</value>
+    <value>随机 GUID</value>
   </data>
   <data name="ReplCodeMenuCategory_Date_and_Time" xml:space="preserve">
     <value>日期时间</value>
@@ -725,7 +725,7 @@
     <value>图像高度</value>
   </data>
   <data name="ReplCodeMenuEntry_i_Auto_increment_number" xml:space="preserve">
-    <value>自动递增数</value>
+    <value>自动递增数，使用 {n} 补零</value>
   </data>
   <data name="ReplCodeMenuEntry_mi_Current_minute" xml:space="preserve">
     <value>当前分</value>
@@ -743,10 +743,10 @@
     <value>当前毫秒</value>
   </data>
   <data name="ReplCodeMenuEntry_n_New_line" xml:space="preserve">
-    <value>新线</value>
+    <value>新线条</value>
   </data>
   <data name="ReplCodeMenuEntry_pm_Gets_AM_PM" xml:space="preserve">
-    <value>获取AM/PM</value>
+    <value>获取 AM/PM</value>
   </data>
   <data name="ReplCodeMenuEntry_pn_Process_name_of_active_window" xml:space="preserve">
     <value>活动窗口的进程名</value>
@@ -755,7 +755,7 @@
     <value>随机字符</value>
   </data>
   <data name="ReplCodeMenuEntry_rn_Random_number_0_to_9" xml:space="preserve">
-    <value>随机数0至9</value>
+    <value>随机数 0 至 9</value>
   </data>
   <data name="ReplCodeMenuEntry_s_Current_second" xml:space="preserve">
     <value>当前秒</value>
@@ -770,7 +770,7 @@
     <value>用户名</value>
   </data>
   <data name="ReplCodeMenuEntry_unix_Unix_timestamp" xml:space="preserve">
-    <value>Unix时间戳</value>
+    <value>Unix 时间戳</value>
   </data>
   <data name="ReplCodeMenuEntry_w_Current_week_name__Local_language_" xml:space="preserve">
     <value>当前周（本地语言）</value>
@@ -785,7 +785,7 @@
     <value>当前年</value>
   </data>
   <data name="ReplCodeMenuEntry_yy_Current_year__2_digits_" xml:space="preserve">
-    <value>当前年（2位数字）</value>
+    <value>当前年（2 位数字）</value>
   </data>
   <data name="AfterCaptureTasks_ShowQuickTaskMenu" xml:space="preserve">
     <value>显示快速任务菜单</value>
@@ -797,7 +797,7 @@
     <value>打开历史图片</value>
   </data>
   <data name="HotkeyType_OpenImageHistory_Category" xml:space="preserve">
-    <value>其他</value>
+    <value>其它</value>
   </data>
   <data name="HotkeyType_OpenHistory_Category" xml:space="preserve">
     <value>其他</value>
@@ -839,7 +839,7 @@
     <value>屏幕捕捉</value>
   </data>
   <data name="RegionCaptureAction_CancelCapture" xml:space="preserve">
-    <value>屏幕捕捉</value>
+    <value>取消捕获</value>
   </data>
   <data name="RegionCaptureAction_CaptureActiveMonitor" xml:space="preserve">
     <value>捕捉活动显示器</value>
@@ -860,28 +860,28 @@
     <value>互换工具类型</value>
   </data>
   <data name="ShapeType_DrawingArrow" xml:space="preserve">
-    <value>绘图：箭头</value>
+    <value>绘图：箭头 (A)</value>
   </data>
   <data name="ShapeType_EffectBlur" xml:space="preserve">
-    <value>效果：朦胧</value>
+    <value>效果：模糊 (B)</value>
   </data>
   <data name="ShapeType_DrawingEllipse" xml:space="preserve">
-    <value>绘图：椭圆</value>
+    <value>绘图：椭圆 (E)</value>
   </data>
   <data name="ShapeType_EffectHighlight" xml:space="preserve">
-    <value>效果：高亮</value>
+    <value>效果：高亮 (H)</value>
   </data>
   <data name="ShapeType_DrawingLine" xml:space="preserve">
-    <value>绘图：线条</value>
+    <value>绘图：线条 (L)</value>
   </data>
   <data name="ShapeType_EffectPixelate" xml:space="preserve">
-    <value>效果：马赛克</value>
+    <value>效果：马赛克 (P)</value>
   </data>
   <data name="ShapeType_DrawingRectangle" xml:space="preserve">
-    <value>绘图：矩形</value>
+    <value>绘图：矩形 (R)</value>
   </data>
   <data name="ShapeType_DrawingStep" xml:space="preserve">
-    <value>绘图：序号</value>
+    <value>绘图：序号 (I)</value>
   </data>
   <data name="ShapeType_RegionEllipse" xml:space="preserve">
     <value>区域：椭圆形</value>
@@ -893,10 +893,10 @@
     <value>绘图：画笔</value>
   </data>
   <data name="ShapeType_DrawingImage" xml:space="preserve">
-    <value>绘图：图片</value>
+    <value>绘图：图片文件</value>
   </data>
   <data name="ShapeType_RegionFreehand" xml:space="preserve">
-    <value>区域：画笔</value>
+    <value>区域：自由</value>
   </data>
   <data name="HotkeyType_AbortScreenRecording_Category" xml:space="preserve">
     <value>屏幕录制</value>
@@ -932,7 +932,7 @@
     <value>发送滚动消息至窗口或控件</value>
   </data>
   <data name="ScrollingCaptureScrollTopMethod_All" xml:space="preserve">
-    <value>先模拟按下“Home”键，然后发送滚动至消息上方</value>
+    <value>先模拟按下“Home”键，然后发送向上滚动消息</value>
   </data>
   <data name="ScrollingCaptureScrollTopMethod_None" xml:space="preserve">
     <value>禁用滚动至顶部</value>
@@ -941,37 +941,37 @@
     <value>发送滚动消息至顶部</value>
   </data>
   <data name="ScrollingCaptureScrollMethod_Automatic" xml:space="preserve">
-    <value>自动尝试所有方法，直到完成工作</value>
+    <value>自动尝试所有方法，直到某方法生效</value>
   </data>
   <data name="ShapeType_DrawingSpeechBalloon" xml:space="preserve">
-    <value>绘图：言语气球</value>
+    <value>绘图：文本气泡 (S)</value>
   </data>
   <data name="HotkeyType_ToggleActionsToolbar" xml:space="preserve">
     <value>切换工作栏</value>
   </data>
   <data name="HotkeyType_ToggleActionsToolbar_Category" xml:space="preserve">
-    <value>其他</value>
+    <value>其它</value>
   </data>
   <data name="HotkeyType_ExitShareX" xml:space="preserve">
     <value>退出 ShareX</value>
   </data>
   <data name="HotkeyType_ExitShareX_Category" xml:space="preserve">
-    <value>其他</value>
+    <value>其它</value>
   </data>
   <data name="ShapeType_DrawingTextOutline" xml:space="preserve">
-    <value>绘图：文字（轮廓线）</value>
+    <value>绘图：文字（描边）</value>
   </data>
   <data name="ShapeType_DrawingTextBackground" xml:space="preserve">
-    <value>绘图：文字（底色）</value>
+    <value>绘图：文字（背景填充）(T)</value>
   </data>
   <data name="ShapeType_DrawingImageScreen" xml:space="preserve">
-    <value>绘图：图像（屏幕）</value>
+    <value>绘图：屏幕画面</value>
   </data>
   <data name="URLSharingServices_GoogleImageSearch" xml:space="preserve">
-    <value>谷歌图片搜索</value>
+    <value>Google 图片搜索</value>
   </data>
   <data name="CustomUploaderDestinationType_URLShortener" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="CustomUploaderDestinationType_FileUploader" xml:space="preserve">
     <value>文件上传</value>
@@ -989,16 +989,16 @@
     <value>自动检测</value>
   </data>
   <data name="PNGBitDepth_Bit32" xml:space="preserve">
-    <value>32 bit</value>
+    <value>32 位</value>
   </data>
   <data name="PNGBitDepth_Bit24" xml:space="preserve">
-    <value>24 bit</value>
+    <value>24 位</value>
   </data>
   <data name="LinearGradientMode_Vertical" xml:space="preserve">
     <value>垂直</value>
   </data>
   <data name="CustomUploaderDestinationType_URLSharingService" xml:space="preserve">
-    <value>URL分享服务</value>
+    <value>URL 分享服务</value>
   </data>
   <data name="HotkeyType_UploadText" xml:space="preserve">
     <value>上传文本</value>
@@ -1016,7 +1016,7 @@
     <value>非公开</value>
   </data>
   <data name="ShapeType_ToolCrop" xml:space="preserve">
-    <value>工具：图像裁剪（C）</value>
+    <value>工具：图像裁剪 (C)</value>
   </data>
   <data name="AmazonS3StorageClass_STANDARD" xml:space="preserve">
     <value>标准存储</value>
@@ -1031,13 +1031,13 @@
     <value>小正方形</value>
   </data>
   <data name="HotkeyType_ShortenURL" xml:space="preserve">
-    <value>缩短URL</value>
+    <value>缩短 URL</value>
   </data>
   <data name="AfterCaptureTasks_ScanQRCode" xml:space="preserve">
     <value>扫描二维码</value>
   </data>
   <data name="ReplCodeMenuEntry_rf_Random_line_from_file" xml:space="preserve">
-    <value>从文件产生随机线条，使用{filepath}选取文件</value>
+    <value>从文件产生随机线条，使用 {filepath} 选取文件</value>
   </data>
   <data name="PastebinPrivacy_Public" xml:space="preserve">
     <value>公开</value>
@@ -1106,7 +1106,7 @@
     <value>绘图：指针</value>
   </data>
   <data name="URLSharingServices_CustomURLSharingService" xml:space="preserve">
-    <value>自定义URL分享</value>
+    <value>自定义 URL 分享</value>
   </data>
   <data name="UpdateMessageBox_UpdateMessageBox_CurrentVersion" xml:space="preserve">
     <value>当前版本</value>
@@ -1128,5 +1128,38 @@
   </data>
   <data name="ImageEditorStartMode_AutoSize" xml:space="preserve">
     <value>自动尺寸</value>
+  </data>
+  <data name="PastebinExpiration_D1" xml:space="preserve">
+    <value>1 天</value>
+  </data>
+  <data name="PastebinExpiration_H1" xml:space="preserve">
+    <value>1 小时</value>
+  </data>
+  <data name="PastebinExpiration_W2" xml:space="preserve">
+    <value>2 周</value>
+  </data>
+  <data name="PastebinExpiration_W1" xml:space="preserve">
+    <value>1 周</value>
+  </data>
+  <data name="ShapeType_ToolSelect" xml:space="preserve">
+    <value>选择并移动 (M)</value>
+  </data>
+  <data name="PastebinExpiration_M1" xml:space="preserve">
+    <value>1 月</value>
+  </data>
+  <data name="Extensions_AddContextMenu_Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="Extensions_AddContextMenu_SelectAll" xml:space="preserve">
+    <value>全选</value>
+  </data>
+  <data name="Extensions_AddContextMenu_Redo" xml:space="preserve">
+    <value>重复</value>
+  </data>
+  <data name="Extensions_AddContextMenu_Undo" xml:space="preserve">
+    <value>撤销</value>
+  </data>
+  <data name="ShapeType_DrawingMagnify" xml:space="preserve">
+    <value>放大</value>
   </data>
 </root>

--- a/ShareX.HelpersLib/UpdateChecker/UpdateCheckerLabel.zh-CN.resx
+++ b/ShareX.HelpersLib/UpdateChecker/UpdateCheckerLabel.zh-CN.resx
@@ -124,6 +124,6 @@
     <value>...是最新的</value>
   </data>
   <data name="llblUpdateAvailable.Text" xml:space="preserve">
-    <value>ShareX有可用新版本</value>
+    <value>ShareX 有可用新版本</value>
   </data>
 </root>

--- a/ShareX.HistoryLib/Forms/HistoryForm.zh-CN.resx
+++ b/ShareX.HistoryLib/Forms/HistoryForm.zh-CN.resx
@@ -153,4 +153,13 @@
   <data name="chURL.Text" xml:space="preserve">
     <value>URL</value>
   </data>
+  <data name="btnShowStats.Text" xml:space="preserve">
+    <value>显示统计数据</value>
+  </data>
+  <data name="lblURLFilter.Text" xml:space="preserve">
+    <value>URL：</value>
+  </data>
+  <data name="lblFilenameFilter.Text" xml:space="preserve">
+    <value>文件名：</value>
+  </data>
 </root>

--- a/ShareX.HistoryLib/Forms/ImageHistoryForm.zh-CN.resx
+++ b/ShareX.HistoryLib/Forms/ImageHistoryForm.zh-CN.resx
@@ -118,12 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>图像历史</value>
+    <value>ShareX - 历史图片</value>
   </data>
   <data name="tsbSearch.Text" xml:space="preserve">
-    <value>条带按钮</value>
+    <value>搜索</value>
   </data>
   <data name="tslSearch.Text" xml:space="preserve">
     <value>搜索：</value>
+  </data>
+  <data name="tsbSearch.ToolTipText" xml:space="preserve">
+    <value>搜索</value>
+  </data>
+  <data name="tsbSettings.Text" xml:space="preserve">
+    <value>设置...</value>
   </data>
 </root>

--- a/ShareX.HistoryLib/Forms/ImageHistorySettingsForm.zh-CN.resx
+++ b/ShareX.HistoryLib/Forms/ImageHistorySettingsForm.zh-CN.resx
@@ -117,19 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="lblViewMode.Text" xml:space="preserve">
+    <value>浏览模式：</value>
+  </data>
+  <data name="lblThumbnailSize.Text" xml:space="preserve">
+    <value>缩略图尺寸：</value>
+  </data>
+  <data name="cbFilterMissingFiles.Text" xml:space="preserve">
+    <value>过滤丢失文件</value>
+  </data>
+  <data name="lblMaximumImageLimit.Text" xml:space="preserve">
+    <value>最大图像限制：</value>
+  </data>
+  <data name="lblThumbnailSizeUnit.Text" xml:space="preserve">
+    <value>像素</value>
+  </data>
+  <data name="cbRememberSearchText.Text" xml:space="preserve">
+    <value>记住搜索输入</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - 屏幕录制</value>
-  </data>
-  <data name="btnAbort.Text" xml:space="preserve">
-    <value>中止</value>
-  </data>
-  <data name="btnStart.Text" xml:space="preserve">
-    <value>开始</value>
-  </data>
-  <data name="tsmiStart.Text" xml:space="preserve">
-    <value>开始</value>
-  </data>
-  <data name="tsmiAbort.Text" xml:space="preserve">
-    <value>停止</value>
+    <value>ShareX - 历史图片设置</value>
   </data>
 </root>

--- a/ShareX.HistoryLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.HistoryLib/Properties/Resources.zh-CN.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="HistoryForm_UpdateItemCount___Filtered___0_" xml:space="preserve">
-    <value>过滤: {0}</value>
+    <value>过滤：{0}</value>
   </data>
   <data name="HistoryForm_UpdateItemCount_Total___0_" xml:space="preserve">
-    <value>总计: {0}</value>
+    <value>总计：{0}</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Copy" xml:space="preserve">
     <value>复制</value>
@@ -145,13 +145,13 @@
     <value>文件夹</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Forum__BBCode__image" xml:space="preserve">
-    <value>论坛（BBCode）的图像</value>
+    <value>论坛（BB 代码）的图像</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Forum__BBCode__link" xml:space="preserve">
-    <value>论坛（BBCode）链接</value>
+    <value>论坛（BB 代码）链接</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Forum__BBCode__linked_image" xml:space="preserve">
-    <value>论坛（BBCode）链接的图像</value>
+    <value>论坛（BB 代码）链接的图像</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_HTML_image" xml:space="preserve">
     <value>HTML图像</value>
@@ -175,7 +175,7 @@
     <value>打开</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Shortened_URL" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Show" xml:space="preserve">
     <value>显示</value>
@@ -184,7 +184,7 @@
     <value>文本</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Thumbnail_URL" xml:space="preserve">
-    <value>缩略图URL</value>
+    <value>缩略图 URL</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_URL" xml:space="preserve">
     <value>URL</value>
@@ -211,7 +211,7 @@
     <value>错误</value>
   </data>
   <data name="HistoryManager_GetHistoryItems_Error_occured_while_reading_XML_file___0_" xml:space="preserve">
-    <value>读取XML文件({0})时发生错误</value>
+    <value>读取 XML 文件 {0} 时发生错误</value>
   </data>
   <data name="HistoryItemManager_InitializeComponent_Markdown__linked_image" xml:space="preserve">
     <value>Markdown 链接的图像</value>
@@ -221,5 +221,11 @@
   </data>
   <data name="HistoryItemManager_InitializeComponent_Markdown__image" xml:space="preserve">
     <value>Markdown 图像</value>
+  </data>
+  <data name="HistoryItemManager_InitializeComponent_EditImage" xml:space="preserve">
+    <value>编辑图像...</value>
+  </data>
+  <data name="HistoryItemManager_InitializeComponent_UploadFile" xml:space="preserve">
+    <value>上传文件</value>
   </data>
 </root>

--- a/ShareX.ImageEffectsLib/ImageEffectsForm.zh-CN.resx
+++ b/ShareX.ImageEffectsLib/ImageEffectsForm.zh-CN.resx
@@ -162,4 +162,7 @@
   <data name="btnClose.Text" xml:space="preserve">
     <value>关闭</value>
   </data>
+  <data name="btnRefresh.Text" xml:space="preserve">
+    <value>刷新</value>
+  </data>
 </root>

--- a/ShareX.ImageEffectsLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.ImageEffectsLib/Properties/Resources.zh-CN.resx
@@ -121,7 +121,7 @@
     <value>调整</value>
   </data>
   <data name="ImageEffectsForm_AddAllEffectsToTreeView_Drawings" xml:space="preserve">
-    <value>图纸</value>
+    <value>绘图</value>
   </data>
   <data name="ImageEffectsForm_AddAllEffectsToTreeView_Filters" xml:space="preserve">
     <value>过滤器</value>

--- a/ShareX.IndexerLib/Forms/DirectoryIndexerForm.zh-CN.resx
+++ b/ShareX.IndexerLib/Forms/DirectoryIndexerForm.zh-CN.resx
@@ -117,19 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="btnBrowseFolder.Text" xml:space="preserve">
+    <value>浏览文件夹...</value>
+  </data>
+  <data name="btnIndexFolder.Text" xml:space="preserve">
+    <value>索引所选文件夹</value>
+  </data>
+  <data name="tpPreview.Text" xml:space="preserve">
+    <value>预览</value>
+  </data>
+  <data name="tpSettings.Text" xml:space="preserve">
+    <value>设置</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - 屏幕录制</value>
+    <value>ShareX - 目录索引</value>
   </data>
-  <data name="btnAbort.Text" xml:space="preserve">
-    <value>中止</value>
-  </data>
-  <data name="btnStart.Text" xml:space="preserve">
-    <value>开始</value>
-  </data>
-  <data name="tsmiStart.Text" xml:space="preserve">
-    <value>开始</value>
-  </data>
-  <data name="tsmiAbort.Text" xml:space="preserve">
-    <value>停止</value>
+  <data name="btnUpload.Text" xml:space="preserve">
+    <value>上传并关闭此窗口</value>
   </data>
 </root>

--- a/ShareX.MediaLib/Forms/ImageThumbnailerForm.zh-CN.resx
+++ b/ShareX.MediaLib/Forms/ImageThumbnailerForm.zh-CN.resx
@@ -147,4 +147,7 @@
   <data name="txtOutputFilename.Text" xml:space="preserve">
     <value>$filename_th</value>
   </data>
+  <data name="lblQuality.Text" xml:space="preserve">
+    <value>质量：</value>
+  </data>
 </root>

--- a/ShareX.MediaLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.MediaLib/Properties/Resources.zh-CN.resx
@@ -120,4 +120,7 @@
   <data name="VideoThumbnailerForm_btnBrowse_Click_Browse_for_media_file" xml:space="preserve">
     <value>浏览媒体文件</value>
   </data>
+  <data name="ThumbnailsSuccessfullyGenerated" xml:space="preserve">
+    <value>缩略图生成成功</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Forms/CanvasSizeForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/CanvasSizeForm.zh-CN.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="lblTop.Text" xml:space="preserve">
-    <value>顶部:</value>
+    <value>顶部：</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>ShareX - 画布尺寸</value>

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-CN.resx
@@ -169,17 +169,17 @@
     <value>质量：</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>CRF：范围为0-51。其中，0表示无损，30为默认值，51表示最差质量。
+    <value>CRF：范围为 0-51。其中，0 表示无损，30 为默认值，51 表示最差质量。
 值越高质量越差，但文件体积越小。</value>
   </data>
   <data name="tbAACBitrate.ToolTip" xml:space="preserve">
-    <value>默认值是128k</value>
+    <value>默认值为 128k</value>
   </data>
   <data name="tbMP3_qscale.ToolTip" xml:space="preserve">
-    <value>范围为0-9，较低的值表示更高的质量。0-3通常会产生透明效果，4（默认）接近感知透明度，6为“可勉强接受的”质量。</value>
+    <value>范围为 0-9，较低的值表示更高的质量。0-3 通常会产生透明效果，4（默认）接近感知透明度，6 为“可勉强接受的”质量。</value>
   </data>
   <data name="tbVorbis_qscale.ToolTip" xml:space="preserve">
-    <value>范围为0-10，其中10为最高质量，3-6为推荐测试范围，默认值为3.</value>
+    <value>范围为 0-10，其中 10 为最高质量，3-6 为推荐测试范围，默认值为 3.</value>
   </data>
   <data name="lblx264Preset.Text" xml:space="preserve">
     <value>预设：</value>
@@ -188,7 +188,7 @@
     <value>可变比特率：</value>
   </data>
   <data name="gbFFmpegExe.Text" xml:space="preserve">
-    <value>FFmpeg路径</value>
+    <value>FFmpeg 路径</value>
   </data>
   <data name="cbOverrideFFmpegPath.Text" xml:space="preserve">
     <value>使用自定义路径</value>
@@ -211,7 +211,7 @@
   <data name="cbx264Preset.ToolTip" xml:space="preserve">
     <value>较快的预设 = 编码速度较快，但是文件比较大。
 较慢的预设 = 编码速度较慢，但是文件比较小。
-对于实时编码（比如屏幕录制），预设必须尽快</value>
+对于实时编码（比如屏幕录制），预设的速度必须尽量快</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">
     <value>1表示最高质量、最大文件，31表示最低质量、最小文件。</value>
@@ -230,9 +230,21 @@
     <value>比特率：</value>
   </data>
   <data name="cbGIFDither.ToolTip" xml:space="preserve">
-    <value>默认值为sierra2_4a</value>
+    <value>默认值为 sierra2_4a</value>
   </data>
   <data name="cbGIFStatsMode.ToolTip" xml:space="preserve">
-    <value>默认值为full</value>
+    <value>默认值为 full</value>
+  </data>
+  <data name="lblQSVBitrate.Text" xml:space="preserve">
+    <value>比特率：</value>
+  </data>
+  <data name="lblQSVPreset.Text" xml:space="preserve">
+    <value>预设：</value>
+  </data>
+  <data name="lblAMFQuality.Text" xml:space="preserve">
+    <value>质量：</value>
+  </data>
+  <data name="lblAMFUsage.Text" xml:space="preserve">
+    <value>使用量：</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Forms/ScrollingCaptureForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/ScrollingCaptureForm.zh-CN.resx
@@ -190,7 +190,7 @@
     <value>合并调整</value>
   </data>
   <data name="lblCombineLastVertical.Text" xml:space="preserve">
-    <value>最后垂直:</value>
+    <value>最后垂直：</value>
   </data>
   <data name="lblCombineVertical.Text" xml:space="preserve">
     <value>垂直:</value>
@@ -205,7 +205,7 @@
     <value>右：</value>
   </data>
   <data name="lblTrimTop.Text" xml:space="preserve">
-    <value>顶部:</value>
+    <value>顶部：</value>
   </data>
   <data name="lblTrimLeft.Text" xml:space="preserve">
     <value>左：</value>

--- a/ShareX.ScreenCaptureLib/Forms/StickerForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/StickerForm.zh-CN.resx
@@ -132,7 +132,4 @@
   <data name="tsbEditStickers.Text" xml:space="preserve">
     <value>编辑贴纸包</value>
   </data>
-  <data name="tsnudSize.Text" xml:space="preserve">
-    <value>64</value>
-  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Forms/TextDrawingInputBox.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/TextDrawingInputBox.zh-CN.resx
@@ -133,7 +133,7 @@
     <value>右</value>
   </data>
   <data name="tsmiAlignmentCenter.Text" xml:space="preserve">
-    <value>正中</value>
+    <value>中心</value>
   </data>
   <data name="tsmiAlignmentLeft.Text" xml:space="preserve">
     <value>左</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FFmpegHelper_Record_FFmpeg_error" xml:space="preserve">
-    <value>FFmpeg错误</value>
+    <value>FFmpeg 错误</value>
   </data>
   <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>浏览ffmpeg.exe</value>
+    <value>浏览 ffmpeg.exe</value>
   </data>
   <data name="FFmpegOptionsForm_DownloaderForm_InstallRequested_Successfully_downloaded_FFmpeg_" xml:space="preserve">
     <value>FFmpeg下载成功。</value>
@@ -150,16 +150,16 @@
     <value>停止捕捉</value>
   </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>透明矩形捕捉</value>
+    <value>透明矩形（ShareX 窗口透明）</value>
   </data>
   <data name="FFmpegOptionsForm_DownloaderForm_InstallRequested_Download_of_FFmpeg_failed_" xml:space="preserve">
     <value>FFmpeg下载失败。</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>高亮矩形捕捉</value>
+    <value>矩形捕捉（不变暗）</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>显示FPS</value>
+    <value>显示 FPS</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
     <value>高度：</value>
@@ -267,31 +267,31 @@
     <value>上移一层</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>应用更改 &amp; 继续工作 (Enter)</value>
+    <value>应用更改并继续 (Enter)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>继续工作（空格或鼠标右键）</value>
+    <value>继续（空格或鼠标右键）</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>取消工作 (ESC)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>保存图像（Ctrl + S）</value>
+    <value>保存图像 (Ctrl + S)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>保存图像为…（Ctrl + Shift + S）</value>
+    <value>保存图像为… (Ctrl + Shift + S)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
     <value>将图像复制到剪贴板</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
-    <value>上传图像</value>
+    <value>上传图像 (Ctrl + U)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>打印图像…</value>
+    <value>打印图像… (Ctrl + P)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>完成捕捉任务后运行（Enter）</value>
+    <value>完成捕捉任务后运行 (Enter)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
     <value>捕捉最后区域</value>
@@ -392,5 +392,29 @@
   </data>
   <data name="ShapeManager_CreateToolbar_UseLetters" xml:space="preserve">
     <value>使用字母</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>添加图像效果...</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>阴影颜色...</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>打开按键绑定页面...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>选择形状后切换到绘图工具</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>绘制形状后切换到选区工具</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>此窗口将在打开按键绑定页面前关闭，要继续吗？</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>使用简单的尺寸调整节点</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>第一步的值：</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Controls/AccountTypeControl.zh-CN.resx
+++ b/ShareX.UploadersLib/Controls/AccountTypeControl.zh-CN.resx
@@ -121,7 +121,7 @@
     <value>匿名</value>
   </data>
   <data name="cbAccountType.Items1" xml:space="preserve">
-    <value>普通用户</value>
+    <value>用户</value>
   </data>
   <data name="lblAccountType.Text" xml:space="preserve">
     <value>账号类型：</value>

--- a/ShareX.UploadersLib/Forms/CustomUploaderSettingsForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/CustomUploaderSettingsForm.zh-CN.resx
@@ -117,19 +117,181 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - 贴纸包</value>
+  <data name="btnXmlAddSyntax.Text" xml:space="preserve">
+    <value>向 URL 字段添加规则</value>
   </data>
-  <data name="btnRemove.Text" xml:space="preserve">
-    <value>移除</value>
+  <data name="btnRegexAddSyntax.Text" xml:space="preserve">
+    <value>向 URL 字段添加规则</value>
+  </data>
+  <data name="btnJsonAddSyntax.Text" xml:space="preserve">
+    <value>向 URL 字段添加规则</value>
+  </data>
+  <data name="lblBody.Text" xml:space="preserve">
+    <value>请求体：</value>
+  </data>
+  <data name="btnClearUploaders.Text" xml:space="preserve">
+    <value>清除自定义上传...</value>
+  </data>
+  <data name="tsbResponseTextCopy.Text" xml:space="preserve">
+    <value>复制响应</value>
+  </data>
+  <data name="mbDestinationType.ToolTip" xml:space="preserve">
+    <value>目前，当用户双击 .sxcu 文件导入自定义上传目标时，上传目标类型将被使用。</value>
+  </data>
+  <data name="tsmiCustomUploaderGuide.Text" xml:space="preserve">
+    <value>自定义上传向导（英语）...</value>
+  </data>
+  <data name="tsmiCustomUploaders.Text" xml:space="preserve">
+    <value>自定义上传（GitHub）...</value>
+  </data>
+  <data name="lblResultDeletionURL.Text" xml:space="preserve">
+    <value>删除 URL：</value>
+  </data>
+  <data name="lblDestinationType.Text" xml:space="preserve">
+    <value>上传目标类型：</value>
+  </data>
+  <data name="btnDuplicate.Text" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="lblXPathExample.Text" xml:space="preserve">
+    <value>示例：
+
+/Files/File[1]/URL
+/store/book[1]/title</value>
+  </data>
+  <data name="lblJsonPathExample.Text" xml:space="preserve">
+    <value>示例：
+
+Files[0].URL
+store.book[0].title</value>
+  </data>
+  <data name="tsmiExportAll.Text" xml:space="preserve">
+    <value>导出全部：</value>
+  </data>
+  <data name="lblFileFormName.Text" xml:space="preserve">
+    <value>文件格式名：</value>
+  </data>
+  <data name="lblFileUploader.Text" xml:space="preserve">
+    <value>文件上传器：</value>
+  </data>
+  <data name="lblHeaders.Text" xml:space="preserve">
+    <value>头：</value>
+  </data>
+  <data name="lblImageUploader.Text" xml:space="preserve">
+    <value>图片上载器：</value>
+  </data>
+  <data name="tsbResponseTextJSONFormat.Text" xml:space="preserve">
+    <value>JSON 格式</value>
+  </data>
+  <data name="lblRequestMethod.Text" xml:space="preserve">
+    <value>方法：</value>
+  </data>
+  <data name="btnDataMinify.Text" xml:space="preserve">
+    <value>压缩</value>
+  </data>
+  <data name="cArgumentsName.HeaderText" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="cParametersName.HeaderText" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="cHeadersName.HeaderText" xml:space="preserve">
+    <value>名称</value>
   </data>
   <data name="lblName.Text" xml:space="preserve">
     <value>名称：</value>
   </data>
-  <data name="lblFolder.Text" xml:space="preserve">
-    <value>文件夹：</value>
+  <data name="btnNew.Text" xml:space="preserve">
+    <value>新增</value>
   </data>
-  <data name="btnAdd.Text" xml:space="preserve">
-    <value>添加</value>
+  <data name="lblParseResponse.Text" xml:space="preserve">
+    <value>解析响应：</value>
+  </data>
+  <data name="tpRegexParse.Text" xml:space="preserve">
+    <value>正则表达式</value>
+  </data>
+  <data name="cRegex.HeaderText" xml:space="preserve">
+    <value>正则表达式</value>
+  </data>
+  <data name="lblRegex.Text" xml:space="preserve">
+    <value>正则表达式</value>
+  </data>
+  <data name="btnRemove.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="tpRequest.Text" xml:space="preserve">
+    <value>请求</value>
+  </data>
+  <data name="tpResponse.Text" xml:space="preserve">
+    <value>响应</value>
+  </data>
+  <data name="tpResponseInfo.Text" xml:space="preserve">
+    <value>响应信息</value>
+  </data>
+  <data name="tpResponseText.Text" xml:space="preserve">
+    <value>响应文本</value>
+  </data>
+  <data name="tpResult.Text" xml:space="preserve">
+    <value>结果</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>ShareX - 自定义上传设置</value>
+  </data>
+  <data name="btnFileUploaderTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="btnURLShortenerTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="tpTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="btnURLSharingServiceTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="btnImageUploaderTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="btnTextUploaderTest.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="lblTextUploader.Text" xml:space="preserve">
+    <value>文本上载器：</value>
+  </data>
+  <data name="lblResultThumbnailURL.Text" xml:space="preserve">
+    <value>缩略图 URL：</value>
+  </data>
+  <data name="tsmiUpdateFolder.Text" xml:space="preserve">
+    <value>更新文件夹...</value>
+  </data>
+  <data name="gbCustomUploaders.Text" xml:space="preserve">
+    <value>上载器</value>
+  </data>
+  <data name="lblParameters.Text" xml:space="preserve">
+    <value>URL 参数：</value>
+  </data>
+  <data name="lblURLSharingService.Text" xml:space="preserve">
+    <value>URL 共享服务：</value>
+  </data>
+  <data name="lblURLShortener.Text" xml:space="preserve">
+    <value>URL 短链：</value>
+  </data>
+  <data name="cParametersValue.HeaderText" xml:space="preserve">
+    <value>值</value>
+  </data>
+  <data name="cArgumentsValue.HeaderText" xml:space="preserve">
+    <value>值</value>
+  </data>
+  <data name="cHeadersValue.HeaderText" xml:space="preserve">
+    <value>值</value>
+  </data>
+  <data name="tsbResponseTextXMLFormat.Text" xml:space="preserve">
+    <value>XML 格式</value>
+  </data>
+  <data name="lblXPath.Text" xml:space="preserve">
+    <value>XPath：</value>
+  </data>
+  <data name="btnDataBeautify.Text" xml:space="preserve">
+    <value>格式化</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/EmailForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/EmailForm.zh-CN.resx
@@ -133,6 +133,6 @@
     <value>主题：</value>
   </data>
   <data name="lblToEmail.Text" xml:space="preserve">
-    <value>发送到邮箱：</value>
+    <value>发送到电子邮箱：</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/JiraUpload.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/JiraUpload.zh-CN.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - Jira文件上传</value>
+    <value>ShareX - Jira 文件上传</value>
   </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>取消</value>
@@ -130,6 +130,6 @@
     <value>概要</value>
   </data>
   <data name="lblIssueId.Text" xml:space="preserve">
-    <value>问题ID：</value>
+    <value>问题 ID：</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/OCRSpaceForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/OCRSpaceForm.zh-CN.resx
@@ -121,7 +121,7 @@
     <value>语言：</value>
   </data>
   <data name="llGoogleTranslate.Text" xml:space="preserve">
-    <value>在Google翻译中打开并关闭窗口</value>
+    <value>在 Google 翻译中打开并关闭窗口</value>
   </data>
   <data name="lblResult.Text" xml:space="preserve">
     <value>结果：</value>
@@ -130,6 +130,6 @@
     <value>ShareX - 光学字符识别</value>
   </data>
   <data name="btnStartOCR.Text" xml:space="preserve">
-    <value>开始OCR识别</value>
+    <value>开始文本识别</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/PuushLoginForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/PuushLoginForm.zh-CN.resx
@@ -130,6 +130,6 @@
     <value>密码：</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>puush登陆</value>
+    <value>puush 登陆</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/ResponseForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/ResponseForm.zh-CN.resx
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -123,6 +124,6 @@
     <value>文本</value>
   </data>
   <data name="tpWebBrowser.Text" xml:space="preserve">
-    <value>Web浏览器</value>
+    <value>Web 浏览器</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/TwitterTweetForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/TwitterTweetForm.zh-CN.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - Twitter信息</value>
+    <value>ShareX - Twitter 信息</value>
   </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>取消</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-CN.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="cbAmazonS3CustomCNAME.Text" xml:space="preserve">
-    <value>使用自定义域:</value>
+    <value>使用自定义域：</value>
   </data>
   <data name="cbAmazonS3CustomCNAME.ToolTip" xml:space="preserve">
-    <value>如果你有用自定义域设置的bucket，请使用此选项。
-如果文本字段为空，则bucket名称将被用于URL。
-例如，如果你的bucket名称为bucket.example.com，则URL将为http://bucket.example.com/...</value>
+    <value>如果你有用自定义域设置的存储桶，请使用此选项。
+如果文本字段为空，则存储桶名称将被用于 URL。
+例如，如果你的存储桶名称为 bucket.example.com，则URL将为 http://bucket.example.com/...</value>
   </data>
   <data name="tpOtherUploaders.Text" xml:space="preserve">
     <value>其它上传</value>
   </data>
   <data name="tpURLShorteners.Text" xml:space="preserve">
-    <value>URL短链：</value>
+    <value>URL 短链：</value>
   </data>
   <data name="btnTwitterAdd.Text" xml:space="preserve">
     <value>添加</value>
@@ -144,7 +144,7 @@
     <value>跳过推特消息框</value>
   </data>
   <data name="lblTwitterDefaultMessage.Text" xml:space="preserve">
-    <value>预设推特消息：</value>
+    <value>默认推特消息：</value>
   </data>
   <data name="btnTwitterNameUpdate.Text" xml:space="preserve">
     <value>更新</value>
@@ -153,7 +153,7 @@
     <value>域名：</value>
   </data>
   <data name="lblYourlsNote.Text" xml:space="preserve">
-    <value>注意：如果你有一个签名,那么你并不需要一个用户名/密码.</value>
+    <value>注意：使用签名则无需用户名与密码。</value>
   </data>
   <data name="lblYourlsPassword.Text" xml:space="preserve">
     <value>密码：</value>
@@ -165,16 +165,16 @@
     <value>签名：</value>
   </data>
   <data name="llAdflyLink.Text" xml:space="preserve">
-    <value>可在此处找到你的API密钥和UID</value>
+    <value>可在此处找到你的 API 密钥和 UID</value>
   </data>
   <data name="lblAdflyAPIKEY.Text" xml:space="preserve">
-    <value>API密钥:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="lblPolrAPIKey.Text" xml:space="preserve">
-    <value>API密钥:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="lblPolrAPIHostname.Text" xml:space="preserve">
-    <value>API主机名:(例如http://example.com/api.php，留空将使用polr.me)</value>
+    <value>API 主机名：(例如 http://demo.polr.me/api/v2/action/shorten)</value>
   </data>
   <data name="lblStreamableUsername.Text" xml:space="preserve">
     <value>用户名：</value>
@@ -192,16 +192,16 @@
     <value>邮箱</value>
   </data>
   <data name="tpFileUploaders.Text" xml:space="preserve">
-    <value>文件上传</value>
+    <value>文件上载器</value>
   </data>
   <data name="tpTextUploaders.Text" xml:space="preserve">
-    <value>文本上传</value>
+    <value>文本上载器</value>
   </data>
   <data name="lblOneTimeSecretEmail.Text" xml:space="preserve">
     <value>邮箱：</value>
   </data>
   <data name="lblOneTimeSecretAPIKey.Text" xml:space="preserve">
-    <value>API密钥：</value>
+    <value>API 密钥：</value>
   </data>
   <data name="lblHastebinCustomDomain.Text" xml:space="preserve">
     <value>自定义域：</value>
@@ -240,7 +240,7 @@
     <value>有效期：</value>
   </data>
   <data name="lblPastebinSyntax.Text" xml:space="preserve">
-    <value>粘贴语法：</value>
+    <value>粘贴规则：</value>
   </data>
   <data name="btnPastebinRegister.Text" xml:space="preserve">
     <value>注册...</value>
@@ -261,7 +261,7 @@
     <value>密码：</value>
   </data>
   <data name="lblEmailSmtpServer.Text" xml:space="preserve">
-    <value>SMTP服务器：</value>
+    <value>SMTP 服务器：</value>
   </data>
   <data name="lblSharedFolderImages.Text" xml:space="preserve">
     <value>图片：</value>
@@ -273,16 +273,16 @@
     <value>文件：</value>
   </data>
   <data name="lblSulAPIKey.Text" xml:space="preserve">
-    <value>API密钥：</value>
+    <value>API 密钥：</value>
   </data>
   <data name="lblSeafileAuthToken.Text" xml:space="preserve">
     <value>身份验证令牌：</value>
   </data>
   <data name="cbSeafileCreateShareableURL.Text" xml:space="preserve">
-    <value>创建共享URL</value>
+    <value>创建共享 URL</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.Text" xml:space="preserve">
-    <value>忽略无效的SSL证书</value>
+    <value>忽略无效的 SSL 证书</value>
   </data>
   <data name="lblSeafilePassword.Text" xml:space="preserve">
     <value>密码：</value>
@@ -325,7 +325,7 @@
     <value>验证</value>
   </data>
   <data name="colSeafileLibraryEncrypted.Text" xml:space="preserve">
-    <value>加密</value>
+    <value>已加密</value>
   </data>
   <data name="colSeafileLibrarySize.Text" xml:space="preserve">
     <value>大小</value>
@@ -340,40 +340,34 @@
     <value>验证</value>
   </data>
   <data name="lblSeafileDaysToExpire.Text" xml:space="preserve">
-    <value>到期时间：</value>
+    <value>过期时间：</value>
   </data>
   <data name="lblSeafileSharePassword.Text" xml:space="preserve">
     <value>共享密码：</value>
   </data>
   <data name="grpSeafileShareSettings.Text" xml:space="preserve">
-    <value>Seafile共享设置</value>
-  </data>
-  <data name="lblPomfUploaders.Text" xml:space="preserve">
-    <value>上传至：</value>
+    <value>Seafile 共享设置</value>
   </data>
   <data name="lblPomfUploadURL.Text" xml:space="preserve">
-    <value>上传URL:</value>
+    <value>上传 URL：</value>
   </data>
   <data name="lblPomfResultURL.Text" xml:space="preserve">
-    <value>结果URL:</value>
-  </data>
-  <data name="btnPomfTest.Text" xml:space="preserve">
-    <value>测试全部</value>
+    <value>结果 URL:</value>
   </data>
   <data name="lblLambdaUploadURL.Text" xml:space="preserve">
-    <value>链接URL:</value>
+    <value>链接 URL:</value>
   </data>
   <data name="lblLambdaInfo.Text" xml:space="preserve">
-    <value>为了得到一个API密钥，在https://lambda.sx/登录LAMBDA然后点击你的用户名，单击管理帐户。</value>
+    <value>为了得到一个API密钥，在 https://lambda.sx/ 登录 Lambda 并点击你的用户名，单击管理帐户。</value>
   </data>
   <data name="lblJiraHost.Text" xml:space="preserve">
-    <value>Jira域名:</value>
+    <value>Jira 域名:</value>
   </data>
   <data name="txtJiraConfigHelp.Text" xml:space="preserve">
     <value>模板</value>
   </data>
   <data name="lblJiraIssuePrefix.Text" xml:space="preserve">
-    <value>Jira问题的前缀:</value>
+    <value>Jira 问题的前缀:</value>
   </data>
   <data name="lblLocalhostrEmail.Text" xml:space="preserve">
     <value>邮箱：</value>
@@ -382,7 +376,7 @@
     <value>密码：</value>
   </data>
   <data name="cbLocalhostrDirectURL.Text" xml:space="preserve">
-    <value>如果存在则使用直接URL</value>
+    <value>如果存在则使用直链</value>
   </data>
   <data name="btnGe_ttLogin.Text" xml:space="preserve">
     <value>登录</value>
@@ -406,7 +400,7 @@
     <value>注册...</value>
   </data>
   <data name="lblPushbulletUserKey.Text" xml:space="preserve">
-    <value>用户API密钥：</value>
+    <value>用户 API 密钥：</value>
   </data>
   <data name="btnPushbulletGetDeviceList.Text" xml:space="preserve">
     <value>获取设备列表</value>
@@ -426,9 +420,6 @@
   <data name="cbMediaFireUseLongLink.Text" xml:space="preserve">
     <value>使用其中包括文件名较长的链接</value>
   </data>
-  <data name="lblOwnCloudHost.Text" xml:space="preserve">
-    <value>域名：</value>
-  </data>
   <data name="lblOwnCloudUsername.Text" xml:space="preserve">
     <value>用户名：</value>
   </data>
@@ -439,10 +430,10 @@
     <value>路径：</value>
   </data>
   <data name="cbOwnCloudCreateShare.Text" xml:space="preserve">
-    <value>创建共享URL</value>
+    <value>创建共享 URL</value>
   </data>
   <data name="cbOwnCloudDirectLink.Text" xml:space="preserve">
-    <value>直接链接（添加"&amp;download"到URL）</value>
+    <value>直接链接</value>
   </data>
   <data name="lblMegaPassword.Text" xml:space="preserve">
     <value>密码：</value>
@@ -475,7 +466,7 @@
     <value>节点：</value>
   </data>
   <data name="lblAmazonS3BucketName.Text" xml:space="preserve">
-    <value>Bucket名称:</value>
+    <value>存储桶名称：</value>
   </data>
   <data name="lblAmazonS3PathPreview.Text" xml:space="preserve">
     <value>预览</value>
@@ -487,7 +478,7 @@
     <value>刷新文件夹列表</value>
   </data>
   <data name="lblBoxFolderID.Text" xml:space="preserve">
-    <value>选定的文件夹:</value>
+    <value>所选文件夹:</value>
   </data>
   <data name="chBoxFoldersName.Text" xml:space="preserve">
     <value>文件夹名称</value>
@@ -496,7 +487,7 @@
     <value>创建共享链接</value>
   </data>
   <data name="lblBoxFolderTip.Text" xml:space="preserve">
-    <value>注意: 您可以双击文件夹的名称进入该文件夹内.</value>
+    <value>注意：双击文件夹名称可打开文件夹。</value>
   </data>
   <data name="cbGoogleDriveIsPublic.Text" xml:space="preserve">
     <value>是否公共上传?</value>
@@ -511,7 +502,7 @@
     <value>标题</value>
   </data>
   <data name="lblGoogleDriveFolderID.Text" xml:space="preserve">
-    <value>文件夹ID：</value>
+    <value>文件夹 ID：</value>
   </data>
   <data name="cbGoogleDriveUseFolder.Text" xml:space="preserve">
     <value>上传文件到选定的文件夹</value>
@@ -520,25 +511,25 @@
     <value>创建共享链接</value>
   </data>
   <data name="lblOneDriveFolderID.Text" xml:space="preserve">
-    <value>选定的文件夹：</value>
+    <value>所选文件夹：</value>
   </data>
   <data name="lblDropboxPath.Text" xml:space="preserve">
     <value>上传路径：</value>
   </data>
   <data name="cbDropboxAutoCreateShareableLink.Text" xml:space="preserve">
-    <value>创建共享网址：</value>
+    <value>创建共享网址</value>
   </data>
   <data name="tpImageUploaders.Text" xml:space="preserve">
-    <value>图片上传</value>
+    <value>图片上载器</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>ShareX - 上传至...设定</value>
+    <value>ShareX - 上传目标设置</value>
   </data>
   <data name="lblCheveretoAPIKey.Text" xml:space="preserve">
-    <value>API密钥：</value>
+    <value>API 密钥：</value>
   </data>
   <data name="cbCheveretoDirectURL.Text" xml:space="preserve">
-    <value>直接URL</value>
+    <value>直链</value>
   </data>
   <data name="btnPicasaRefreshAlbumList.Text" xml:space="preserve">
     <value>刷新相册列表</value>
@@ -550,7 +541,7 @@
     <value>名称</value>
   </data>
   <data name="lblPicasaAlbumID.Text" xml:space="preserve">
-    <value>上传相册ID（空=无相册上传）:</value>
+    <value>上传相册 ID（空 = 无相册上传）:</value>
   </data>
   <data name="lblPhotobucketAccountStatus.Text" xml:space="preserve">
     <value>需要登录。</value>
@@ -559,7 +550,7 @@
     <value>第2步：完成授权</value>
   </data>
   <data name="lblPhotobucketVerificationCode.Text" xml:space="preserve">
-    <value>验证码（从授权页面获得验证码）：</value>
+    <value>验证码（从授权页面获得）：</value>
   </data>
   <data name="btnPhotobucketAuthOpen.Text" xml:space="preserve">
     <value>第1步：打开授权页面...</value>
@@ -574,10 +565,10 @@
     <value>创建相册</value>
   </data>
   <data name="lblPhotobucketParentAlbumPath.Text" xml:space="preserve">
-    <value>父级相册路径</value>
+    <value>父相册路径</value>
   </data>
   <data name="lblPhotobucketNewAlbumName.Text" xml:space="preserve">
-    <value>新相册的名称（必须在2至50个字符之间，有效字符为字母,数字,下划线（_）,连字符（ - ）,和空间）</value>
+    <value>新相册的名称（2 至 50 个字符，有效字符为字母、数字、下划线（ _ ）、连字符（ - ）、空格）。</value>
   </data>
   <data name="btnPhotobucketRemoveAlbum.Text" xml:space="preserve">
     <value>删除相册</value>
@@ -586,10 +577,10 @@
     <value>添加相册</value>
   </data>
   <data name="gbPhotobucketAlbumPath.Text" xml:space="preserve">
-    <value>上传图像</value>
+    <value>上传图像至</value>
   </data>
   <data name="btnTinyPicOpenMyImages.Text" xml:space="preserve">
-    <value>打开我的图片页...</value>
+    <value>打开我的图片页面...</value>
   </data>
   <data name="lblTinyPicUsername.Text" xml:space="preserve">
     <value>邮箱：</value>
@@ -607,19 +598,19 @@
     <value>用户名：</value>
   </data>
   <data name="btnImageShackOpenMyImages.Text" xml:space="preserve">
-    <value>打开我的图片页...</value>
+    <value>打开我的图片页面...</value>
   </data>
   <data name="cbImageShackIsPublic.Text" xml:space="preserve">
     <value>是否公开上传?</value>
   </data>
   <data name="btnImageShackOpenPublicProfile.Text" xml:space="preserve">
-    <value>打开公共资料页...</value>
+    <value>打开公共资料页面...</value>
   </data>
   <data name="btnImageShackLogin.Text" xml:space="preserve">
     <value>登录</value>
   </data>
   <data name="lblImgurThumbnailType.Text" xml:space="preserve">
-    <value>缩略图类型:</value>
+    <value>缩略图类型：</value>
   </data>
   <data name="btnImgurRefreshAlbumList.Text" xml:space="preserve">
     <value>刷新相册列表</value>
@@ -631,13 +622,13 @@
     <value>标题</value>
   </data>
   <data name="cbImgurDirectLink.Text" xml:space="preserve">
-    <value>使用直接链接</value>
+    <value>使用直链</value>
   </data>
   <data name="cbImgurUploadSelectedAlbum.Text" xml:space="preserve">
     <value>上传图片到选中相册</value>
   </data>
   <data name="cbImgurUseGIFV.Text" xml:space="preserve">
-    <value>使用GIF而不是GIFV链接</value>
+    <value>使用 GIF 而不是 GIFV 链接</value>
   </data>
   <data name="gbPhotobucketAlbums.Text" xml:space="preserve">
     <value>创建新相册</value>
@@ -655,7 +646,7 @@
     <value>忘记密码？</value>
   </data>
   <data name="cbGoogleDriveDirectLink.Text" xml:space="preserve">
-    <value>使用直接链接</value>
+    <value>使用直链</value>
   </data>
   <data name="lblOwnCloudHostExample.Text" xml:space="preserve">
     <value>示例：http://example.com/owncloud</value>
@@ -669,14 +660,11 @@
   <data name="lblCheveretoUploadURLExample.Text" xml:space="preserve">
     <value>示例：http://example.com/api/1/upload</value>
   </data>
-  <data name="btnCheveretoTestAll.Text" xml:space="preserve">
-    <value>测试全部</value>
-  </data>
   <data name="cbHastebinUseFileExtension.Text" xml:space="preserve">
-    <value>使用文件扩展名显示语法高亮（.txt除外）</value>
+    <value>使用文件扩展名显示语法高亮（.txt 除外）</value>
   </data>
   <data name="cbFTPAppendRemoteDirectory.Text" xml:space="preserve">
-    <value>添加远程目录到URL路径</value>
+    <value>添加远程目录到 URL 路径</value>
   </data>
   <data name="btnFTPTest.Text" xml:space="preserve">
     <value>测试</value>
@@ -697,7 +685,7 @@
     <value>被动模式</value>
   </data>
   <data name="cbFTPRemoveFileExtension.Text" xml:space="preserve">
-    <value>从URL路径移除文件扩展名</value>
+    <value>从 URL 路径移除文件扩展名</value>
   </data>
   <data name="lblFTPPort.Text" xml:space="preserve">
     <value>端口：</value>
@@ -715,7 +703,7 @@
     <value>密码：</value>
   </data>
   <data name="lblFTPURLPath.Text" xml:space="preserve">
-    <value>URL路径：</value>
+    <value>URL 路径：</value>
   </data>
   <data name="lblFTPRemoteDirectory.Text" xml:space="preserve">
     <value>远程目录：</value>
@@ -745,10 +733,10 @@
     <value>图片：</value>
   </data>
   <data name="lblSFTPKeyPassphrase.Text" xml:space="preserve">
-    <value>关键密码：</value>
+    <value>密钥密码：</value>
   </data>
   <data name="lblSFTPKeyLocation.Text" xml:space="preserve">
-    <value>关键位置：</value>
+    <value>密钥位置：</value>
   </data>
   <data name="lblFTPSCertificateLocation.Text" xml:space="preserve">
     <value>证书位置：</value>
@@ -757,10 +745,10 @@
     <value>加密：</value>
   </data>
   <data name="cbDropboxUseDirectLink.Text" xml:space="preserve">
-    <value>使用直接链接</value>
+    <value>使用直链</value>
   </data>
   <data name="lblPuushAPIKey.Text" xml:space="preserve">
-    <value>API密钥:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="cbAmazonS3UsePathStyle.Text" xml:space="preserve">
     <value>使用路径样式请求</value>
@@ -772,10 +760,10 @@
     <value>节点：</value>
   </data>
   <data name="lblAmazonS3SecretKey.Text" xml:space="preserve">
-    <value>密匙：</value>
+    <value>密钥：</value>
   </data>
   <data name="lblAmazonS3AccessKey.Text" xml:space="preserve">
-    <value>访问密钥：</value>
+    <value>访问密钥 ID：</value>
   </data>
   <data name="lblAzureStorageContainer.Text" xml:space="preserve">
     <value>容器名称：</value>
@@ -787,22 +775,22 @@
     <value>账户名称：</value>
   </data>
   <data name="cbGfycatIsPublic.Text" xml:space="preserve">
-    <value>是否公开上传？</value>
+    <value>公共上传</value>
   </data>
   <data name="cbOwnCloud81Compatibility.Text" xml:space="preserve">
-    <value>ownCloud 8.1与兼容性</value>
+    <value>ownCloud 8.1 与兼容性</value>
   </data>
   <data name="lblLambdaApiKey.Text" xml:space="preserve">
-    <value>API密钥:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="cbStreamableUseDirectURL.Text" xml:space="preserve">
-    <value>使用直接链接</value>
+    <value>使用直链</value>
   </data>
   <data name="btnLithiioGetAPIKey.Text" xml:space="preserve">
-    <value>获得API密钥...</value>
+    <value>打开账户页面...</value>
   </data>
   <data name="lblLithiioApiKey.Text" xml:space="preserve">
-    <value>API密钥：</value>
+    <value>API 密钥：</value>
   </data>
   <data name="gbPlikSettings.Text" xml:space="preserve">
     <value>其它设置</value>
@@ -829,7 +817,7 @@
     <value>分钟</value>
   </data>
   <data name="lblPlikTTL.Text" xml:space="preserve">
-    <value>自动删除文件</value>
+    <value>文件自动删除</value>
   </data>
   <data name="lblPlikURL.Text" xml:space="preserve">
     <value>主机</value>
@@ -838,7 +826,7 @@
     <value>需要用户名以及密码？</value>
   </data>
   <data name="lblPlikAPIKey.Text" xml:space="preserve">
-    <value>API密钥:</value>
+    <value>API 密钥：</value>
   </data>
   <data name="lblPlikPassword.Text" xml:space="preserve">
     <value>密码：</value>
@@ -847,13 +835,13 @@
     <value>用户名：</value>
   </data>
   <data name="cbEmailAutomaticSend.Text" xml:space="preserve">
-    <value>发送邮件至以下邮箱：</value>
+    <value>发送邮件至此邮箱（不显示对话框）：</value>
   </data>
   <data name="cbEmailRememberLastTo.Text" xml:space="preserve">
     <value>记住上一个收件地址</value>
   </data>
   <data name="cbPastebinRaw.Text" xml:space="preserve">
-    <value>使用原始URL</value>
+    <value>使用原始 URL</value>
   </data>
   <data name="lblGistCustomURLExample.Text" xml:space="preserve">
     <value>示例：https://api.github.com</value>
@@ -862,10 +850,10 @@
     <value>自定义域：</value>
   </data>
   <data name="cbGistUseRawURL.Text" xml:space="preserve">
-    <value>使用原始URL</value>
+    <value>使用原始 URL</value>
   </data>
   <data name="cbGistPublishPublic.Text" xml:space="preserve">
-    <value>创建公共Gist</value>
+    <value>创建公共 Gist</value>
   </data>
   <data name="cbPastieIsPublic.Text" xml:space="preserve">
     <value>是否公开上传?</value>
@@ -876,68 +864,35 @@
   <data name="lvlVgymeUserKey.Text" xml:space="preserve">
     <value>用户密钥：</value>
   </data>
-  <data name="lblCheveretoUploaders.Text" xml:space="preserve">
-    <value>上传至：</value>
-  </data>
   <data name="lblCheveretoUploadURL.Text" xml:space="preserve">
-    <value>上传URL:</value>
+    <value>上传 URL：</value>
   </data>
   <data name="lblGistOAuthInfo.Text" xml:space="preserve">
-    <value>注意：账户登录不支持GitHub Enterprise</value>
+    <value>注意：不支持 GitHub Enterprise。</value>
   </data>
   <data name="cbPolrIsSecret.Text" xml:space="preserve">
-    <value>是否私密URL</value>
+    <value>是否私密 URL</value>
   </data>
   <data name="btnSharedFolderAdd.Text" xml:space="preserve">
     <value>添加</value>
   </data>
-  <data name="tpAdFly.Text" xml:space="preserve">
-    <value>adf.ly</value>
-  </data>
   <data name="gbAmazonS3Advanced.Text" xml:space="preserve">
     <value>高级</value>
   </data>
-  <data name="tpAmazonS3.Text" xml:space="preserve">
-    <value>Amazon S3</value>
-  </data>
   <data name="lblAdflyAPIUID.Text" xml:space="preserve">
-    <value>API UID:</value>
+    <value>API UID：</value>
   </data>
   <data name="lblSeafileAPIURL.Text" xml:space="preserve">
-    <value>API URL:</value>
+    <value>API URL：</value>
   </data>
   <data name="lblYourlsAPIURL.Text" xml:space="preserve">
-    <value>API URL:</value>
-  </data>
-  <data name="tpJira.Text" xml:space="preserve">
-    <value>Atlassian Jira</value>
+    <value>API URL：</value>
   </data>
   <data name="tpAzureStorage.Text" xml:space="preserve">
     <value>Azure 存储</value>
   </data>
-  <data name="tpBitly.Text" xml:space="preserve">
-    <value>bit.ly</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items2" xml:space="preserve">
-    <value>blob.core.chinacloudapi.cn</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items3" xml:space="preserve">
-    <value>blob.core.cloudapi.de</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items1" xml:space="preserve">
-    <value>blob.core.usgovcloudapi.net</value>
-  </data>
-  <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
-    <value>blob.core.windows.net</value>
-  </data>
-  <data name="tpBox.Text" xml:space="preserve">
-    <value>Box</value>
-  </data>
   <data name="lblGoogleCloudStorageBucket.Text" xml:space="preserve">
-    <value>Bucket名称:</value>
-  </data>
-  <data name="tpChevereto.Text" xml:space="preserve">
-    <value>Chevereto</value>
+    <value>存储桶名称：</value>
   </data>
   <data name="lblAzureStorageCustomDomain.Text" xml:space="preserve">
     <value>自定义域：</value>
@@ -951,9 +906,6 @@
   <data name="btnSharedFolderDuplicate.Text" xml:space="preserve">
     <value>复制</value>
   </data>
-  <data name="tpDropbox.Text" xml:space="preserve">
-    <value>Dropbox</value>
-  </data>
   <data name="lblLithiioEmail.Text" xml:space="preserve">
     <value>邮箱：</value>
   </data>
@@ -964,13 +916,10 @@
     <value>示例：google.page.link</value>
   </data>
   <data name="btnLithiioFetchAPIKey.Text" xml:space="preserve">
-    <value>获取API密钥</value>
+    <value>获取 API 密钥</value>
   </data>
   <data name="tpFirebaseDynamicLinks.Text" xml:space="preserve">
-    <value>Firebase动态链接</value>
-  </data>
-  <data name="tpFlickr.Text" xml:space="preserve">
-    <value>Flickr</value>
+    <value>Firebase 动态链接</value>
   </data>
   <data name="rbFTPProtocolFTP.Text" xml:space="preserve">
     <value>FTP</value>
@@ -984,20 +933,11 @@
   <data name="rbFTPProtocolFTPS.Text" xml:space="preserve">
     <value>FTPS</value>
   </data>
-  <data name="tpGe_tt.Text" xml:space="preserve">
-    <value>Ge.tt</value>
-  </data>
   <data name="btnSulGetAPIKey.Text" xml:space="preserve">
-    <value>获取API密钥...</value>
+    <value>获取 API 密钥...</value>
   </data>
   <data name="btnPaste_eeGetUserKey.Text" xml:space="preserve">
     <value>获取用户密钥...</value>
-  </data>
-  <data name="tpGfycat.Text" xml:space="preserve">
-    <value>Gfycat</value>
-  </data>
-  <data name="tpGist.Text" xml:space="preserve">
-    <value>GitHub Gist</value>
   </data>
   <data name="tpGoogleCloudStorage.Text" xml:space="preserve">
     <value>Google 云存储</value>
@@ -1008,83 +948,17 @@
   <data name="tpGooglePhotos.Text" xml:space="preserve">
     <value>Google 相册</value>
   </data>
-  <data name="tpHastebin.Text" xml:space="preserve">
-    <value>Hastebin</value>
-  </data>
-  <data name="tpHostr.Text" xml:space="preserve">
-    <value>Hostr</value>
-  </data>
-  <data name="txtJiraHost.Text" xml:space="preserve">
-    <value>http://</value>
-  </data>
-  <data name="cbSeafileAPIURL.Items1" xml:space="preserve">
-    <value>https://cloud.mein-seafile.de/api2/</value>
-  </data>
-  <data name="cbSeafileAPIURL.Items" xml:space="preserve">
-    <value>https://seacloud.cc/api2/</value>
-  </data>
-  <data name="chPicasaID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="chImgurID.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
   <data name="cbAmazonS3StripExtensionImage.Text" xml:space="preserve">
     <value>图片</value>
   </data>
-  <data name="tpImgur.Text" xml:space="preserve">
-    <value>Imgur</value>
-  </data>
-  <data name="tpImageShack.Text" xml:space="preserve">
-    <value>ImageShack</value>
-  </data>
   <data name="gbJiraServer.Text" xml:space="preserve">
-    <value>Jira服务器</value>
+    <value>Jira 服务器</value>
   </data>
   <data name="tpLambda.Text" xml:space="preserve">
     <value>Lambda</value>
   </data>
-  <data name="tpLithiio.Text" xml:space="preserve">
-    <value>Lithiio</value>
-  </data>
-  <data name="tpMediaFire.Text" xml:space="preserve">
-    <value>MediaFire</value>
-  </data>
-  <data name="tpMega.Text" xml:space="preserve">
-    <value>Mega</value>
-  </data>
-  <data name="tpOneDrive.Text" xml:space="preserve">
-    <value>OneDrive</value>
-  </data>
-  <data name="tpOneTimeSecret.Text" xml:space="preserve">
-    <value>OneTimeSecret</value>
-  </data>
-  <data name="tpOwnCloud.Text" xml:space="preserve">
-    <value>ownCloud / Nextcloud</value>
-  </data>
   <data name="lblLithiioPassword.Text" xml:space="preserve">
     <value>密码：</value>
-  </data>
-  <data name="tpPaste_ee.Text" xml:space="preserve">
-    <value>Paste.ee</value>
-  </data>
-  <data name="tpPastebin.Text" xml:space="preserve">
-    <value>Pastebin</value>
-  </data>
-  <data name="tpPastie.Text" xml:space="preserve">
-    <value>Pastie</value>
-  </data>
-  <data name="tpPhotobucket.Text" xml:space="preserve">
-    <value>Photobucket</value>
-  </data>
-  <data name="tpPlik.Text" xml:space="preserve">
-    <value>Plik</value>
-  </data>
-  <data name="tpPolr.Text" xml:space="preserve">
-    <value>Polr</value>
-  </data>
-  <data name="tpPomf.Text" xml:space="preserve">
-    <value>Pomf</value>
   </data>
   <data name="lblAzureStorageURLPreview.Text" xml:space="preserve">
     <value>预览</value>
@@ -1095,35 +969,14 @@
   <data name="lblYouTubePrivacyType.Text" xml:space="preserve">
     <value>隐私类型：</value>
   </data>
-  <data name="txtJiraIssuePrefix.Text" xml:space="preserve">
-    <value>PROJECT-</value>
-  </data>
-  <data name="tpPushbullet.Text" xml:space="preserve">
-    <value>Pushbullet</value>
-  </data>
-  <data name="tpPuush.Text" xml:space="preserve">
-    <value>puush</value>
-  </data>
   <data name="btnSharedFolderRemove.Text" xml:space="preserve">
     <value>删除</value>
   </data>
   <data name="lblAmazonS3StripExtension.Text" xml:space="preserve">
     <value>移除文件扩展名于：</value>
   </data>
-  <data name="tpSeafile.Text" xml:space="preserve">
-    <value>Seafile</value>
-  </data>
-  <data name="tpSendSpace.Text" xml:space="preserve">
-    <value>SendSpace</value>
-  </data>
   <data name="cbAmazonS3PublicACL.Text" xml:space="preserve">
-    <value>在文件上设置公开ACL</value>
-  </data>
-  <data name="rbFTPProtocolSFTP.Text" xml:space="preserve">
-    <value>SFTP</value>
-  </data>
-  <data name="gbSFTP.Text" xml:space="preserve">
-    <value>SFTP</value>
+    <value>在文件上设置公开 ACL</value>
   </data>
   <data name="cbFirebaseIsShort.Text" xml:space="preserve">
     <value>短链</value>
@@ -1131,23 +984,8 @@
   <data name="lblAmazonS3StorageClass.Text" xml:space="preserve">
     <value>存储类：</value>
   </data>
-  <data name="tpStreamable.Text" xml:space="preserve">
-    <value>Streamable</value>
-  </data>
-  <data name="tpSul.Text" xml:space="preserve">
-    <value>s-ul</value>
-  </data>
   <data name="cbAmazonS3StripExtensionText.Text" xml:space="preserve">
     <value>文本</value>
-  </data>
-  <data name="tpTinyPic.Text" xml:space="preserve">
-    <value>TinyPic</value>
-  </data>
-  <data name="tpTwitter.Text" xml:space="preserve">
-    <value>Twitter</value>
-  </data>
-  <data name="tpUpaste.Text" xml:space="preserve">
-    <value>uPaste</value>
   </data>
   <data name="lblGoogleCloudStorageObjectPrefix.Text" xml:space="preserve">
     <value>上传路径：</value>
@@ -1162,33 +1000,143 @@
     <value>URL预览：</value>
   </data>
   <data name="lblSeafileAccInfoUsage.Text" xml:space="preserve">
-    <value>用法：</value>
+    <value>使用量：</value>
   </data>
   <data name="cbPolrUseAPIv1.Text" xml:space="preserve">
-    <value>使用已弃用的API v1</value>
+    <value>使用已弃用的 API v1</value>
   </data>
   <data name="cbFlickrDirectLink.Text" xml:space="preserve">
-    <value>使用直接链接</value>
+    <value>使用直链</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.Text" xml:space="preserve">
-    <value>使用预览链接（仅NextCloud）</value>
+    <value>使用预览链接（仅 NextCloud）</value>
   </data>
   <data name="cbYouTubeUseShortenedLink.Text" xml:space="preserve">
-    <value>使用UR短链L</value>
-  </data>
-  <data name="tpVgyme.Text" xml:space="preserve">
-    <value>vgy.me</value>
+    <value>使用短链</value>
   </data>
   <data name="cbAmazonS3StripExtensionVideo.Text" xml:space="preserve">
     <value>视频</value>
   </data>
   <data name="lblFirebaseWebAPIKey.Text" xml:space="preserve">
-    <value>Web API密钥：</value>
+    <value>Web API 密钥：</value>
   </data>
-  <data name="tpYourls.Text" xml:space="preserve">
-    <value>YOURLS</value>
+  <data name="gbGoogleCloudStorageAdvanced.Text" xml:space="preserve">
+    <value>高级</value>
   </data>
-  <data name="tpYouTube.Text" xml:space="preserve">
-    <value>YouTube</value>
+  <data name="lblGooglePhotosCreateAlbumName.Text" xml:space="preserve">
+    <value>相册名：</value>
+  </data>
+  <data name="lblKuttAPIKey.Text" xml:space="preserve">
+    <value>API 密钥：</value>
+  </data>
+  <data name="lblB2ApplicationKey.Text" xml:space="preserve">
+    <value>应用程序密钥（私密）：</value>
+  </data>
+  <data name="lblB2ApplicationKeyId.Text" xml:space="preserve">
+    <value>应用程序密钥 ID：</value>
+  </data>
+  <data name="lblTeknikAuthUrl.Text" xml:space="preserve">
+    <value>认证 URL：</value>
+  </data>
+  <data name="cbOwnCloudAutoExpire.Text" xml:space="preserve">
+    <value>共享连接自动过期</value>
+  </data>
+  <data name="lblB2Bucket.Text" xml:space="preserve">
+    <value>存储桶名称：</value>
+  </data>
+  <data name="cbTeknikEncrypt.Text" xml:space="preserve">
+    <value>客户端加密</value>
+  </data>
+  <data name="lblB2ManageLink.Text" xml:space="preserve">
+    <value>单击此处以创建应用程序密钥或管理存储桶。</value>
+  </data>
+  <data name="btnGooglePhotosCreateAlbum.Text" xml:space="preserve">
+    <value>创建</value>
+  </data>
+  <data name="txtB2CustomUrl.ToolTip" xml:space="preserve">
+    <value>在此输入一个自定义 URL，它将替换 BackBlaze 返回的主机和路径。</value>
+  </data>
+  <data name="lblTeknikExpiration.Text" xml:space="preserve">
+    <value>有效期：</value>
+  </data>
+  <data name="lblOwnCloudExpiryTime.Text" xml:space="preserve">
+    <value>有效期（天）：</value>
+  </data>
+  <data name="cbTeknikGenDeleteKey.Text" xml:space="preserve">
+    <value>生成删除密钥</value>
+  </data>
+  <data name="lblKuttHost.Text" xml:space="preserve">
+    <value>主机：</value>
+  </data>
+  <data name="cbKuttReuse.Text" xml:space="preserve">
+    <value>如果存在具有指定目标的 URL，则返回该 URL</value>
+  </data>
+  <data name="cbB2CustomUrl.ToolTip" xml:space="preserve">
+    <value>如果启用，您收到的 URL 将是附加到给定 URL 的上载路径。
+
+这与 CloudFlare 等服务或作为 B2 前端的其它服务结合使用
+非常有用。 请参阅 B2 知识库中的文章“使用 B2 创建短链”。
+
+如果禁用，您将收到的 URL将由 Backblaze B2 确定。</value>
+  </data>
+  <data name="cbGoogleCloudStorageStripExtensionImage.Text" xml:space="preserve">
+    <value>图片</value>
+  </data>
+  <data name="cbGfycatKeepAudio.Text" xml:space="preserve">
+    <value>保持声音</value>
+  </data>
+  <data name="lblKuttPassword.Text" xml:space="preserve">
+    <value>密码：</value>
+  </data>
+  <data name="lblTeknikPasteAPIUrl.Text" xml:space="preserve">
+    <value>粘贴 API URL：</value>
+  </data>
+  <data name="cbGooglePhotosIsPublic.Text" xml:space="preserve">
+    <value>公共上传</value>
+  </data>
+  <data name="lblGoogleCloudStorageStripExtension.Text" xml:space="preserve">
+    <value>移除文件扩展名于：</value>
+  </data>
+  <data name="cbGoogleCloudStorageSetPublicACL.Text" xml:space="preserve">
+    <value>在文件上设置公开 ACL</value>
+  </data>
+  <data name="cbAmazonS3SignedPayload.Text" xml:space="preserve">
+    <value>有效负载</value>
+  </data>
+  <data name="cbGoogleCloudStorageStripExtensionText.Text" xml:space="preserve">
+    <value>文本</value>
+  </data>
+  <data name="txtB2ApplicationKeyId.ToolTip" xml:space="preserve">
+    <value>应用程序密钥 ID，小写的十六进制字符串。</value>
+  </data>
+  <data name="txtB2ApplicationKey.ToolTip" xml:space="preserve">
+    <value>应用程序密钥，仅包含字母与数字。</value>
+  </data>
+  <data name="txtB2UploadPath.ToolTip" xml:space="preserve">
+    <value>文件路径，使用名称模板格式。</value>
+  </data>
+  <data name="lblTeknikUploadAPIUrl.Text" xml:space="preserve">
+    <value>上传 API URL：</value>
+  </data>
+  <data name="lblB2UploadPath.Text" xml:space="preserve">
+    <value>上传路径：</value>
+  </data>
+  <data name="lblB2UrlPreview.Text" xml:space="preserve">
+    <value>URL预览：</value>
+  </data>
+  <data name="lblTeknikUrlShortenerAPIUrl.Text" xml:space="preserve">
+    <value>URL 短链 API URL：</value>
+  </data>
+  <data name="cbB2CustomUrl.Text" xml:space="preserve">
+    <value>使用自定义 URL（支持模板格式）：</value>
+  </data>
+  <data name="cbGoogleCloudStorageStripExtensionVideo.Text" xml:space="preserve">
+    <value>视频</value>
+  </data>
+  <data name="txtB2Bucket.ToolTip" xml:space="preserve">
+    <value>文件存储位置。
+
+此选项仅当你创建应用程序密钥时
+未设置“允许访问存储桶”时有效。</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.UploadersLib/Properties/Resources.zh-CN.resx
@@ -127,13 +127,13 @@
     <value>无效的设备名称</value>
   </data>
   <data name="UploadersConfigForm_BoxListFolders_Box_refresh_folders_list_failed" xml:space="preserve">
-    <value>Box刷新文件夹列表失败</value>
+    <value>Box 刷新文件夹列表失败</value>
   </data>
   <data name="UploadersConfigForm_Error" xml:space="preserve">
     <value>错误</value>
   </data>
   <data name="OneDrive_RootFolder_Root_folder" xml:space="preserve">
-    <value>根文件夹</value>
+    <value>根目录</value>
   </data>
   <data name="JiraUpload_ValidateIssueId_Issue_not_found" xml:space="preserve">
     <value>未发现问题</value>
@@ -151,10 +151,10 @@
     <value>要求认证。</value>
   </data>
   <data name="UploadersConfigForm_LoadSettings_Parent_album_path_e_g_" xml:space="preserve">
-    <value>上级专辑路径例如</value>
+    <value>父相册路径，例如</value>
   </data>
   <data name="UploadersConfigForm_LoadSettings_Selected_folder_" xml:space="preserve">
-    <value>选定的文件夹：</value>
+    <value>所选文件夹：</value>
   </data>
   <data name="UploadersConfigForm_Login_failed" xml:space="preserve">
     <value>登录失败。</value>
@@ -181,7 +181,7 @@
     <value>{0} 创建成功。</value>
   </data>
   <data name="UploadersConfigForm_SendSpaceRegister_SendSpace_Registration___" xml:space="preserve">
-    <value>SendSpace注册</value>
+    <value>SendSpace 注册</value>
   </data>
   <data name="UploadersConfigForm_TestCustomUploader_Error__Result_is_empty_" xml:space="preserve">
     <value>错误：结果是空的。</value>
@@ -194,10 +194,10 @@
 创建的文件夹：</value>
   </data>
   <data name="UploadersConfigForm_FTPOpenClient_Unable_to_find_valid_FTP_account_" xml:space="preserve">
-    <value>无法找到有效的FTP帐户。</value>
+    <value>无法找到有效的 FTP 帐户。</value>
   </data>
   <data name="CustomFileUploader_Upload_Response_parse_failed_" xml:space="preserve">
-    <value>解析响应失败。</value>
+    <value>响应解析失败。</value>
   </data>
   <data name="UploadersConfigForm_Remove_all_custom_uploaders_Confirmation" xml:space="preserve">
     <value>删除所有自定义上传？</value>
@@ -212,10 +212,10 @@
     <value>“文件格式名称”必须被配置</value>
   </data>
   <data name="UploadersConfigForm_eiCustomUploaders_ExportRequested_RequestURLMustBeConfigured" xml:space="preserve">
-    <value>“请求URL”必须被配置</value>
+    <value>“请求 URL”必须被配置</value>
   </data>
   <data name="CustomUploaderItem_GetRequestURL_RequestURLMustBeConfigured" xml:space="preserve">
-    <value>“请求URL”必须被配置</value>
+    <value>“请求 URL”必须被配置</value>
   </data>
   <data name="UploadersConfigForm_ConnectSFTPAccount_Key_file_not_found" xml:space="preserve">
     <value>密钥文件不存在</value>
@@ -234,5 +234,11 @@
   </data>
   <data name="OAuthControl_Status_NotLoggedIn" xml:space="preserve">
     <value>未登陆</value>
+  </data>
+  <data name="DuplicateNameNotAllowed" xml:space="preserve">
+    <value>复制名称不允许。</value>
+  </data>
+  <data name="txtB2BucketWatermark" xml:space="preserve">
+    <value>可选项，仅当创建密钥不设置存储桶时使用</value>
   </data>
 </root>

--- a/ShareX/Forms/AboutForm.zh-CN.resx
+++ b/ShareX/Forms/AboutForm.zh-CN.resx
@@ -129,4 +129,7 @@
   <data name="$this.Text" xml:space="preserve">
     <value>ShareX - 关于</value>
   </data>
+  <data name="lblBuild.Text" xml:space="preserve">
+    <value>编译版本</value>
+  </data>
 </root>

--- a/ShareX/Forms/ActionsForm.zh-CN.resx
+++ b/ShareX/Forms/ActionsForm.zh-CN.resx
@@ -136,12 +136,15 @@
     <value>名称:</value>
   </data>
   <data name="lblOutputExtension.Text" xml:space="preserve">
-    <value>输出文件的扩展名：（空=使用相同的文件名）</value>
+    <value>输出文件的扩展名：（空 = 使用相同的文件名）</value>
   </data>
   <data name="lblPath.Text" xml:space="preserve">
     <value>文件路径：</value>
   </data>
   <data name="cbHiddenWindow.Text" xml:space="preserve">
     <value>隐藏窗口</value>
+  </data>
+  <data name="cbDeleteInputFile.Text" xml:space="preserve">
+    <value>删除输入文件</value>
   </data>
 </root>

--- a/ShareX/Forms/AfterCaptureForm.zh-CN.resx
+++ b/ShareX/Forms/AfterCaptureForm.zh-CN.resx
@@ -133,7 +133,7 @@
     <value>截图后</value>
   </data>
   <data name="tpBeforeUpload.Text" xml:space="preserve">
-    <value>目的地...</value>
+    <value>上传目标</value>
   </data>
   <data name="tpAfterUpload.Text" xml:space="preserve">
     <value>上传后</value>

--- a/ShareX/Forms/AfterUploadForm.zh-CN.resx
+++ b/ShareX/Forms/AfterUploadForm.zh-CN.resx
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/ShareX/Forms/ApplicationSettingsForm.zh-CN.resx
+++ b/ShareX/Forms/ApplicationSettingsForm.zh-CN.resx
@@ -136,7 +136,7 @@
     <value>编辑...</value>
   </data>
   <data name="lblUploadLimitHint.Text" xml:space="preserve">
-    <value>0 - 25（0禁用）</value>
+    <value>0 - 25（0 禁用）</value>
   </data>
   <data name="lblBufferSize.Text" xml:space="preserve">
     <value>缓冲区大小：</value>
@@ -148,7 +148,7 @@
     <value>综合</value>
   </data>
   <data name="cbPrintDontShowWindowsDialog.Text" xml:space="preserve">
-    <value>不显示Windows打印对话框</value>
+    <value>不显示 Windows 打印对话框</value>
   </data>
   <data name="gbSecondaryFileUploaders.Text" xml:space="preserve">
     <value>辅助文件上传程序</value>
@@ -157,10 +157,10 @@
     <value>显示托盘图标</value>
   </data>
   <data name="cbSilentRun.Text" xml:space="preserve">
-    <value>开始时最小化到托盘</value>
+    <value>启动时最小化到托盘</value>
   </data>
   <data name="cbSendToMenu.Text" xml:space="preserve">
-    <value>在 "发送到" 菜单显示 ShareX</value>
+    <value>在 "发送到" 菜单中显示 ShareX</value>
   </data>
   <data name="cbRememberMainFormPosition.Text" xml:space="preserve">
     <value>记住主窗口的位置</value>
@@ -217,7 +217,7 @@
     <value>打开...</value>
   </data>
   <data name="cbTrayIconProgressEnabled.Text" xml:space="preserve">
-    <value>在系统托盘显示进展</value>
+    <value>在系统托盘显示进度</value>
   </data>
   <data name="lblProxyUsername.Text" xml:space="preserve">
     <value>用户名：</value>
@@ -253,10 +253,10 @@
     <value>辅助文本上传程序</value>
   </data>
   <data name="cbSteamShowInApp.Text" xml:space="preserve">
-    <value>当 ShareX 打开时，在 Steam 状态显示 ShareX</value>
+    <value>当 ShareX 开启时，在 Steam 状态显示 ShareX</value>
   </data>
   <data name="cbShellContextMenu.Text" xml:space="preserve">
-    <value>在 Windows 资源管理器右键菜单显示 "使用ShareX上传" 按钮</value>
+    <value>在 Windows 资源管理器右键菜单显示 "使用 ShareX 上传" 按钮</value>
   </data>
   <data name="tpGeneral.Text" xml:space="preserve">
     <value>常规</value>
@@ -292,10 +292,10 @@
     <value>保存任务历史</value>
   </data>
   <data name="lblRecentTasksMaxCount.Text" xml:space="preserve">
-    <value>最大数量的保存任务</value>
+    <value>保存任务最大数量</value>
   </data>
   <data name="cbHistoryCheckURL.Text" xml:space="preserve">
-    <value>仅保存URL（截图并上传图床之后）</value>
+    <value>仅保存 URL（截图并上传图床之后）</value>
   </data>
   <data name="gbHistory.Text" xml:space="preserve">
     <value>历史</value>
@@ -307,7 +307,7 @@
     <value>在托盘菜单显示近期任务</value>
   </data>
   <data name="cbRecentTasksSave.Text" xml:space="preserve">
-    <value>保存近期的任务</value>
+    <value>保存近期任务</value>
   </data>
   <data name="gbRecentLinks.Text" xml:space="preserve">
     <value>近期任务</value>
@@ -316,7 +316,7 @@
     <value>历史</value>
   </data>
   <data name="cbRecentTasksShowInMainWindow.Text" xml:space="preserve">
-    <value>在启动主窗口时显示近期的任务</value>
+    <value>在启动主窗口时显示近期任务</value>
   </data>
   <data name="gbChrome.Text" xml:space="preserve">
     <value>Chrome 扩展程序</value>
@@ -352,9 +352,21 @@
     <value>Firefox 扩展程序</value>
   </data>
   <data name="btnCheckDevBuild.Text" xml:space="preserve">
-    <value>安装dev build...</value>
+    <value>安装开发版...</value>
   </data>
   <data name="cbEditWithShareX.Text" xml:space="preserve">
     <value>在Windows上下文菜单中显示“使用ShareX编辑”</value>
+  </data>
+  <data name="cbExperimentalDarkTheme.Text" xml:space="preserve">
+    <value>实验性黑暗主题</value>
+  </data>
+  <data name="cbUseWhiteShareXIcon.Text" xml:space="preserve">
+    <value>使用白色 ShareX 图标</value>
+  </data>
+  <data name="cbUseDarkTheme.Text" xml:space="preserve">
+    <value>使用黑暗主题</value>
+  </data>
+  <data name="btnPersonalFolderPathApply.Text" xml:space="preserve">
+    <value>应用</value>
   </data>
 </root>

--- a/ShareX/Forms/AutoCaptureForm.zh-CN.resx
+++ b/ShareX/Forms/AutoCaptureForm.zh-CN.resx
@@ -127,10 +127,10 @@
     <value>选择区域</value>
   </data>
   <data name="cbAutoMinimize.Text" xml:space="preserve">
-    <value>自动最小化到托盘</value>
+    <value>自动最小化到系统托盘</value>
   </data>
   <data name="cbWaitUploads.Text" xml:space="preserve">
-    <value>等到任务完成</value>
+    <value>等待任务完成</value>
   </data>
   <data name="gbRegion.Text" xml:space="preserve">
     <value>区域</value>

--- a/ShareX/Forms/FileExistForm.zh-CN.resx
+++ b/ShareX/Forms/FileExistForm.zh-CN.resx
@@ -130,7 +130,7 @@
     <value>覆盖：</value>
   </data>
   <data name="btnUniqueName.Text" xml:space="preserve">
-    <value>使用唯的名称:</value>
+    <value>使用唯一名称:</value>
   </data>
   <data name="lblTitle.Text" xml:space="preserve">
     <value>在该位置已经存在具有相同名称的文件。

--- a/ShareX/Forms/FirstTimeConfigForm.zh-CN.resx
+++ b/ShareX/Forms/FirstTimeConfigForm.zh-CN.resx
@@ -121,16 +121,16 @@
     <value>开机时自动启动</value>
   </data>
   <data name="cbShellContextMenuButton.Text" xml:space="preserve">
-    <value>在Windows资源管理器右键菜单显示“使用ShareX上传”按钮</value>
+    <value>在 Windows 资源管理器右键菜单显示“使用 ShareX 上传”按钮</value>
   </data>
   <data name="cbSendToMenu.Text" xml:space="preserve">
-    <value>在"发送到"菜单显示ShareX</value>
+    <value>在"发送到"菜单显示 ShareX</value>
   </data>
   <data name="lblNote.Text" xml:space="preserve">
     <value>你可以在“应用程序设置-&gt;综合”找到这些设置。</value>
   </data>
   <data name="cbSteamInApp.Text" xml:space="preserve">
-    <value>当ShareX打开时，在Steam内显示ShareX</value>
+    <value>当 ShareX 开启时，在 Steam 状态显示 ShareX</value>
   </data>
   <data name="lblTitle.Text" xml:space="preserve">
     <value>ShareX 首次配置</value>

--- a/ShareX/Forms/HotkeySettingsForm.zh-CN.resx
+++ b/ShareX/Forms/HotkeySettingsForm.zh-CN.resx
@@ -133,6 +133,6 @@
     <value>删除</value>
   </data>
   <data name="btnReset.Text" xml:space="preserve">
-    <value>恢复默认快捷键</value>
+    <value>恢复默认快捷键...</value>
   </data>
 </root>

--- a/ShareX/Forms/MainForm.zh-CN.resx
+++ b/ShareX/Forms/MainForm.zh-CN.resx
@@ -154,7 +154,7 @@
     <value>截图文件夹...</value>
   </data>
   <data name="tsbTaskSettings.Text" xml:space="preserve">
-    <value>任务设置...</value>
+    <value>动作设置...</value>
   </data>
   <data name="tsddbAfterCaptureTasks.Text" xml:space="preserve">
     <value>截图后的动作</value>
@@ -169,7 +169,7 @@
     <value>调试</value>
   </data>
   <data name="tsddbDestinations.Text" xml:space="preserve">
-    <value>目的地...</value>
+    <value>上传至...</value>
   </data>
   <data name="tsddbTools.Text" xml:space="preserve">
     <value>工具</value>
@@ -190,7 +190,7 @@
     <value>复制</value>
   </data>
   <data name="tsmiCopyDeletionURL.Text" xml:space="preserve">
-    <value>删除URL</value>
+    <value>删除 URL</value>
   </data>
   <data name="tsmiCopyFile.Text" xml:space="preserve">
     <value>文件</value>
@@ -208,28 +208,28 @@
     <value>文件夹</value>
   </data>
   <data name="tsmiCopyForumImage.Text" xml:space="preserve">
-    <value>论坛（BB代码）的图像</value>
+    <value>论坛（BB 代码）的图像</value>
   </data>
   <data name="tsmiCopyForumLink.Text" xml:space="preserve">
-    <value>论坛（BB代码）链接</value>
+    <value>论坛（BB 代码）链接</value>
   </data>
   <data name="tsmiCopyForumLinkedImage.Text" xml:space="preserve">
-    <value>论坛（BB代码）链接的图像</value>
+    <value>论坛（BB 代码）链接的图像</value>
   </data>
   <data name="tsmiCopyHTMLImage.Text" xml:space="preserve">
-    <value>HTML图像</value>
+    <value>HTML 图像</value>
   </data>
   <data name="tsmiCopyHTMLLink.Text" xml:space="preserve">
-    <value>HTML链接</value>
+    <value>HTML 链接</value>
   </data>
   <data name="tsmiCopyHTMLLinkedImage.Text" xml:space="preserve">
-    <value>HTML链接的图像</value>
+    <value>HTML 链接的图像</value>
   </data>
   <data name="tsmiCopyImage.Text" xml:space="preserve">
     <value>图像</value>
   </data>
   <data name="tsmiCopyShortenedURL.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="tsmiCopyText.Text" xml:space="preserve">
     <value>文本</value>
@@ -241,7 +241,7 @@
     <value>缩略图</value>
   </data>
   <data name="tsmiCopyThumbnailURL.Text" xml:space="preserve">
-    <value>缩略图URL</value>
+    <value>缩略图 URL</value>
   </data>
   <data name="tsmiCopyURL.Text" xml:space="preserve">
     <value>URL</value>
@@ -250,7 +250,7 @@
     <value>删除本地文件</value>
   </data>
   <data name="tsmiDestinationSettings.Text" xml:space="preserve">
-    <value>目的地设置..</value>
+    <value>上传目标设置...</value>
   </data>
   <data name="tsmiDNSChanger.Text" xml:space="preserve">
     <value>修改 DNS...</value>
@@ -304,7 +304,7 @@
     <value>打开</value>
   </data>
   <data name="tsmiOpenDeletionURL.Text" xml:space="preserve">
-    <value>删除URL</value>
+    <value>删除 URL</value>
   </data>
   <data name="tsmiOpenFile.Text" xml:space="preserve">
     <value>文件</value>
@@ -313,13 +313,13 @@
     <value>文件夹</value>
   </data>
   <data name="tsmiOpenShortenedURL.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="tsmiOpenThumbnailFile.Text" xml:space="preserve">
     <value>缩略图文件</value>
   </data>
   <data name="tsmiOpenThumbnailURL.Text" xml:space="preserve">
-    <value>缩略图URL</value>
+    <value>缩略图 URL</value>
   </data>
   <data name="tsmiOpenURL.Text" xml:space="preserve">
     <value>URL</value>
@@ -328,10 +328,10 @@
     <value>二维码...</value>
   </data>
   <data name="tsmiRectangle.Text" xml:space="preserve">
-    <value>矩形</value>
+    <value>矩形区域</value>
   </data>
   <data name="tsmiRectangleLight.Text" xml:space="preserve">
-    <value>矩形（光）</value>
+    <value>矩形区域（不变暗）</value>
   </data>
   <data name="tsmiRuler.Text" xml:space="preserve">
     <value>尺子...</value>
@@ -349,10 +349,10 @@
     <value>截图文件夹...</value>
   </data>
   <data name="tsmiShareSelectedURL.Text" xml:space="preserve">
-    <value>URL分享</value>
+    <value>分享 URL</value>
   </data>
   <data name="tsmiShortenSelectedURL.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>生成 URL 短链</value>
   </data>
   <data name="tsmiShowDebugLog.Text" xml:space="preserve">
     <value>调试日志...</value>
@@ -379,10 +379,10 @@
     <value>测试文本上传</value>
   </data>
   <data name="tsmiTestURLSharing.Text" xml:space="preserve">
-    <value>测试URL共享</value>
+    <value>测试 URL 共享</value>
   </data>
   <data name="tsmiTestURLShortener.Text" xml:space="preserve">
-    <value>测试URL短链</value>
+    <value>测试 URL 短链</value>
   </data>
   <data name="tsmiTextUploaders.Text" xml:space="preserve">
     <value>文字上传</value>
@@ -460,10 +460,10 @@
     <value>二维码...</value>
   </data>
   <data name="tsmiTrayRectangle.Text" xml:space="preserve">
-    <value>矩形</value>
+    <value>矩形区域</value>
   </data>
   <data name="tsmiTrayRectangleLight.Text" xml:space="preserve">
-    <value>矩形（光）</value>
+    <value>矩形区域（不变暗）</value>
   </data>
   <data name="tsmiTrayRuler.Text" xml:space="preserve">
     <value>尺子...</value>
@@ -541,19 +541,19 @@
     <value>上传</value>
   </data>
   <data name="tsmiUploadURL.Text" xml:space="preserve">
-    <value>从URL上传...</value>
+    <value>从 URL 上传...</value>
   </data>
   <data name="tsmiURLSharingServices.Text" xml:space="preserve">
-    <value>URL共享</value>
+    <value>URL 共享</value>
   </data>
   <data name="tsmiURLShorteners.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="tsmiWindow.Text" xml:space="preserve">
     <value>窗口</value>
   </data>
   <data name="tsmiRectangleTransparent.Text" xml:space="preserve">
-    <value>矩形（透明）</value>
+    <value>矩形区域（ShareX 窗口透明）</value>
   </data>
   <data name="tsmiScrollingCapture.Text" xml:space="preserve">
     <value>滚动捕捉...</value>
@@ -568,7 +568,7 @@
     <value>视频缩略图...</value>
   </data>
   <data name="tsmiTrayRectangleTransparent.Text" xml:space="preserve">
-    <value>矩形（透明）</value>
+    <value>矩形区域（ShareX 窗口透明）</value>
   </data>
   <data name="tsmiTrayScrollingCapture.Text" xml:space="preserve">
     <value>滚动捕捉...</value>
@@ -610,13 +610,13 @@
     <value>最近的链接</value>
   </data>
   <data name="tsmiTextCapture.Text" xml:space="preserve">
-    <value>文本捕捉（OCR）</value>
+    <value>文本识别（OCR）</value>
   </data>
   <data name="tsmiDownloadSelectedURL.Text" xml:space="preserve">
     <value>下载</value>
   </data>
   <data name="tsmiTrayTextCapture.Text" xml:space="preserve">
-    <value>文本捕捉（OCR）</value>
+    <value>文本识别（OCR）</value>
   </data>
   <data name="tsmiHideColumns.Text" xml:space="preserve">
     <value>隐藏列</value>
@@ -631,10 +631,10 @@
     <value>Google 图片搜索</value>
   </data>
   <data name="tsmiOCRImage.Text" xml:space="preserve">
-    <value>OCR 图片...</value>
+    <value>文字识别（OCR）...</value>
   </data>
   <data name="tsmiCombineImages.Text" xml:space="preserve">
-    <value>图片拼接...</value>
+    <value>合并图像...</value>
   </data>
   <data name="tsmiOpenActionsToolbar.Text" xml:space="preserve">
     <value>显示工作栏</value>
@@ -661,7 +661,7 @@
     <value>Alt+C</value>
   </data>
   <data name="tsmiCopyMarkdownImage.Text" xml:space="preserve">
-    <value>Markdown 的图像</value>
+    <value>Markdown 图像</value>
   </data>
   <data name="tsmiCopyMarkdownLink.Text" xml:space="preserve">
     <value>Markdown 链接</value>
@@ -706,7 +706,7 @@
     <value>Enter</value>
   </data>
   <data name="tsmiShortenURL.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>UR L短链</value>
   </data>
   <data name="tsmiShowCursor.Text" xml:space="preserve">
     <value>显示指针</value>
@@ -731,5 +731,38 @@
   </data>
   <data name="tsmiUploadText.Text" xml:space="preserve">
     <value>上传文本...</value>
+  </data>
+  <data name="tsmiScreenshotDelay.Text" xml:space="preserve">
+    <value>截图倒计时</value>
+  </data>
+  <data name="tsmiScreenshotDelay0.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="tsmiScreenshotDelay1.Text" xml:space="preserve">
+    <value>1 秒</value>
+  </data>
+  <data name="tsmiScreenshotDelay2.Text" xml:space="preserve">
+    <value>2 秒</value>
+  </data>
+  <data name="tsmiScreenshotDelay3.Text" xml:space="preserve">
+    <value>3 秒</value>
+  </data>
+  <data name="tsmiScreenshotDelay4.Text" xml:space="preserve">
+    <value>4 秒</value>
+  </data>
+  <data name="tsmiScreenshotDelay5.Text" xml:space="preserve">
+    <value>5 秒</value>
+  </data>
+  <data name="tsmiCustomUploaderSettings.Text" xml:space="preserve">
+    <value>自定义上传目标...</value>
+  </data>
+  <data name="tsmiCopyImageDimensions.Text" xml:space="preserve">
+    <value>图像尺寸</value>
+  </data>
+  <data name="tsmiHideThumbnailTitle.Text" xml:space="preserve">
+    <value>隐藏缩略图标题</value>
+  </data>
+  <data name="tsmiSwitchTaskViewMode.Text" xml:space="preserve">
+    <value>切换至缩略图视图</value>
   </data>
 </root>

--- a/ShareX/Forms/TaskSettingsForm.zh-CN.resx
+++ b/ShareX/Forms/TaskSettingsForm.zh-CN.resx
@@ -136,7 +136,7 @@
     <value>高</value>
   </data>
   <data name="cbShowCursor.Text" xml:space="preserve">
-    <value>在屏幕截图上显示鼠标指针</value>
+    <value>在截图上显示鼠标指针</value>
   </data>
   <data name="lblCaptureShadowOffset.Text" xml:space="preserve">
     <value>阴影偏移:</value>
@@ -145,16 +145,16 @@
     <value>捕捉具有透明度的窗口</value>
   </data>
   <data name="cbCaptureAutoHideTaskbar.Text" xml:space="preserve">
-    <value>捕捉窗口时，如果窗口与任务栏相交，则隐藏任务栏</value>
+    <value>捕捉窗口时，如果窗口与任务栏重叠，则隐藏任务栏</value>
   </data>
   <data name="cbCaptureShadow.Text" xml:space="preserve">
-    <value>拍摄窗口阴影（需要透明度）</value>
+    <value>捕捉窗口阴影（需要透明度）</value>
   </data>
   <data name="lblScreenshotDelayInfo.Text" xml:space="preserve">
     <value>秒</value>
   </data>
   <data name="cbCaptureClientArea.Text" xml:space="preserve">
-    <value>捕捉窗口或活动窗口时,   捕捉客户区</value>
+    <value>截图时排除标题栏与边框</value>
   </data>
   <data name="tpRegionCapture.Text" xml:space="preserve">
     <value>区域截图</value>
@@ -199,7 +199,7 @@
     <value>文件夹路径</value>
   </data>
   <data name="cbWatchFolderEnabled.Text" xml:space="preserve">
-    <value>监控文件夹, 如果发现新的文件自动上传。</value>
+    <value>监控文件夹，如果发现新的文件自动上传。</value>
   </data>
   <data name="btnActionsRemove.Text" xml:space="preserve">
     <value>删除</value>
@@ -229,10 +229,10 @@
     <value>如果剪贴板中包含一个URL链接, 则使用URL短链来缩短。</value>
   </data>
   <data name="cbClipboardUploadAutoIndexFolder.Text" xml:space="preserve">
-    <value>如果剪贴板中包含的文件夹路径, 则自动索引文件夹并上传索引。</value>
+    <value>如果剪贴板中包含文件夹路径, 则自动索引文件夹并上传索引。</value>
   </data>
   <data name="cbClipboardUploadShareURL.Text" xml:space="preserve">
-    <value>如果剪贴板中包含一个URL链接, 则使用URL共享服务分享。</value>
+    <value>如果剪贴板中包含 URL 链接, 则使用 URL 共享服务分享。</value>
   </data>
   <data name="tpUploadClipboard.Text" xml:space="preserve">
     <value>剪贴板上传</value>
@@ -241,13 +241,13 @@
     <value>截图或剪贴板的文件名设置：</value>
   </data>
   <data name="cbFileUploadUseNamePattern.Text" xml:space="preserve">
-    <value>使用以上的文件名格式设置上传, 而不使用实际文件名上传.</value>
+    <value>使用以上的文件名格式设置上传，而不使用实际文件名上传.</value>
   </data>
   <data name="lblNameFormatPatternPreviewActiveWindow.Text" xml:space="preserve">
     <value>预览：</value>
   </data>
   <data name="lblNameFormatPatternActiveWindow.Text" xml:space="preserve">
-    <value>文件夹监控自动上传的文件名设置:</value>
+    <value>窗口截图文件名格式：</value>
   </data>
   <data name="lblNameFormatPatternPreview.Text" xml:space="preserve">
     <value>预览：</value>
@@ -256,7 +256,7 @@
     <value>使用自定义时区：</value>
   </data>
   <data name="cbRegionCaptureUseWindowPattern.Text" xml:space="preserve">
-    <value>使用窗口名称模式捕捉区域（ShareX将尝试检测选择区域后面的窗口）</value>
+    <value>使用窗口名称模式捕捉区域（ShareX 将尝试检测选择区域后面的窗口）</value>
   </data>
   <data name="tpFileNaming.Text" xml:space="preserve">
     <value>文件命名</value>
@@ -286,13 +286,13 @@
     <value>在录像中显示鼠标指针</value>
   </data>
   <data name="lblThumbnailWidth.Text" xml:space="preserve">
-    <value>宽度：</value>
+    <value>宽：</value>
   </data>
   <data name="lblThumbnailHeight.Text" xml:space="preserve">
     <value>高：</value>
   </data>
   <data name="lblThumbnailName.Text" xml:space="preserve">
-    <value>缩略图的名字：</value>
+    <value>缩略图名称：</value>
   </data>
   <data name="lblThumbnailNamePreview.Text" xml:space="preserve">
     <value>预览</value>
@@ -304,7 +304,7 @@
     <value>缩略图</value>
   </data>
   <data name="btnImageEffects.Text" xml:space="preserve">
-    <value>图像效果的配置...</value>
+    <value>图像效果配置...</value>
   </data>
   <data name="cbImageEffectOnlyRegionCapture.Text" xml:space="preserve">
     <value>只适用于区域截图</value>
@@ -343,10 +343,10 @@
     <value>任务...</value>
   </data>
   <data name="tsmiURLSharingServices.Text" xml:space="preserve">
-    <value>URL分享</value>
+    <value>URL 分享</value>
   </data>
   <data name="tsmiURLShorteners.Text" xml:space="preserve">
-    <value>URL短链</value>
+    <value>URL 短链</value>
   </data>
   <data name="tsmiFileUploaders.Text" xml:space="preserve">
     <value>文件上传</value>
@@ -358,7 +358,7 @@
     <value>图片上传</value>
   </data>
   <data name="btnDestinations.Text" xml:space="preserve">
-    <value>目的地...</value>
+    <value>上传目标...</value>
   </data>
   <data name="btnAfterUpload.Text" xml:space="preserve">
     <value>上传后...</value>
@@ -373,7 +373,7 @@
     <value>覆盖默认的自定义上传：</value>
   </data>
   <data name="cbImageAutoUseJPEG.Text" xml:space="preserve">
-    <value>如果图像大小比指定大小大，使用JPEG格式</value>
+    <value>如果图像大小比指定大小大，则使用JPEG格式</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.Text" xml:space="preserve">
     <value>选择区域...</value>
@@ -382,7 +382,7 @@
     <value>自定义区域：</value>
   </data>
   <data name="cbRegionCaptureShowFPS.Text" xml:space="preserve">
-    <value>在左上角显示FPS</value>
+    <value>在左上角显示 FPS</value>
   </data>
   <data name="lblRegionCaptureFixedSizeWidth.Text" xml:space="preserve">
     <value>宽：</value>
@@ -409,7 +409,7 @@
     <value>在光标附近显示放大镜</value>
   </data>
   <data name="cbRegionCaptureShowInfo.Text" xml:space="preserve">
-    <value>显示位置以及尺寸</value>
+    <value>显示位置与尺寸</value>
   </data>
   <data name="lblRegionCaptureSnapSizes.Text" xml:space="preserve">
     <value>按”ALT”键时、自动吸附区域</value>
@@ -442,7 +442,7 @@
     <value>宽：</value>
   </data>
   <data name="cbRegionCaptureUseDimming.Text" xml:space="preserve">
-    <value>灰暗的背景，这样选择可以更易区分（将影响启动速度）</value>
+    <value>背景暗化（便于区分选区，将影响启动速度）</value>
   </data>
   <data name="cbRegionCaptureUseCustomInfoText.Text" xml:space="preserve">
     <value>在光标附近显示自定义信息：</value>
@@ -451,13 +451,13 @@
     <value>屏幕拾色器格式：</value>
   </data>
   <data name="cbOverrideAfterCaptureSettings.Text" xml:space="preserve">
-    <value>覆盖“截图”设置</value>
+    <value>覆盖“截图后”设置</value>
   </data>
   <data name="cbOverrideAfterUploadSettings.Text" xml:space="preserve">
-    <value>覆盖“上传”设置</value>
+    <value>覆盖“上传后”设置</value>
   </data>
   <data name="cbOverrideDestinationSettings.Text" xml:space="preserve">
-    <value>覆盖“目标”设置</value>
+    <value>覆盖“上传目标”设置</value>
   </data>
   <data name="chkOverrideGeneralSettings.Text" xml:space="preserve">
     <value>覆盖一般设置</value>
@@ -484,7 +484,7 @@
     <value>上传至：</value>
   </data>
   <data name="lblUploaderFiltersExtensionsExample.Text" xml:space="preserve">
-    <value>例子：png, jpg, jpeg</value>
+    <value>例如：png, jpg, jpeg</value>
   </data>
   <data name="lblUploaderFiltersExtensions.Text" xml:space="preserve">
     <value>扩展筛选：</value>
@@ -508,7 +508,7 @@
     <value>覆盖上传设置</value>
   </data>
   <data name="lblImagePNGBitDepth.Text" xml:space="preserve">
-    <value>PNG 图像色深</value>
+    <value>PNG 图像位深</value>
   </data>
   <data name="btnRegionCaptureSnapSizesAdd.Text" xml:space="preserve">
     <value>+</value>
@@ -520,10 +520,10 @@
     <value>编辑...</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.Text" xml:space="preserve">
-    <value>上传时使用下划线替换URL中的问题字符</value>
+    <value>上传时使用下划线替换 URL 中的非法字符</value>
   </data>
   <data name="lblAutoIncrementNumber.Text" xml:space="preserve">
-    <value>0</value>
+    <value>自增数：</value>
   </data>
   <data name="lblCaptureCustomRegionX.Text" xml:space="preserve">
     <value>X</value>
@@ -538,9 +538,39 @@
     <value>kB</value>
   </data>
   <data name="lblRegionCaptureMouse4ClickAction.Text" xml:space="preserve">
-    <value>鼠标侧键1动作</value>
+    <value>鼠标侧键 1 动作</value>
   </data>
   <data name="lblRegionCaptureMouse5ClickAction.Text" xml:space="preserve">
-    <value>鼠标侧键2动作</value>
+    <value>鼠标侧键 2 动作</value>
+  </data>
+  <data name="lblScreenshotDelay.Text" xml:space="preserve">
+    <value>截图定时器：</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Text" xml:space="preserve">
+    <value>使用无损编码录制，并应用用户编码选项</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Text" xml:space="preserve">
+    <value>中止时确认</value>
+  </data>
+  <data name="cbCaptureOCRAutoCopy.Text" xml:space="preserve">
+    <value>自动复制结果至剪贴板</value>
+  </data>
+  <data name="cbCaptureOCRProcessOnLoad.Text" xml:space="preserve">
+    <value>对话框打开时识别</value>
+  </data>
+  <data name="cbCaptureOCRSilent.Text" xml:space="preserve">
+    <value>静默识别</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.Text" xml:space="preserve">
+    <value>默认语言：</value>
+  </data>
+  <data name="tpOCR.Text" xml:space="preserve">
+    <value>文本识别（OCR）</value>
+  </data>
+  <data name="btnAutoIncrementNumber.Text" xml:space="preserve">
+    <value>更改</value>
+  </data>
+  <data name="cbClipboardUploadURLContents.Text" xml:space="preserve">
+    <value>如果剪贴板中包含文件 URL，则下载并上传它</value>
   </data>
 </root>

--- a/ShareX/Properties/Resources.zh-CN.resx
+++ b/ShareX/Properties/Resources.zh-CN.resx
@@ -118,26 +118,26 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AutoCaptureForm_UpdateStatus_Timeleft___0_s___1____Total___2_" xml:space="preserve">
-    <value>剩余时间: {0}秒 ({1}%) 总计: {2}</value>
+    <value>剩余时间：{0}秒 ({1}%) 总计：{2}</value>
   </data>
   <data name="AboutForm_AboutForm_Contributors" xml:space="preserve">
     <value>开源贡献</value>
   </data>
   <data name="TaskHelpers_TweetMessage_Unable_to_find_valid_Twitter_account_" xml:space="preserve">
-    <value>无法找到可用的Twitter账号。</value>
+    <value>无法找到可用的 Twitter 账号。</value>
   </data>
   <data name="UploadTask_ThreadDoWork_URL_is_empty_" xml:space="preserve">
-    <value>URL是空的.</value>
+    <value>URL是空的。</value>
   </data>
   <data name="ApplicationSettingsForm_btnBrowsePersonalFolderPath_Click_Choose_ShareX_personal_folder_path" xml:space="preserve">
     <value>选择ShareX个人文件夹路径</value>
   </data>
   <data name="HotkeyManager_ShowFailedHotkeys_Unable_to_register_hotkey" xml:space="preserve">
-    <value>无法注册 {0}:
+    <value>无法注册快捷键 {0}：
 
 {1}
 
-请选择一个不同的快捷键,   或退出冲突的应用程序,   然后重新打开ShareX.</value>
+请选择一个不同的快捷键，或退出冲突的应用程序，并重新启动ShareX。</value>
   </data>
   <data name="MainForm_tsmiDeleteSelectedFile_Click_File_delete_confirmation" xml:space="preserve">
     <value>文件删除确认</value>
@@ -146,19 +146,19 @@
     <value>停止</value>
   </data>
   <data name="UploadTask_CreateShareURLTask_Share_URL___0__" xml:space="preserve">
-    <value>分享URL ({0})</value>
+    <value>分享 URL ({0})</value>
   </data>
   <data name="AutoCaptureForm_UpdateRegion_X___0___Y___1___Width___2___Height___3_" xml:space="preserve">
-    <value>X: {0},   Y: {1},   宽: {2},   高: {3}</value>
+    <value>X: {0}，Y: {1}， 宽: {2}，高: {3}</value>
   </data>
   <data name="UploadManager_IsUploadConfirmed_Don_t_show_this_message_again_" xml:space="preserve">
     <value>不要再显示此消息。</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_Task___0_" xml:space="preserve">
-    <value>任务: {0}</value>
+    <value>任务：{0}</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_FFmpeg_video_and_audio_source_both_can_t_be__None__" xml:space="preserve">
-    <value>FFmpeg的视频和音频信号源都不能是"None".</value>
+    <value>FFmpeg 的视频和音频信号源不可都为“空”。</value>
   </data>
   <data name="AboutForm_AboutForm_Changelog" xml:space="preserve">
     <value>更新日志</value>
@@ -173,15 +173,15 @@
     <value>任务设置</value>
   </data>
   <data name="BeforeUploadForm_BeforeUploadForm_Please_choose_a_destination_" xml:space="preserve">
-    <value>请选择一个上传地址.</value>
+    <value>请选择一个上传地址。</value>
   </data>
   <data name="UploadTask_Prepare_Starting" xml:space="preserve">
     <value>开始</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_does_not_exist" xml:space="preserve">
-    <value>{0} 不存在.
+    <value>{0} 不存在。
 
-你想自动下载吗?</value>
+要自动下载吗?</value>
   </data>
   <data name="AboutForm_AboutForm_External_libraries" xml:space="preserve">
     <value>外部库</value>
@@ -196,14 +196,14 @@
     <value>您可以从快捷键设置添加快捷动作...</value>
   </data>
   <data name="ImageData_Write_Error" xml:space="preserve">
-    <value>无法写入图像到路径{0}。</value>
+    <value>无法写入图像到路径 {0}。</value>
   </data>
   <data name="ApplicationSettingsForm_cbLanguage_SelectedIndexChanged_Language_Restart" xml:space="preserve">
-    <value>语言更改需要重新启动ShareX。
-你要重新启动ShareX？</value>
+    <value>语言更改需要重新启动 ShareX。
+你要重新启动 ShareX ？</value>
   </data>
   <data name="FileExistForm_txtNewName_TextChanged_Use_new_name__" xml:space="preserve">
-    <value>使用新的名字:</value>
+    <value>使用新的名字：</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Missing" xml:space="preserve">
     <value>丢失</value>
@@ -215,13 +215,13 @@
     <value>第一次上传警告</value>
   </data>
   <data name="ChromeForm_btnRegister_Click_Chrome_support_enabled_" xml:space="preserve">
-    <value>Chrome浏览器扩展支持已启用。</value>
+    <value>Chrome 浏览器扩展支持已启用。</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_After_capture___0_" xml:space="preserve">
-    <value>捕捉后: {0}</value>
+    <value>捕捉后：{0}</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_URL_shortener___0_" xml:space="preserve">
-    <value>URL短链: {0}</value>
+    <value>URL短链：{0}</value>
   </data>
   <data name="UploadInfoManager_ShowErrors_Upload_errors" xml:space="preserve">
     <value>上传错误</value>
@@ -242,14 +242,14 @@
     <value>文件上传</value>
   </data>
   <data name="MainForm_tsmiDeleteSelectedFile_Click_Do_you_really_want_to_delete_this_file_" xml:space="preserve">
-    <value>你真的要删除这个文件?</value>
+    <value>你真的要删除这个文件吗?</value>
   </data>
   <data name="UploadManager_DownloadAndUploadFile_Download_failed" xml:space="preserve">
-    <value>下载失败:
+    <value>下载失败：
 {0}</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_Text_uploader___0_" xml:space="preserve">
-    <value>文字上传: {0}</value>
+    <value>文字上传：{0}</value>
   </data>
   <data name="UploadTask_Prepare_Preparing" xml:space="preserve">
     <value>准备</value>
@@ -258,7 +258,7 @@
     <value>停止</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_URL_sharing_service___0_" xml:space="preserve">
-    <value>URL共享: {0}</value>
+    <value>URL 共享: {0}</value>
   </data>
   <data name="ChromeForm_btnUnregister_Click_Chrome_support_disabled_" xml:space="preserve">
     <value>Chrome浏览器扩展支持已禁用。</value>
@@ -282,13 +282,13 @@
     <value>完成</value>
   </data>
   <data name="BeforeUploadForm_BeforeUploadForm__0__is_about_to_be_uploaded_to__1___You_may_choose_a_different_destination_" xml:space="preserve">
-    <value>{0} 是将要上载至 {1}. 您可以选择不同的上传地址.</value>
+    <value>{0} 将上载至 {1}，您可以选择不同的上传目标。</value>
   </data>
   <data name="AboutForm_AboutForm_Website" xml:space="preserve">
     <value>网站</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_After_upload___0_" xml:space="preserve">
-    <value>上传后: {0}</value>
+    <value>上传后：{0}</value>
   </data>
   <data name="ApplicationSettingsForm_btnBrowseCustomScreenshotsPath_Click_Choose_screenshots_folder_path" xml:space="preserve">
     <value>选择截图文件夹路径</value>
@@ -303,10 +303,10 @@
     <value>等待...</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_Image_uploader___0_" xml:space="preserve">
-    <value>图片上传: {0}</value>
+    <value>图片上传：{0}</value>
   </data>
   <data name="TaskHelpers_OpenQuickScreenColorPicker_Copied_to_clipboard___0_" xml:space="preserve">
-    <value>已复制到剪贴板: {0}</value>
+    <value>已复制到剪贴板：{0}</value>
   </data>
   <data name="MainForm_UpdateMenu_Hide_menu" xml:space="preserve">
     <value>隐藏菜单</value>
@@ -315,7 +315,7 @@
     <value>显示菜单</value>
   </data>
   <data name="UploadManager_UploadURL_URL_to_download_from_and_upload" xml:space="preserve">
-    <value>下载和上传URL</value>
+    <value>下载和上传 URL</value>
   </data>
   <data name="ActionsForm_btnOK_Click_File_path_can_t_be_empty_" xml:space="preserve">
     <value>文件路径不能为空。</value>
@@ -342,7 +342,7 @@
     <value>错误</value>
   </data>
   <data name="ClipboardFormatForm_ClipboardFormatForm_Supported_variables___0__and_other_variables_such_as__1__etc_" xml:space="preserve">
-    <value>支持的变量: {0} 和其他变量,   如 {1} 等。</value>
+    <value>支持的变量：{0} 和其它变量，如 {1} 等。</value>
   </data>
   <data name="DropForm_DrawDropImage_Drop_here" xml:space="preserve">
     <value>拖到
@@ -355,20 +355,20 @@
     <value>快捷键</value>
   </data>
   <data name="TaskSettingsForm_UpdateUploaderMenuNames_File_uploader___0_" xml:space="preserve">
-    <value>文件上传: {0}</value>
+    <value>文件上传：{0}</value>
   </data>
   <data name="AboutForm_AboutForm_Project_page" xml:space="preserve">
     <value>项目页面</value>
   </data>
   <data name="TaskHelpers_TweetMessage_Tweet_successfully_sent_" xml:space="preserve">
-    <value>Tweet发送成功。</value>
+    <value>Tweet 发送成功。</value>
   </data>
   <data name="Program_WritePersonalPathConfig_Cant_access_to_file" xml:space="preserve">
     <value>无法访问 "{0}" 文件.
-请以管理员权限运行ShareX以更改个人文件夹的路径.</value>
+请以管理员权限运行 ShareX 以更改个人文件夹路径。</value>
   </data>
   <data name="ApplicationSettingsForm_cbSteamShowInApp_CheckedChanged_For_settings_to_take_effect_ShareX_needs_to_be_reopened_from_Steam_" xml:space="preserve">
-    <value>为了使设置生效，ShareX需要从Steam重新开启。</value>
+    <value>为使设置生效，ShareX 需从 Steam 重新启动。</value>
   </data>
   <data name="ActionsForm_btnOK_Click_Name_can_t_be_empty_" xml:space="preserve">
     <value>名称不能为空。</value>
@@ -383,7 +383,7 @@
     <value>文件上传</value>
   </data>
   <data name="ScreenRecordForm_DownloaderForm_InstallRequested_FFmpeg_successfully_downloaded_" xml:space="preserve">
-    <value>FFmpeg下载成功。</value>
+    <value>FFmpeg 下载成功。</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
     <value>编码...</value>
@@ -401,7 +401,7 @@
     <value>暂停</value>
   </data>
   <data name="UploadTask_CreateURLShortenerTask_Shorten_URL___0__" xml:space="preserve">
-    <value>缩短URL ({0})</value>
+    <value>缩短 URL ({0})</value>
   </data>
   <data name="UploadTask_DoUploadJob_First_time_upload_warning_text" xml:space="preserve">
     <value>你确定要上传这个截图？
@@ -442,7 +442,7 @@
     <value>继续</value>
   </data>
   <data name="IntegrationHelpers_UploadWithShareX" xml:space="preserve">
-    <value>使用ShareX上传</value>
+    <value>使用 ShareX 上传</value>
   </data>
   <data name="ActionsToolbarEditForm_Separator" xml:space="preserve">
     <value>分隔符</value>
@@ -457,7 +457,7 @@
     <value>保持在其他窗口前端</value>
   </data>
   <data name="ActionsToolbar_OpenAtShareXStartup" xml:space="preserve">
-    <value>和ShareX一起打开</value>
+    <value>和 ShareX 同时启动</value>
   </data>
   <data name="ActionsToolbar_Edit" xml:space="preserve">
     <value>编辑...</value>
@@ -519,7 +519,7 @@
     <value>意大利语</value>
   </data>
   <data name="UploadManager_ShowShortenURLDialog_ShortenURL" xml:space="preserve">
-    <value>生成URL短链</value>
+    <value>生成 UR L短链</value>
   </data>
   <data name="UploadManager_ShowShortenURLDialog_Shorten" xml:space="preserve">
     <value>生成</value>
@@ -528,9 +528,53 @@
     <value>使用ShareX编辑</value>
   </data>
   <data name="ApplicationSettingsForm_btnCheckDevBuild_Click_DevBuilds_Warning" xml:space="preserve">
-    <value>Dev builds并不稳定，仅可用于测试目的，要安装吗？</value>
+    <value>开发版并不稳定，仅用于测试目的，要安装吗？</value>
   </data>
   <data name="ApplicationSettingsForm_btnResetSettings_Click_WouldYouLikeToResetShareXSettings" xml:space="preserve">
-    <value>要重置ShareX设置项吗？</value>
+    <value>要重置 ShareX 设置项吗？</value>
+  </data>
+  <data name="ApplicationSettingsForm_cbStartWithWindows_EnabledByPolicy_Text" xml:space="preserve">
+    <value>启动已由你的组织启用</value>
+  </data>
+  <data name="OCRForm_AutoCompleteFail" xml:space="preserve">
+    <value>文本识别时出错，或未识别到任何文本。</value>
+  </data>
+  <data name="AboutForm_AboutForm_Language_uk" xml:space="preserve">
+    <value>乌克兰语</value>
+  </data>
+  <data name="OCRForm_AutoComplete" xml:space="preserve">
+    <value>文本识别结果已复制至剪贴板。</value>
+  </data>
+  <data name="AboutForm_AboutForm_Language_id_ID" xml:space="preserve">
+    <value>印尼语</value>
+  </data>
+  <data name="ApplicationSettingsForm_cbStartWithWindows_DisabledByPolicy_Text" xml:space="preserve">
+    <value>开机启动项已被你的组织禁用</value>
+  </data>
+  <data name="OCRForm_AutoProcessing" xml:space="preserve">
+    <value>文字识别中。</value>
+  </data>
+  <data name="MainForm_UploadDebugLogWarning" xml:space="preserve">
+    <value>调试日志可能包含敏感信息，确定继续吗？</value>
+  </data>
+  <data name="AboutForm_AboutForm_Language_es_MX" xml:space="preserve">
+    <value>西班牙语 - 墨西哥</value>
+  </data>
+  <data name="ShareXNeedsToBeRestartedForThePersonalFolderChangesToApply" xml:space="preserve">
+    <value>ShareX 需要重启以应用个人文件夹更改。
+
+要重启吗？</value>
+  </data>
+  <data name="ShareXConfirmation" xml:space="preserve">
+    <value>ShareX - 确认</value>
+  </data>
+  <data name="ScreenshotDelay0S" xml:space="preserve">
+    <value>截图倒计时：{0} 秒</value>
+  </data>
+  <data name="PleaseNoteThatShareXIsUsingOCRSpaceSOnlineAPIToPerformOpticalCharacterRecognitionDoYouGivePermissionToShareXToUploadImagesToThisService" xml:space="preserve">
+    <value>请注意，ShareX 使用 OCR.Space 的在线 API 来执行光学字符识别，是否允许 ShareX 上传图像至此在线服务？</value>
+  </data>
+  <data name="ShareXOpticalCharacterRecognition" xml:space="preserve">
+    <value>ShareX - 光学字符识别</value>
   </data>
 </root>


### PR DESCRIPTION
1. Created translation files for the new windows and modules.
2. Inserted translations of the new items.
3. Removed unnecessary retranslations of proper nouns, abbreviations, and links.
4. Deleted the items which were deleted in the neutral version.
5. Added appropriate spaces to optimize the mixed typesetting of Chinese and English.
6. Optimized some translated texts.
7. Unified the forms of punctuations between halfwidth and fullwidth except the hotkey suffixes.