### PR TITLE
Added the ability to mass copy links in different formats

### DIFF
--- a/ShareX.HistoryLib/HistoryItemManager.cs
+++ b/ShareX.HistoryLib/HistoryItemManager.cs
@@ -161,10 +161,9 @@ namespace ShareX.HistoryLib
 
         public void CopyURL()
         {
-            if (HistoryItem != null && IsURLExist)
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
             {
-                HistoryItem[] historyItems = OnGetHistoryItems();
-
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => x.URL).ToArray();
 
                 if (array != null && array.Length > 0)
@@ -181,12 +180,40 @@ namespace ShareX.HistoryLib
 
         public void CopyShortenedURL()
         {
-            if (HistoryItem != null && IsShortenedURLExist) ClipboardHelpers.CopyText(HistoryItem.ShortenedURL);
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.ShortenedURL)).Select(x => x.ShortenedURL).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string shortenedURLs = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(shortenedURLs))
+                    {
+                        ClipboardHelpers.CopyText(shortenedURLs);
+                    }
+                }
+            }
         }
 
         public void CopyThumbnailURL()
         {
-            if (HistoryItem != null && IsThumbnailURLExist) ClipboardHelpers.CopyText(HistoryItem.ThumbnailURL);
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.ThumbnailURL)).Select(x => x.ThumbnailURL).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string thumbnailURLs = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(thumbnailURLs))
+                    {
+                        ClipboardHelpers.CopyText(thumbnailURLs);
+                    }
+                }
+            }
         }
 
         public void CopyDeletionURL()
@@ -211,10 +238,9 @@ namespace ShareX.HistoryLib
 
         public void CopyHTMLLink()
         {
-            if (HistoryItem != null && IsURLExist)
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
             {
-                HistoryItem[] historyItems = OnGetHistoryItems();
-
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => string.Format("<a href=\"{0}\">{0}</a>", x.URL)).ToArray();
 
                 if (array != null && array.Length > 0)
@@ -231,48 +257,154 @@ namespace ShareX.HistoryLib
 
         public void CopyHTMLImage()
         {
-            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("<img src=\"{0}\"/>", HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL)).Select(x => string.Format("<img src=\"{0}\"/>", x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string htmlImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(htmlImages))
+                    {
+                        ClipboardHelpers.CopyText(htmlImages);
+                    }
+                }
+            }
         }
 
         public void CopyHTMLLinkedImage()
         {
-            if (HistoryItem != null && IsImageURL && IsThumbnailURLExist)
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
             {
-                ClipboardHelpers.CopyText(string.Format("<a href=\"{0}\"><img src=\"{1}\"/></a>", HistoryItem.URL, HistoryItem.ThumbnailURL));
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL) && !string.IsNullOrEmpty(x.ThumbnailURL)).Select(x => string.Format("<a href=\"{0}\"><img src=\"{1}\"/></a>", x.URL, x.ThumbnailURL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string htmlLinkedImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(htmlLinkedImages))
+                    {
+                        ClipboardHelpers.CopyText(htmlLinkedImages);
+                    }
+                }
             }
         }
 
         public void CopyForumLink()
         {
-            if (HistoryItem != null && IsURLExist) ClipboardHelpers.CopyText(string.Format("[url]{0}[/url]", HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => string.Format("[url]{0}[/url]", x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string forumLinks = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(forumLinks))
+                    {
+                        ClipboardHelpers.CopyText(forumLinks);
+                    }
+                }
+            }
         }
 
         public void CopyForumImage()
         {
-            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("[img]{0}[/img]", HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL)).Select(x => string.Format("[img]{0}[/img]", x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string forumImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(forumImages))
+                    {
+                        ClipboardHelpers.CopyText(forumImages);
+                    }
+                }
+            }
         }
 
         public void CopyForumLinkedImage()
         {
-            if (HistoryItem != null && IsImageURL && IsThumbnailURLExist)
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
             {
-                ClipboardHelpers.CopyText(string.Format("[url={0}][img]{1}[/img][/url]", HistoryItem.URL, HistoryItem.ThumbnailURL));
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL) && !string.IsNullOrEmpty(x.ThumbnailURL)).Select(x => string.Format("[url={0}][img]{1}[/img][/url]", x.URL, x.ThumbnailURL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string forumLinkedImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(forumLinkedImages))
+                    {
+                        ClipboardHelpers.CopyText(forumLinkedImages);
+                    }
+                }
             }
         }
 
         public void CopyMarkdownLink()
         {
-            if (HistoryItem != null && IsURLExist) ClipboardHelpers.CopyText(string.Format("[{0}]({1})", HistoryItem.FileName, HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => string.Format("[{0}]({1})", x.FileName, x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string markdownLinks = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(markdownLinks))
+                    {
+                        ClipboardHelpers.CopyText(markdownLinks);
+                    }
+                }
+            }
         }
 
         public void CopyMarkdownImage()
         {
-            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("![{0}]({1})", HistoryItem.FileName, HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL)).Select(x => string.Format("![{0}]({1})", x.FileName, x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string markdownImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(markdownImages))
+                    {
+                        ClipboardHelpers.CopyText(markdownImages);
+                    }
+                }
+            }
         }
 
         public void CopyMarkdownLinkedImage()
         {
-            if (HistoryItem != null && IsImageURL) ClipboardHelpers.CopyText(string.Format("[![{0}]({1})]({2})", HistoryItem.FileName, HistoryItem.URL, HistoryItem.URL));
+            HistoryItem[] historyItems = OnGetHistoryItems();
+            if (historyItems != null)
+            {
+                string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && Helpers.IsImageFile(x.URL) && !string.IsNullOrEmpty(x.ThumbnailURL)).Select(x => string.Format("[![{0}]({1})]({2})", x.FileName, x.ThumbnailURL, x.URL)).ToArray();
+
+                if (array != null && array.Length > 0)
+                {
+                    string markdownLinkedImages = string.Join("\r\n", array);
+
+                    if (!string.IsNullOrEmpty(markdownLinkedImages))
+                    {
+                        ClipboardHelpers.CopyText(markdownLinkedImages);
+                    }
+                }
+            }
         }
 
         public void CopyFilePath()

