### PR TITLE
Added an "offline mode"

### DIFF
--- a/ShareX.HelpersLib/HelpersOptions.cs
+++ b/ShareX.HelpersLib/HelpersOptions.cs
@@ -40,5 +40,6 @@ namespace ShareX.HelpersLib
         public static List<Color> RecentColors { get; set; } = new List<Color>();
         public static string LastSaveDirectory { get; set; } = "";
         public static bool URLEncodeIgnoreEmoji { get; set; } = false;
+        public static bool OfflineMode { get; set; } = false;
     }
 }

--- a/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
+++ b/ShareX.HistoryLib/HistoryItemManager_ContextMenu.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using ShareX.HelpersLib;
 using ShareX.HistoryLib.Properties;
 using System;
 using System.Drawing;
@@ -580,6 +581,10 @@ namespace ShareX.HistoryLib
                 tsmiEditImage.Enabled = editImage != null && IsImageFile;
             }
 
+            if (HelpersOptions.OfflineMode) {
+                tsmiUploadFile.Enabled = false;
+            }
+            
             cmsHistory.ResumeLayout();
         }
 

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -184,6 +184,9 @@ namespace ShareX
         [Category("Application"), DefaultValue(false), Description("In main window when task is completed automatically select it.")]
         public bool AutoSelectLastCompletedTask { get; set; }
 
+        [Category("Application"), DefaultValue(false), Description("Run ShareX in offline mode.")]
+        public bool OfflineMode { get; set; }
+
         [Category("Hotkey"), DefaultValue(false), Description("Disables hotkeys.")]
         public bool DisableHotkeys { get; set; }
 

--- a/ShareX/Forms/ApplicationSettingsForm.cs
+++ b/ShareX/Forms/ApplicationSettingsForm.cs
@@ -230,7 +230,9 @@ namespace ShareX
                 tpUploadResults.Enabled = false;
                 tpUploadRetry.Enabled = false;
                 tpProxy.Enabled = false;
