### PR TITLE
Fix dark titlebar for Windows 10 20H1

### DIFF
--- a/ShareX.HelpersLib/Native/NativeEnums.cs
+++ b/ShareX.HelpersLib/Native/NativeEnums.cs
@@ -2084,7 +2084,9 @@ namespace ShareX.HelpersLib
         /// </summary>
         DWMWA_LAST,
         // Undocumented, available since October 2018 update (build 17763)
-        DWMWA_USE_IMMERSIVE_DARK_MODE = 19
+        DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19,
+        // Windows 10 20H1 changed the value of the constant
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20
     }
 
     public enum InputType : int

--- a/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
@@ -235,16 +235,14 @@ namespace ShareX.HelpersLib
         {
             if (Helpers.IsWindows10OrGreater(17763))
             {
-                try
+                var attribute = DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1;
+                if (Helpers.IsWindows10OrGreater(18985))
                 {
-                    int useImmersiveDarkMode = enabled ? 1 : 0;
-                    int result = DwmSetWindowAttribute(handle, (int)DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE, ref useImmersiveDarkMode, sizeof(int));
-                    return result == 0;
+                    attribute = DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE;
                 }
-                catch (Exception e)
-                {
-                    DebugHelper.WriteException(e);
-                }
+
+                int useImmersiveDarkMode = enabled ? 1 : 0;
+                return DwmSetWindowAttribute(handle, (int)attribute, ref useImmersiveDarkMode, sizeof(int)) == 0;
             }
 
             return false;


### PR DESCRIPTION
I'm not quite sure which exact Windows 10 build changed the API, but build 18985 is the earliest I know of which did.