--- a/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
+++ b/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
@@ -440,15 +440,23 @@ namespace ShareX.HistoryLib
 
         public void UpdateTexts(int itemsCount)
         {
+            UpdateButtons();
             if (itemsCount > 1)
             {
-                tsmiCopyURL.Text = string.Format(Resources.HistoryItemManager_UpdateTexts_URLs___0__, itemsCount);
-                tsmiCopyHTMLLink.Text = string.Format(Resources.HistoryItemManager_UpdateTexts_HTML_link___0__, itemsCount);
-            }
-            else
-            {
-                tsmiCopyURL.Text = Resources.HistoryItemManager_InitializeComponent_URL;
-                tsmiCopyHTMLLink.Text = Resources.HistoryItemManager_InitializeComponent_HTML_link;
+                tsmiCopyURL.Text = Resources.HistoryItemManager_InitializeComponent_URL + " (" + itemsCount + ")";
+                tsmiCopyShortenedURL.Text = Resources.HistoryItemManager_InitializeComponent_Shortened_URL + " (" + itemsCount + ")";
+                tsmiCopyThumbnailURL.Text = Resources.HistoryItemManager_InitializeComponent_Thumbnail_URL + " (" + itemsCount + ")";
+                tsmiCopyDeletionURL.Text = Resources.HistoryItemManager_InitializeComponent_Deletion_URL + " (" + itemsCount + ")";
+                tsmiCopyHTMLLink.Text = Resources.HistoryItemManager_InitializeComponent_HTML_link + " (" + itemsCount + ")";
+                tsmiCopyHTMLImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_image + " (" + itemsCount + ")";
+                tsmiCopyHTMLLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_linked_image + " (" + itemsCount + ")";
+                tsmiCopyHTMLLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_linked_image + " (" + itemsCount + ")";
+                tsmiCopyForumLink.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__link + " (" + itemsCount + ")";
+                tsmiCopyForumImage.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__image + " (" + itemsCount + ")";
+                tsmiCopyForumLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__linked_image + " (" + itemsCount + ")";
+                tsmiCopyMarkdownLink.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__link + " (" + itemsCount + ")";
+                tsmiCopyMarkdownImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__image + " (" + itemsCount + ")";
+                tsmiCopyMarkdownLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__linked_image + " (" + itemsCount + ")";
             }
         }
 
