### PR TITLE
Replace System.Remoting by named pipe, remove RIPEMD-160 support

### DIFF
--- a/ShareX.HelpersLib/ApplicationInstanceManager.cs
+++ b/ShareX.HelpersLib/ApplicationInstanceManager.cs
@@ -94,7 +94,6 @@ namespace ShareX.HelpersLib
                     return;
                 }
 
-
                 CreateServer(callback);
             }
             catch (Exception e)

--- a/ShareX.HelpersLib/Cryptographic/HashCheck.cs
+++ b/ShareX.HelpersLib/Cryptographic/HashCheck.cs
@@ -154,8 +154,6 @@ namespace ShareX.HelpersLib
                     return new SHA384CryptoServiceProvider();
                 case HashType.SHA512:
                     return new SHA512CryptoServiceProvider();
-                case HashType.RIPEMD160:
-                    return new RIPEMD160Managed();
             }
 
             return null;

--- a/ShareX.HelpersLib/Cryptographic/Translator.cs
+++ b/ShareX.HelpersLib/Cryptographic/Translator.cs
@@ -97,12 +97,9 @@ namespace ShareX.HelpersLib
         public string SHA384 { get; private set; }
         public string SHA512 { get; private set; }
 
-        // http://en.wikipedia.org/wiki/RIPEMD
-        public string RIPEMD160 { get; private set; }
-
         public void Clear()
         {
-            Text = Base64 = CRC32 = MD5 = SHA1 = SHA256 = SHA384 = SHA512 = RIPEMD160 = null;
+            Text = Base64 = CRC32 = MD5 = SHA1 = SHA256 = SHA384 = SHA512 = null;
             Binary = null;
             Hexadecimal = null;
             ASCII = null;
@@ -127,7 +124,6 @@ namespace ShareX.HelpersLib
                     SHA256 = TranslatorHelper.TextToHash(text, HashType.SHA256, true);
                     SHA384 = TranslatorHelper.TextToHash(text, HashType.SHA384, true);
                     SHA512 = TranslatorHelper.TextToHash(text, HashType.SHA512, true);
-                    RIPEMD160 = TranslatorHelper.TextToHash(text, HashType.RIPEMD160, true);
                     return true;
                 }
             }
@@ -207,7 +203,6 @@ namespace ShareX.HelpersLib
             sb.AppendLine($"SHA-256: {SHA256}");
             sb.AppendLine($"SHA-384: {SHA384}");
             sb.AppendLine($"SHA-512: {SHA512}");
-            sb.Append($"RIPEMD-160: {RIPEMD160}");
             return sb.ToString();
         }
 

--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -87,9 +87,7 @@ namespace ShareX.HelpersLib
         [Description("SHA-384")]
         SHA384,
         [Description("SHA-512")]
-        SHA512,
-        [Description("RIPEMD-160")]
-        RIPEMD160
+        SHA512
     }
 
     public enum BorderType

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -105,7 +105,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Speech" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -40,7 +40,6 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Speech.Synthesis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1347,11 +1346,7 @@ namespace ShareX
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
-            if (!string.IsNullOrEmpty(taskSettings.AdvancedSettings.SpeechCapture))
-            {
-                TextToSpeechAsync(taskSettings.AdvancedSettings.SpeechCapture);
-            }
-            else if (taskSettings.AdvancedSettings.UseCustomCaptureSound && !string.IsNullOrEmpty(taskSettings.AdvancedSettings.CustomCaptureSoundPath))
+            if (taskSettings.AdvancedSettings.UseCustomCaptureSound && !string.IsNullOrEmpty(taskSettings.AdvancedSettings.CustomCaptureSoundPath))
             {
                 Helpers.PlaySoundAsync(taskSettings.AdvancedSettings.CustomCaptureSoundPath);
             }
@@ -1365,11 +1360,7 @@ namespace ShareX
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
-            if (!string.IsNullOrEmpty(taskSettings.AdvancedSettings.SpeechTaskCompleted))
-            {
-                TextToSpeechAsync(taskSettings.AdvancedSettings.SpeechTaskCompleted);
-            }
-            else if (taskSettings.AdvancedSettings.UseCustomTaskCompletedSound && !string.IsNullOrEmpty(taskSettings.AdvancedSettings.CustomTaskCompletedSoundPath))
+            if (taskSettings.AdvancedSettings.UseCustomTaskCompletedSound && !string.IsNullOrEmpty(taskSettings.AdvancedSettings.CustomTaskCompletedSoundPath))
             {
                 Helpers.PlaySoundAsync(taskSettings.AdvancedSettings.CustomTaskCompletedSoundPath);
             }
@@ -1391,17 +1382,6 @@ namespace ShareX
             {
                 Helpers.PlaySoundAsync(Resources.ErrorSound);
             }
-        }
-
-        public static void TextToSpeechAsync(string text)
-        {
-            Task.Run(() =>
-            {
-                using (SpeechSynthesizer speaker = new SpeechSynthesizer())
-                {
-                    speaker.Speak(text);
-                }
-            });
         }
 
         public static void OpenUploadersConfigWindow(IUploaderService uploaderService = null)

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -429,18 +429,12 @@ namespace ShareX
         Editor(typeof(WavFileNameEditor), typeof(UITypeEditor))]
         public string CustomCaptureSoundPath { get; set; }
 
-        [Category("Sound"), DefaultValue(""), Description("If this text is not empty then when the screen is captured text to speech engine will say the phrase entered instead of playing the default sound.")]
-        public string SpeechCapture { get; set; }
-
         [Category("Sound"), DefaultValue(false), Description("Enable/disable custom task complete sound.")]
         public bool UseCustomTaskCompletedSound { get; set; }
 
         [Category("Sound"), DefaultValue(""), Description("Task complete sound file path."),
         Editor(typeof(WavFileNameEditor), typeof(UITypeEditor))]
         public string CustomTaskCompletedSoundPath { get; set; }
-
-        [Category("Sound"), DefaultValue(""), Description("If this text is not empty then when a task is completed text to speech engine will say the phrase entered instead of playing the default sound.")]
-        public string SpeechTaskCompleted { get; set; }
 
         [Category("Sound"), DefaultValue(false), Description("Enable/disable custom error sound.")]
         public bool UseCustomErrorSound { get; set; }


### PR DESCRIPTION
This is a step towards full .NET Core API coverage. It makes ShareX.HelpersLib 100% covered by .NET Core + Platform Extensions, from a 99.41% previously

Before: 
![image](https://user-images.githubusercontent.com/6440374/79923169-01e87000-8403-11ea-8665-4247c4d94290.png)
![image](https://user-images.githubusercontent.com/6440374/79923178-07de5100-8403-11ea-8623-e41598b73094.png)

After:
![image](https://user-images.githubusercontent.com/6440374/79923186-0e6cc880-8403-11ea-9368-b71388efd472.png)
![image](https://user-images.githubusercontent.com/6440374/79923244-1d537b00-8403-11ea-8d1c-088613cb5c54.png)
