### PR TITLE
Add alternative default ffmpeg location under install folder

### DIFF
--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -233,7 +233,19 @@ namespace ShareX
 
         public static string ToolsFolder => Path.Combine(PersonalFolder, "Tools");
         public static string ScreenRecorderCacheFilePath => Path.Combine(PersonalFolder, "ScreenRecorder.avi");
-        public static string DefaultFFmpegFilePath => Path.Combine(ToolsFolder, "ffmpeg.exe");
+        public static string DefaultFFmpegFilePath
+        {
+            get
+            {
+                string ffmpegFilePath = Helpers.GetAbsolutePath("Tools\\ffmpeg.exe");
+                if (!File.Exists(ffmpegFilePath))
+                {
+                    ffmpegFilePath = null;
+                }
+
+                return ffmpegFilePath ?? Path.Combine(ToolsFolder, "ffmpeg.exe");
+            }
+        }
         public static string ChromeHostManifestFilePath => Path.Combine(ToolsFolder, "Chrome-host-manifest.json");
         public static string FirefoxHostManifestFilePath => Path.Combine(ToolsFolder, "Firefox-host-manifest.json");
 


### PR DESCRIPTION
This PR fixes #4621, adds posibility to install ffmpeg globally in install dir. Use case is for example to first install sharex silently in batch script and then copy ffmpeg.exe to %programfile%\ShareX\Tools\ffmpeg.exe