@@ -457,51 +465,153 @@ namespace ShareX.HistoryLib
             cmsHistory.SuspendLayout();
             cmsHistory.Enabled = true;
 
-            // Open
-            tsmiOpenURL.Enabled = IsURLExist;
-            tsmiOpenShortenedURL.Enabled = IsShortenedURLExist;
-            tsmiOpenThumbnailURL.Enabled = IsThumbnailURLExist;
-            tsmiOpenDeletionURL.Enabled = IsDeletionURLExist;
-
-            tsmiOpenFile.Enabled = IsFileExist;
-            tsmiOpenFolder.Enabled = IsFileExist;
-
             // Copy
-            tsmiCopyURL.Enabled = IsURLExist;
-            tsmiCopyShortenedURL.Enabled = IsShortenedURLExist;
-            tsmiCopyThumbnailURL.Enabled = IsThumbnailURLExist;
-            tsmiCopyDeletionURL.Enabled = IsDeletionURLExist;
+            if (OnGetHistoryItems().Length == 1)
+            {
+                // Open
+                tsmiOpenURL.Enabled = IsURLExist;
+                tsmiOpenShortenedURL.Enabled = IsShortenedURLExist;
+                tsmiOpenThumbnailURL.Enabled = IsThumbnailURLExist;
+                tsmiOpenDeletionURL.Enabled = IsDeletionURLExist;
 
-            tsmiCopyFile.Enabled = IsFileExist;
-            tsmiCopyImage.Enabled = IsImageFile;
-            tsmiCopyText.Enabled = IsTextFile;
+                tsmiOpenFile.Enabled = IsFileExist;
+                tsmiOpenFolder.Enabled = IsFileExist;
 
-            tsmiCopyHTMLLink.Enabled = IsURLExist;
-            tsmiCopyHTMLImage.Enabled = IsImageURL;
-            tsmiCopyHTMLLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
+                // Copy
+                tsmiCopyURL.Enabled = IsURLExist;
+                tsmiCopyShortenedURL.Enabled = IsShortenedURLExist;
+                tsmiCopyThumbnailURL.Enabled = IsThumbnailURLExist;
+                tsmiCopyDeletionURL.Enabled = IsDeletionURLExist;
 
-            tsmiCopyForumLink.Enabled = IsURLExist;
-            tsmiCopyForumImage.Enabled = IsImageURL && IsURLExist;
-            tsmiCopyForumLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
+                tsmiCopyFile.Enabled = IsFileExist;
+                tsmiCopyImage.Enabled = IsImageFile;
+                tsmiCopyText.Enabled = IsTextFile;
 
-            tsmiCopyMarkdownLink.Enabled = IsURLExist;
-            tsmiCopyMarkdownImage.Enabled = IsImageURL && IsURLExist;
-            tsmiCopyMarkdownLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
+                tsmiCopyHTMLLink.Enabled = IsURLExist;
+                tsmiCopyHTMLImage.Enabled = IsImageURL;
+                tsmiCopyHTMLLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
 
-            tsmiCopyFilePath.Enabled = IsFilePathValid;
-            tsmiCopyFileName.Enabled = IsFilePathValid;
-            tsmiCopyFileNameWithExtension.Enabled = IsFilePathValid;
-            tsmiCopyFolder.Enabled = IsFilePathValid;
+                tsmiCopyForumLink.Enabled = IsURLExist;
+                tsmiCopyForumImage.Enabled = IsImageURL && IsURLExist;
+                tsmiCopyForumLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
 
-            // Show
-            tsmiShowImagePreview.Enabled = IsImageFile;
+                tsmiCopyMarkdownLink.Enabled = IsURLExist;
+                tsmiCopyMarkdownImage.Enabled = IsImageURL && IsURLExist;
+                tsmiCopyMarkdownLinkedImage.Enabled = IsImageURL && IsThumbnailURLExist;
 
-            // Upload file
-            tsmiUploadFile.Enabled = uploadFile != null && IsFileExist;
+                tsmiCopyFilePath.Enabled = IsFilePathValid;
+                tsmiCopyFileName.Enabled = IsFilePathValid;
+                tsmiCopyFileNameWithExtension.Enabled = IsFilePathValid;
+                tsmiCopyFolder.Enabled = IsFilePathValid;
 
-            // Edit image
-            tsmiEditImage.Enabled = editImage != null && IsImageFile;
+                // Show
+                tsmiShowImagePreview.Enabled = IsImageFile;
+                tsmiShowMoreInfo.Enabled = true;
 
+                // Upload file
+                tsmiUploadFile.Enabled = uploadFile != null && IsFileExist;
+
+                // Edit image
+                tsmiEditImage.Enabled = editImage != null && IsImageFile;
+            }
+            else if (OnGetHistoryItems().Length > 1)
+            {
+                // Open
+                tsmiOpenURL.Enabled = false;
+                tsmiOpenShortenedURL.Enabled = false;
+                tsmiOpenThumbnailURL.Enabled = false;
+                tsmiOpenDeletionURL.Enabled = false;
+
+                tsmiOpenFile.Enabled = false;
+                tsmiOpenFolder.Enabled = false;
+
+                // Copy
+                tsmiCopyURL.Enabled = true;
+                tsmiCopyShortenedURL.Enabled = true;
+                tsmiCopyThumbnailURL.Enabled = true;
+                tsmiCopyDeletionURL.Enabled = true;
+
+                tsmiCopyFile.Enabled = false;
+                tsmiCopyImage.Enabled = false;
+                tsmiCopyText.Enabled = false;
+
+                tsmiCopyHTMLLink.Enabled = true;
+                tsmiCopyHTMLImage.Enabled = true;
+                tsmiCopyHTMLLinkedImage.Enabled = true;
+
+                tsmiCopyForumLink.Enabled = true;
+                tsmiCopyForumImage.Enabled = true;
+                tsmiCopyForumLinkedImage.Enabled = true;
+
+                tsmiCopyMarkdownLink.Enabled = true;
+                tsmiCopyMarkdownImage.Enabled = true;
+                tsmiCopyMarkdownLinkedImage.Enabled = true;
+
+                tsmiCopyFilePath.Enabled = false;
+                tsmiCopyFileName.Enabled = false;
+                tsmiCopyFileNameWithExtension.Enabled = false;
+                tsmiCopyFolder.Enabled = false;
+
+                // Show
+                tsmiShow.Enabled = false;
+                tsmiShowImagePreview.Enabled = false;
+                tsmiShowMoreInfo.Enabled = false;
+
+                // Upload file
+                tsmiUploadFile.Enabled = false;
+
+                // Edit image
+                tsmiEditImage.Enabled = false;
+            }
+            else
+            {
+                // Open
+                tsmiOpenURL.Enabled = false;
+                tsmiOpenShortenedURL.Enabled = false;
+                tsmiOpenThumbnailURL.Enabled = false;
+                tsmiOpenDeletionURL.Enabled = false;
+
+                tsmiOpenFile.Enabled = false;
+                tsmiOpenFolder.Enabled = false;
+
+                // Copy
+                tsmiCopyURL.Enabled = false;
+                tsmiCopyShortenedURL.Enabled = false;
+                tsmiCopyThumbnailURL.Enabled = false;
+                tsmiCopyDeletionURL.Enabled = false;
+
+                tsmiCopyFile.Enabled = false;
+                tsmiCopyImage.Enabled = false;
+                tsmiCopyText.Enabled = false;
+
+                tsmiCopyHTMLLink.Enabled = false;
+                tsmiCopyHTMLImage.Enabled = false;
+                tsmiCopyHTMLLinkedImage.Enabled = false;
+
+                tsmiCopyForumLink.Enabled = false;
+                tsmiCopyForumImage.Enabled = false;
+                tsmiCopyForumLinkedImage.Enabled = false;
+
+                tsmiCopyMarkdownLink.Enabled = false;
+                tsmiCopyMarkdownImage.Enabled = false;
+                tsmiCopyMarkdownLinkedImage.Enabled = false;
+
+                tsmiCopyFilePath.Enabled = false;
+                tsmiCopyFileName.Enabled = false;
+                tsmiCopyFileNameWithExtension.Enabled = false;
+                tsmiCopyFolder.Enabled = false;
+
+                // Show
+                tsmiShow.Enabled = false;
+                tsmiShowImagePreview.Enabled = false;
+                tsmiShowMoreInfo.Enabled = false;
+
+                // Upload file
+                tsmiUploadFile.Enabled = false;
+
+                // Edit image
+                tsmiEditImage.Enabled = false;
+            }
             cmsHistory.ResumeLayout();
         }
 

