### PR TITLE
Fixed problem with pixelization for png images

### DIFF
--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1142,7 +1142,7 @@ namespace ShareX.HelpersLib
                                 {
                                     ColorBgra color = unsafeBitmap.GetPixel(x2, y2);
 
-                                    float pixelWeight = color.Alpha / 255;
+                                    float pixelWeight = (float)color.Alpha / 255;
 
                                     r += color.Red * pixelWeight;
                                     g += color.Green * pixelWeight;


### PR DESCRIPTION
Hi there!
I'm a developer at PVS-Studio company. Recently, I have checked your project with our static code analyzer and found one interesting bug: pixelization doesn't work for png images which have some degree of transparency. This pull request is aiming to solve that issue.
We actually dedicated half of our article to your project check and described more minor imperfect places. You can read it [here](https://www.viva64.com/en/b/0670/), there is a detailed explanation of that pixelization bug too.
We are glad to give you our license for one month, so you can test your project more thorough:
Name: ShareX
Key: 94AG-4M9U-1KK0-T18E
License Type: Team9 License up to 9 developers
License Valid Thru: Oct 17, 2019