### PR TITLE
Add minor thumbnail view styling improvement

### DIFF
--- a/ShareX/Controls/TaskThumbnailPanel.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.Designer.cs
@@ -32,28 +32,14 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.ttMain = new System.Windows.Forms.ToolTip(this.components);
+            this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.pThumbnail = new ShareX.TaskRoundedCornerPanel();
             this.pbProgress = new ShareX.HelpersLib.BlackStyleProgressBar();
             this.pbThumbnail = new System.Windows.Forms.PictureBox();
             this.pThumbnail.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbThumbnail)).BeginInit();
             this.SuspendLayout();
-            // 
-            // lblTitle
-            // 
-            this.lblTitle.AutoEllipsis = true;
-            this.lblTitle.BackColor = System.Drawing.Color.Transparent;
-            this.lblTitle.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblTitle.ForeColor = System.Drawing.Color.White;
-            this.lblTitle.Location = new System.Drawing.Point(0, 0);
-            this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(256, 22);
-            this.lblTitle.TabIndex = 1;
-            this.lblTitle.Text = "Test.png";
-            this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.lblTitle.MouseClick += new System.Windows.Forms.MouseEventHandler(this.LblTitle_MouseClick);
             // 
             // ttMain
             // 
@@ -63,14 +49,29 @@
             this.ttMain.ReshowDelay = 100;
             this.ttMain.Draw += new System.Windows.Forms.DrawToolTipEventHandler(this.TtMain_Draw);
             // 
+            // lblTitle
+            // 
+            this.lblTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblTitle.AutoEllipsis = true;
+            this.lblTitle.BackColor = System.Drawing.Color.Transparent;
+            this.lblTitle.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblTitle.ForeColor = System.Drawing.Color.White;
+            this.lblTitle.Location = new System.Drawing.Point(3, 265);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.Size = new System.Drawing.Size(256, 22);
+            this.lblTitle.TabIndex = 1;
+            this.lblTitle.Text = "Test.png";
+            this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblTitle.MouseClick += new System.Windows.Forms.MouseEventHandler(this.LblTitle_MouseClick);
+            // 
             // pThumbnail
             // 
             this.pThumbnail.BackColor = System.Drawing.Color.Transparent;
             this.pThumbnail.Controls.Add(this.pbProgress);
             this.pThumbnail.Controls.Add(this.pbThumbnail);
-            this.pThumbnail.Location = new System.Drawing.Point(0, 24);
+            this.pThumbnail.Location = new System.Drawing.Point(0, 0);
             this.pThumbnail.Name = "pThumbnail";
-            this.pThumbnail.Padding = new System.Windows.Forms.Padding(5);
+            this.pThumbnail.Padding = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.pThumbnail.PanelColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(32)))), ((int)(((byte)(38)))));
             this.pThumbnail.Radius = 5F;
             this.pThumbnail.Size = new System.Drawing.Size(256, 256);
@@ -83,7 +84,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.pbProgress.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.pbProgress.ForeColor = System.Drawing.Color.White;
-            this.pbProgress.Location = new System.Drawing.Point(8, 216);
+            this.pbProgress.Location = new System.Drawing.Point(5, 214);
             this.pbProgress.Name = "pbProgress";
             this.pbProgress.ShowPercentageText = true;
             this.pbProgress.Size = new System.Drawing.Size(240, 32);
@@ -95,8 +96,8 @@
             // pbThumbnail
             // 
             this.pbThumbnail.BackColor = System.Drawing.Color.Transparent;
-            this.pbThumbnail.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pbThumbnail.Location = new System.Drawing.Point(5, 5);
+            this.pbThumbnail.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pbThumbnail.Name = "pbThumbnail";
             this.pbThumbnail.Size = new System.Drawing.Size(246, 246);
             this.pbThumbnail.TabIndex = 2;
@@ -114,7 +115,7 @@
             this.Controls.Add(this.pThumbnail);
             this.Controls.Add(this.lblTitle);
             this.Name = "TaskThumbnailPanel";
-            this.Size = new System.Drawing.Size(256, 280);
+            this.Size = new System.Drawing.Size(262, 288);
             this.pThumbnail.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pbThumbnail)).EndInit();
             this.ResumeLayout(false);

--- a/ShareX/Controls/TaskThumbnailPanel.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.cs
@@ -233,7 +233,7 @@ namespace ShareX
         {
             lblTitle.Width = pThumbnail.Padding.Horizontal + ThumbnailSize.Width;
             pThumbnail.Size = new Size(pThumbnail.Padding.Horizontal + ThumbnailSize.Width, pThumbnail.Padding.Vertical + ThumbnailSize.Height);
-            Size = new Size(pThumbnail.Width, pThumbnail.Top + pThumbnail.Height);
+            Size = new Size(pThumbnail.Width, pThumbnail.Top + pThumbnail.Height + 22);
         }
 
         public void UpdateThumbnail(Image image = null)


### PR DESCRIPTION
I really love the new redesign of the latest update (including the dark theme) but I just can't stand the new thumbnail view. I don't get why the labels are placed above the thumbnails and it's looks really counter intuitive, especially when scrolling through it. This pull request places the labels below the thumbnails to make it easier to use (in my opinion).

**Before:**
<img src="https://user-images.githubusercontent.com/7524012/63937760-73824100-ca63-11e9-9691-7f945c7abfaf.png" width="450">

**After:**
<img src="https://user-images.githubusercontent.com/7524012/63937816-a1678580-ca63-11e9-8295-33ce0334c170.png" width="450">


If this was intended, feel free to reject my pull request. I did not discuss anything and just made this pull request.