### PR TITLE
fixed #4280: Thumbnail view multi select support

### DIFF
--- a/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleCheckBox.cs
+++ b/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleCheckBox.cs
@@ -76,7 +76,11 @@ namespace ShareX.HelpersLib
             }
         }
 
+        [DefaultValue(3)]
         public int SpaceAfterCheckBox { get; set; }
+
+        [DefaultValue(false)]
+        public bool IgnoreClick { get; set; }
 
         private bool isChecked, isHover;
         private string text;
@@ -151,7 +155,10 @@ namespace ShareX.HelpersLib
         {
             base.OnClick(e);
 
-            Checked = !Checked;
+            if (!IgnoreClick)
+            {
+                Checked = !Checked;
+            }
         }
 
         protected virtual void OnCheckedChanged(EventArgs e)

--- a/ShareX/Controls/TaskThumbnailPanel.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.Designer.cs
@@ -34,6 +34,7 @@
             this.components = new System.ComponentModel.Container();
             this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.ttMain = new System.Windows.Forms.ToolTip(this.components);
+            this.cbSelected = new ShareX.HelpersLib.BlackStyleCheckBox();
             this.pThumbnail = new ShareX.TaskRoundedCornerPanel();
             this.pbProgress = new ShareX.HelpersLib.BlackStyleProgressBar();
             this.pbThumbnail = new System.Windows.Forms.PictureBox();
@@ -63,9 +64,23 @@
             this.ttMain.ReshowDelay = 100;
             this.ttMain.Draw += new System.Windows.Forms.DrawToolTipEventHandler(this.TtMain_Draw);
             // 
+            // cbSelected
+            // 
+            this.cbSelected.BackColor = System.Drawing.Color.Transparent;
+            this.cbSelected.Checked = true;
+            this.cbSelected.Font = new System.Drawing.Font("Arial", 8F);
+            this.cbSelected.ForeColor = System.Drawing.Color.White;
+            this.cbSelected.Location = new System.Drawing.Point(8, 8);
+            this.cbSelected.Name = "cbSelected";
+            this.cbSelected.Size = new System.Drawing.Size(13, 13);
+            this.cbSelected.SpaceAfterCheckBox = 3;
+            this.cbSelected.TabIndex = 2;
+            this.cbSelected.Visible = false;
+            // 
             // pThumbnail
             // 
             this.pThumbnail.BackColor = System.Drawing.Color.Transparent;
+            this.pThumbnail.Controls.Add(this.cbSelected);
             this.pThumbnail.Controls.Add(this.pbProgress);
             this.pThumbnail.Controls.Add(this.pbThumbnail);
             this.pThumbnail.Location = new System.Drawing.Point(0, 24);
@@ -74,6 +89,7 @@
             this.pThumbnail.PanelColor = System.Drawing.Color.FromArgb(((int)(((byte)(28)))), ((int)(((byte)(32)))), ((int)(((byte)(38)))));
             this.pThumbnail.Radius = 5F;
             this.pThumbnail.Size = new System.Drawing.Size(256, 256);
+            this.pThumbnail.StatusLocation = ShareX.ThumbnailTitleLocation.Top;
             this.pThumbnail.TabIndex = 0;
             this.pThumbnail.MouseClick += new System.Windows.Forms.MouseEventHandler(this.PbThumbnail_MouseClick);
             // 
@@ -128,5 +144,6 @@
         private HelpersLib.BlackStyleProgressBar pbProgress;
         private System.Windows.Forms.PictureBox pbThumbnail;
         private System.Windows.Forms.ToolTip ttMain;
+        private HelpersLib.BlackStyleCheckBox cbSelected;
     }
 }

--- a/ShareX/Controls/TaskThumbnailPanel.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.Designer.cs
@@ -32,29 +32,15 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.ttMain = new System.Windows.Forms.ToolTip(this.components);
-            this.cbSelected = new ShareX.HelpersLib.BlackStyleCheckBox();
             this.pThumbnail = new ShareX.TaskRoundedCornerPanel();
+            this.cbSelected = new ShareX.HelpersLib.BlackStyleCheckBox();
             this.pbProgress = new ShareX.HelpersLib.BlackStyleProgressBar();
             this.pbThumbnail = new System.Windows.Forms.PictureBox();
+            this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.pThumbnail.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pbThumbnail)).BeginInit();
             this.SuspendLayout();
-            // 
-            // lblTitle
-            // 
-            this.lblTitle.AutoEllipsis = true;
-            this.lblTitle.BackColor = System.Drawing.Color.Transparent;
-            this.lblTitle.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblTitle.ForeColor = System.Drawing.Color.White;
-            this.lblTitle.Location = new System.Drawing.Point(0, 0);
-            this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(256, 22);
-            this.lblTitle.TabIndex = 1;
-            this.lblTitle.Text = "Test.png";
-            this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.lblTitle.MouseClick += new System.Windows.Forms.MouseEventHandler(this.LblTitle_MouseClick);
             // 
             // ttMain
             // 