-            } else {
+            }
+            else
+            {
                 tpPerformance.Enabled = true;
                 tpUploadResults.Enabled = true;
                 tpUploadRetry.Enabled = true;

--- a/ShareX/Forms/ApplicationSettingsForm.cs
+++ b/ShareX/Forms/ApplicationSettingsForm.cs
@@ -223,6 +223,19 @@ namespace ShareX
             tttvMain.MainTabControl = tcSettings;
 
             ready = true;
+
+            // Offline mode
+            if (Program.Settings.OfflineMode) {
+                tpPerformance.Enabled = false;
+                tpUploadResults.Enabled = false;
+                tpUploadRetry.Enabled = false;
+                tpProxy.Enabled = false;
+            } else {
+                tpPerformance.Enabled = true;
+                tpUploadResults.Enabled = true;
+                tpUploadRetry.Enabled = true;
+                tpProxy.Enabled = true;
+            }
         }
 
         private void ChangeLanguage(SupportedLanguage language)

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -863,7 +863,7 @@ namespace ShareX
 
         private void updateOfflineMode()
         {
-              if (Program.Settings.OfflineMode) {            
+            if (Program.Settings.OfflineMode) {            
                 tsddbAfterUploadTasks.Visible = false;
                 tsddbDestinations.Visible = false;
                 tsddbUpload.Visible = false;

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -353,7 +353,7 @@ namespace ShareX
             {
                 base.WndProc(ref m);
             }
-        }
+        } 
 
         private void AfterShownJobs()
         {
@@ -861,6 +861,64 @@ namespace ShareX
             ucNews.UpdateTheme();
         }
 
+        private void updateOfflineMode()
+        {
+              if (Program.Settings.OfflineMode) {            
+                tsddbAfterUploadTasks.Visible = false;
+                tsddbDestinations.Visible = false;
+                tsddbUpload.Visible = false;
+                tsmiDNSChanger.Visible = false;
+                tsmiTweetMessage.Visible = false;
+                tsmiTextCapture.Visible = false;
+                tsmiTestImageUpload.Visible = false;
+                tsmiTestTextUpload.Visible = false;
+                tsmiTestFileUpload.Visible = false;
+                tsmiTestURLShortener.Visible = false;
+                tsmiTestURLSharing.Visible = false;
+                tsmiCopyText.Visible = false;
+
+                tsmiTrayAfterUploadTasks.Visible = false;
+                tsmiTrayDestinations.Visible = false;
+                tsmiTrayUpload.Visible = false;
+                tsmiTrayDNSChanger.Visible = false;
+                tsmiTrayTweetMessage.Visible = false;
+                tsmiTrayTextCapture.Visible = false;
+                tsmiTrayTestImageUpload.Visible = false;
+                tsmiTrayTestTextUpload.Visible = false;
+                tsmiTrayTestFileUpload.Visible = false;
+                tsmiTrayTestURLShortener.Visible = false;
+                tsmiTrayTestURLSharing.Visible = false;
+                tsmiTrayTextCapture.Visible = false;
+
+            } else {
+                tsddbAfterUploadTasks.Visible = true;
+                tsddbDestinations.Visible = true;
+                tsddbUpload.Visible = true;
+                tsmiDNSChanger.Visible = true;
+                tsmiTweetMessage.Visible = true;
+                tsmiTextCapture.Visible = true;
+                tsmiTestImageUpload.Visible = true;
+                tsmiTestTextUpload.Visible = true;
+                tsmiTestFileUpload.Visible = true;
+                tsmiTestURLShortener.Visible = true;
+                tsmiTestURLSharing.Visible = true;
+                tsmiCopyText.Visible = true;
+
+                tsmiTrayAfterUploadTasks.Visible = true;
+                tsmiTrayDestinations.Visible = true;
+                tsmiTrayUpload.Visible = true;
+                tsmiTrayDNSChanger.Visible = true;
+                tsmiTrayTweetMessage.Visible = true;
+                tsmiTrayTextCapture.Visible = true;
+                tsmiTrayTestImageUpload.Visible = true;
+                tsmiTrayTestTextUpload.Visible = true;
+                tsmiTrayTestFileUpload.Visible = true;
+                tsmiTrayTestURLShortener.Visible = true;
+                tsmiTrayTestURLSharing.Visible = true;
+                tsmiTrayTextCapture.Visible = true;
+            }
+        }
+
         private void CleanCustomClipboardFormats()
         {
             tssCopy6.Visible = false;
@@ -936,9 +994,11 @@ namespace ShareX
             HelpersOptions.RotateImageByExifOrientationData = Program.Settings.RotateImageByExifOrientationData;
             HelpersOptions.BrowserPath = Program.Settings.BrowserPath;
             HelpersOptions.RecentColors = Program.Settings.RecentColors;
+            HelpersOptions.OfflineMode = Program.Settings.OfflineMode;
 
             TaskManager.RecentManager.MaxCount = Program.Settings.RecentTasksMaxCount;
 
+            updateOfflineMode();
             UpdateTheme();
             Refresh();
 
@@ -962,7 +1022,7 @@ namespace ShareX
 
         private void ConfigureAutoUpdate()
         {
-            Program.UpdateManager.AutoUpdateEnabled = Program.Settings.AutoCheckUpdate && !Program.PortableApps;
+            Program.UpdateManager.AutoUpdateEnabled = Program.Settings.AutoCheckUpdate && !Program.PortableApps && !Program.Settings.OfflineMode;
             Program.UpdateManager.CheckPreReleaseUpdates = Program.Settings.CheckPreReleaseUpdates;
             Program.UpdateManager.ConfigureAutoUpdate();
         }

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -889,7 +889,6 @@ namespace ShareX
                 tsmiTrayTestURLShortener.Visible = false;
                 tsmiTrayTestURLSharing.Visible = false;
                 tsmiTrayTextCapture.Visible = false;
-
             }
             else
             {

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -890,7 +890,9 @@ namespace ShareX
                 tsmiTrayTestURLSharing.Visible = false;
                 tsmiTrayTextCapture.Visible = false;
 
-            } else {
+            }
+            else
+            {
                 tsddbAfterUploadTasks.Visible = true;
                 tsddbDestinations.Visible = true;
                 tsddbUpload.Visible = true;

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -80,8 +80,29 @@ namespace ShareX
             }
 
             UpdateDefaultSettingVisibility();
+            UpdateOfflineMode();
 
             tttvMain.MainTabControl = tcTaskSettings;
+
+            void UpdateOfflineMode()
+            {
+                if (HelpersOptions.OfflineMode)
+                {
+                    tpUpload.Enabled = false;
+                    tpUploadMain.Enabled = false;
+                    tpFileNaming.Enabled = false;
+                    tpUploadClipboard.Enabled = false;
+                    tpUploaderFilters.Enabled = false;
+                    tpOCR.Enabled = false;
+                } else {
+                    tpUpload.Enabled = true;
+                    tpUploadMain.Enabled = true;
+                    tpFileNaming.Enabled = true;
+                    tpUploadClipboard.Enabled = true;
+                    tpUploaderFilters.Enabled = true;
+                    tpOCR.Enabled = true;
+                }
+            }
 
             #region Task
 

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -94,7 +94,9 @@ namespace ShareX
                     tpUploadClipboard.Enabled = false;
                     tpUploaderFilters.Enabled = false;
                     tpOCR.Enabled = false;
-                } else {
+                }
+                else
+                {
                     tpUpload.Enabled = true;
                     tpUploadMain.Enabled = true;
                     tpFileNaming.Enabled = true;

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -295,7 +295,7 @@ namespace ShareX
 
                 if (!StopRequested)
                 {
-                    if (Info.IsUploadJob && !Program.Settings.DisableUpload)
+                    if (Info.IsUploadJob && !Program.Settings.DisableUpload && !Program.Settings.OfflineMode)
                     {
                         DoUploadJob();
                     }


### PR DESCRIPTION
Implemented an "offline mode" for https://github.com/ShareX/ShareX/issues/4521
-Adds "OfflineMode" in Application Settings > Advanced > Application 
-Hides everything requiring connectivity (OCR, Uploading, Debug, Proxy etc)

The only issue I had with this was 3 items on the "After Capture Tasks" drop-down menu:
![](https://i.imgur.com/XGQY0bk.png)

If you could tell me where these menu items are located then I'll be able to hide them as well.