### PR TITLE
Update german translation for uploading log files in the debug protocol

### DIFF
--- a/ShareX.HelpersLib/Forms/DebugForm.de.resx
+++ b/ShareX.HelpersLib/Forms/DebugForm.de.resx
@@ -130,7 +130,7 @@
     <value>Log Datei öffnen...</value>
   </data>
   <data name="btnUploadLog.Text" xml:space="preserve">
-    <value>Upload-Protokoll...</value>
+    <value>Protokoll hochladen...</value>
   </data>
   <data name="lblRunningFrom.Text" xml:space="preserve">
     <value>Startverzeichnis:</value>


### PR DESCRIPTION
The current translation could be misunderstanding since it more likely means to open the "upload protocol" and not to upload the protocol. 
This commit clarifies the "upload" of the protocol so the following popup about sensitive information actually makes sense.