### PR TITLE
Use Default Task Settings for screen QR scanner

### DIFF
--- a/ShareX/Forms/QRCodeForm.cs
+++ b/ShareX/Forms/QRCodeForm.cs
@@ -219,7 +219,7 @@ namespace ShareX
                 Hide();
                 Thread.Sleep(250);
 
-                using (Image img = RegionCaptureTasks.GetRegionImage(null))
+                using (Image img = RegionCaptureTasks.GetRegionImage(TaskSettings.GetDefaultTaskSettings().CaptureSettings.SurfaceOptions))
                 {
                     if (img != null)
                     {


### PR DESCRIPTION
Minor testing and I wasn't able to break it, unsure how it bypasses the Pre-Configured region option.
Mainly wrote this to respect the user's task setting of using a Square or Circle magnification shape