@@ -63,19 +49,6 @@
             this.ttMain.OwnerDraw = true;
             this.ttMain.ReshowDelay = 100;
             this.ttMain.Draw += new System.Windows.Forms.DrawToolTipEventHandler(this.TtMain_Draw);
-            // 
-            // cbSelected
-            // 
-            this.cbSelected.BackColor = System.Drawing.Color.Transparent;
-            this.cbSelected.Checked = true;
-            this.cbSelected.Font = new System.Drawing.Font("Arial", 8F);
-            this.cbSelected.ForeColor = System.Drawing.Color.White;
-            this.cbSelected.Location = new System.Drawing.Point(8, 8);
-            this.cbSelected.Name = "cbSelected";
-            this.cbSelected.Size = new System.Drawing.Size(13, 13);
-            this.cbSelected.SpaceAfterCheckBox = 3;
-            this.cbSelected.TabIndex = 2;
-            this.cbSelected.Visible = false;
             // 
             // pThumbnail
             // 
@@ -92,6 +65,19 @@
             this.pThumbnail.StatusLocation = ShareX.ThumbnailTitleLocation.Top;
             this.pThumbnail.TabIndex = 0;
             this.pThumbnail.MouseClick += new System.Windows.Forms.MouseEventHandler(this.PbThumbnail_MouseClick);
+            // 
+            // cbSelected
+            // 
+            this.cbSelected.BackColor = System.Drawing.Color.Transparent;
+            this.cbSelected.Checked = true;
+            this.cbSelected.Font = new System.Drawing.Font("Arial", 8F);
+            this.cbSelected.ForeColor = System.Drawing.Color.White;
+            this.cbSelected.IgnoreClick = true;
+            this.cbSelected.Location = new System.Drawing.Point(4, 4);
+            this.cbSelected.Name = "cbSelected";
+            this.cbSelected.Size = new System.Drawing.Size(13, 13);
+            this.cbSelected.TabIndex = 2;
+            this.cbSelected.Visible = false;
             // 
             // pbProgress
             // 
@@ -121,6 +107,20 @@
             this.pbThumbnail.MouseDown += new System.Windows.Forms.MouseEventHandler(this.PbThumbnail_MouseDown);
             this.pbThumbnail.MouseMove += new System.Windows.Forms.MouseEventHandler(this.PbThumbnail_MouseMove);
             this.pbThumbnail.MouseUp += new System.Windows.Forms.MouseEventHandler(this.PbThumbnail_MouseUp);
+            // 
+            // lblTitle
+            // 
+            this.lblTitle.AutoEllipsis = true;
+            this.lblTitle.BackColor = System.Drawing.Color.Transparent;
+            this.lblTitle.Font = new System.Drawing.Font("Arial", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblTitle.ForeColor = System.Drawing.Color.White;
+            this.lblTitle.Location = new System.Drawing.Point(0, 0);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.Size = new System.Drawing.Size(256, 22);
+            this.lblTitle.TabIndex = 1;
+            this.lblTitle.Text = "Test.png";
+            this.lblTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.lblTitle.MouseClick += new System.Windows.Forms.MouseEventHandler(this.LblTitle_MouseClick);
             // 
             // TaskThumbnailPanel
             // 

--- a/ShareX/Controls/TaskThumbnailPanel.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.cs
@@ -411,7 +411,7 @@ namespace ShareX
 
         private void LblTitle_MouseClick(object sender, MouseEventArgs e)
         {
-            if (e.Button == MouseButtons.Left && Task.Info != null)
+            if (ModifierKeys != Keys.Control && e.Button == MouseButtons.Left && Task.Info != null)
             {
                 if (Task.Info.Result != null)
                 {

--- a/ShareX/Controls/TaskThumbnailPanel.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.cs
@@ -96,6 +96,25 @@ namespace ShareX
 
         public WorkerTask Task { get; private set; }
 
+        private bool selected;
+
+        public bool Selected
+        {
+            get
+            {
+                return selected;
+            }
+            set
+            {
+                if (selected != value)
+                {
+                    selected = value;
+
+                    cbSelected.Visible = selected;
+                }
+            }
+        }
+
         private string title;
 
         public string Title
@@ -428,7 +447,7 @@ namespace ShareX
 
         private void PbThumbnail_MouseClick(object sender, MouseEventArgs e)
         {
-            if (ThumbnailSupportsClick && e.Button == MouseButtons.Left && Task.Info != null)
+            if (ThumbnailSupportsClick && ModifierKeys != Keys.Control && e.Button == MouseButtons.Left && Task.Info != null)
             {
                 string filePath = Task.Info.FilePath;
 

--- a/ShareX/Controls/TaskThumbnailView.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailView.Designer.cs
@@ -42,7 +42,7 @@
             this.flpMain.TabIndex = 0;
             this.flpMain.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FlpMain_MouseDown);
             this.flpMain.MouseEnter += new System.EventHandler(this.FlpMain_MouseEnter);
-            this.flpMain.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Panel_MouseUp);
+            this.flpMain.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TaskThumbnailView_MouseUp);
             // 
             // TaskThumbnailView
             // 
@@ -55,7 +55,7 @@
             this.Size = new System.Drawing.Size(242, 228);
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FlpMain_MouseDown);
             this.MouseEnter += new System.EventHandler(this.FlpMain_MouseEnter);
-            this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Panel_MouseUp);
+            this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TaskThumbnailView_MouseUp);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/ShareX/Controls/TaskThumbnailView.cs
+++ b/ShareX/Controls/TaskThumbnailView.cs
@@ -34,7 +34,20 @@ namespace ShareX
     public partial class TaskThumbnailView : UserControl
     {
         public List<TaskThumbnailPanel> Panels { get; private set; }
-        public TaskThumbnailPanel SelectedPanel { get; private set; }
+        public List<TaskThumbnailPanel> SelectedPanels { get; private set; }
+
+        public TaskThumbnailPanel SelectedPanel
+        {
+            get
+            {
+                if (SelectedPanels.Count > 0)
+                {
+                    return SelectedPanels[SelectedPanels.Count - 1];
+                }
+
+                return null;
+            }
+        }
 
         private bool titleVisible = true;
 
@@ -102,12 +115,13 @@ namespace ShareX
             }
         }
 