--- a/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
+++ b/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
@@ -440,7 +440,6 @@ namespace ShareX.HistoryLib
 
         public void UpdateTexts(int itemsCount)
         {
-            UpdateButtons();
             if (itemsCount > 1)
             {
                 tsmiCopyURL.Text = Resources.HistoryItemManager_InitializeComponent_URL + " (" + itemsCount + ")";
@@ -457,16 +456,33 @@ namespace ShareX.HistoryLib
                 tsmiCopyMarkdownLink.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__link + " (" + itemsCount + ")";
                 tsmiCopyMarkdownImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__image + " (" + itemsCount + ")";
                 tsmiCopyMarkdownLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__linked_image + " (" + itemsCount + ")";
+            } else
+            {
+                tsmiCopyURL.Text = Resources.HistoryItemManager_InitializeComponent_URL;
+                tsmiCopyShortenedURL.Text = Resources.HistoryItemManager_InitializeComponent_Shortened_URL;
+                tsmiCopyThumbnailURL.Text = Resources.HistoryItemManager_InitializeComponent_Thumbnail_URL;
+                tsmiCopyDeletionURL.Text = Resources.HistoryItemManager_InitializeComponent_Deletion_URL;
+                tsmiCopyHTMLLink.Text = Resources.HistoryItemManager_InitializeComponent_HTML_link;
+                tsmiCopyHTMLImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_image;
+                tsmiCopyHTMLLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_linked_image;
+                tsmiCopyHTMLLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_HTML_linked_image;
+                tsmiCopyForumLink.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__link;
+                tsmiCopyForumImage.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__image;
+                tsmiCopyForumLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Forum__BBCode__linked_image;
+                tsmiCopyMarkdownLink.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__link;
+                tsmiCopyMarkdownImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__image;
+                tsmiCopyMarkdownLinkedImage.Text = Resources.HistoryItemManager_InitializeComponent_Markdown__linked_image;
             }
+            UpdateButtons();
         }
 
         public void UpdateButtons()
         {
             cmsHistory.SuspendLayout();
             cmsHistory.Enabled = true;
-
-            // Copy
-            if (OnGetHistoryItems().Length == 1)
+            HistoryItem[] historyItem = OnGetHistoryItems();
+            int count = historyItem.Length;
+            if (count == 1)
             {
                 // Open
                 tsmiOpenURL.Enabled = IsURLExist;
@@ -514,7 +530,7 @@ namespace ShareX.HistoryLib
                 // Edit image
                 tsmiEditImage.Enabled = editImage != null && IsImageFile;
             }
-            else if (OnGetHistoryItems().Length > 1)
+            else if (count > 1)
             {
                 // Open
                 tsmiOpenURL.Enabled = false;


### PR DESCRIPTION
This fulfills the request to implement the ability to mass copy links when multiple items are selected in the 'history' area https://github.com/ShareX/ShareX/issues/2292. 