### PR TITLE
#820: Added support for complete removal of image metadata on upload.

### DIFF
--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -84,6 +84,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
@@ -98,6 +99,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -232,6 +232,9 @@ namespace ShareX
         [Category("Upload"), DefaultValue(100), Description("Large file size defined in MB. ShareX will warn before uploading large files. 0 disables this feature.")]
         public int ShowLargeFileSizeWarning { get; set; }
 
+        [Category("Upload"), DefaultValue(false), Description("Remove metadata information for uploaded images. (Local file will also be changed!).")]
+        public bool RemoveUploadedImageMetadata { get; set; }
+
         [Category("Paths"), Description("Custom uploaders configuration path. If you have already configured this setting in another device and you are attempting to use the same location, then backup the file before configuring this setting and restore after exiting ShareX.")]
         [Editor(typeof(DirectoryNameEditor), typeof(UITypeEditor))]
         public string CustomUploadersConfigPath { get; set; }

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -398,6 +398,17 @@ namespace ShareX
 
                 if (!cancelUpload)
                 {
+                    if (Program.Settings.RemoveUploadedImageMetadata)
+                    {
+                        string[] supportedExtensions = { @".jpg", @".jpeg", @".png", @".tiff" };
+                        if (supportedExtensions.All(Path.GetExtension(Info.FilePath).Contains))
+                        {
+                            Data.Close();
+                            ImageHelpers.StripImageMetadata(Info.FilePath);
+                            LoadFileStream();
+                        }
+                    }
+
                     OnUploadStarted();
 
                     bool isError = DoUpload();


### PR DESCRIPTION
This will remove all EXIF/XMP and other metadata from an Image.
A new option was added "RemoveUploadedImageMetadata" with default value false.

ImageHelpers.StripImageMetadata() will create a copy of the original files metadata information and blanks each value. 
Afterwards a new file is created with the stripped metadata, which will replace the original file.

This will not result in any image quality degredation or loss of information as the image is not reencoded, everything happens InPlace.

As this is my first pull-request for ShareX i'm not familiar with your coding style, so i would be happy if you could give me an extensive code-review and i will change my code accordingly, in the case this functionality is even desired.