-        public delegate void TaskViewMouseEventHandler(object sender, MouseEventArgs e, WorkerTask task);
+        public delegate void TaskViewMouseEventHandler(object sender, MouseEventArgs e);
         public event TaskViewMouseEventHandler ContextMenuRequested;
 
         public TaskThumbnailView()
         {
             Panels = new List<TaskThumbnailPanel>();
+            SelectedPanels = new List<TaskThumbnailPanel>();
 
             InitializeComponent();
             UpdateTheme();
@@ -139,7 +153,15 @@ namespace ShareX
         {
             TaskThumbnailPanel panel = new TaskThumbnailPanel(task);
             panel.MouseEnter += FlpMain_MouseEnter;
-            panel.MouseDown += (sender, e) => SelectedPanel = panel;
+            panel.MouseDown += (sender, e) =>
+            {
+                if (ModifierKeys == Keys.Control)
+                {
+                    SelectedPanels.Clear();
+                }
+
+                SelectedPanels.Add(panel);
+            };
             panel.MouseUp += Panel_MouseUp;
             panel.ThumbnailSize = ThumbnailSize;
             panel.TitleVisible = TitleVisible;
@@ -184,11 +206,11 @@ namespace ShareX
             }
         }
 
-        protected void OnContextMenuRequested(object sender, MouseEventArgs e, WorkerTask task)
+        protected void OnContextMenuRequested(object sender, MouseEventArgs e)
         {
             if (ContextMenuRequested != null)
             {
-                ContextMenuRequested(sender, e, task);
+                ContextMenuRequested(sender, e);
             }
         }
 
@@ -203,14 +225,14 @@ namespace ShareX
 
         private void FlpMain_MouseDown(object sender, MouseEventArgs e)
         {
-            SelectedPanel = null;
+            SelectedPanels.Clear();
         }
 
         private void Panel_MouseUp(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Right)
             {
-                OnContextMenuRequested(sender, e, SelectedPanel?.Task);
+                OnContextMenuRequested(sender, e);
             }
         }
     }

--- a/ShareX/UploadInfoManager.cs
+++ b/ShareX/UploadInfoManager.cs
@@ -32,7 +32,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace ShareX
 {
@@ -61,33 +60,18 @@ namespace ShareX
             }
         }
 
-        private ListView lv;
         private UploadInfoParser parser;
 
-        public UploadInfoManager(ListView listView)
+        public UploadInfoManager()
         {
-            lv = listView;
             parser = new UploadInfoParser();
         }
 
-        public void RefreshSelectedItems()
+        public void UpdateSelectedItems(IEnumerable<WorkerTask> tasks)
         {
-            if (lv != null && lv.SelectedItems != null && lv.SelectedItems.Count > 0)
+            if (tasks != null && tasks.Count() > 0)
             {
-                SelectedItems = lv.SelectedItems.Cast<ListViewItem>().Select(x => x.Tag as WorkerTask).Where(x => x != null && x.Info != null).
-                    Select(x => new UploadInfoStatus(x)).ToArray();
-            }
-            else
-            {
-                SelectedItems = null;
-            }
-        }
-
-        public void SelectItem(WorkerTask task)
-        {
-            if (task != null && task.Info != null)
-            {
-                SelectedItems = new UploadInfoStatus[] { new UploadInfoStatus(task) };
+                SelectedItems = tasks.Where(x => x != null && x.Info != null).Select(x => new UploadInfoStatus(x)).ToArray();
             }
             else
             {


### PR DESCRIPTION
Allows selecting multiple thumbnail panels with <kbd>Ctrl</kbd> key. Also shows selected indicator at top left corner of panels.

Video: https://jaex.getsharex.com/2019/10/HfL2DXaMii.mp4