### PR TITLE
Smoothened regionAnimation rectangle animation

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -793,7 +793,11 @@ namespace ShareX.ScreenCaptureLib
                 {
                     if (!ShapeManager.PreviousHoverRectangle.IsEmpty && ShapeManager.CurrentHoverShape.Rectangle != ShapeManager.PreviousHoverRectangle)
                     {
-                        regionAnimation.FromRectangle = ShapeManager.PreviousHoverRectangle;
+                        if (regionAnimation.CurrentRectangle.Width > 2 && regionAnimation.CurrentRectangle.Height > 2)
+                            regionAnimation.FromRectangle = regionAnimation.CurrentRectangle;
+                        else
+                            regionAnimation.FromRectangle = ShapeManager.PreviousHoverRectangle;
+
                         regionAnimation.ToRectangle = ShapeManager.CurrentHoverShape.Rectangle;
                         regionAnimation.Start();
                     }


### PR DESCRIPTION
Whenever you move your mouse quickly around the shapes on the screen there are usually some visual glitches as the FromRectangle value is always set to PreviousHoverRectangle. This simple change smoothens those animations and improves the overall user experience. Simply use the last CurrentRectangle as the new FromRectangle value.

Preview before/after: https://i.imgur.com/WI0Gof7.mp4