### PR TITLE
fixed issue #4746: Right clicking while on region capture will show a confirmation msg before closing

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -603,6 +603,13 @@ namespace ShareX.ScreenCaptureLib
 
                 CloseWindow(RegionResult.Region);
             }
+            else
+            {
+                if (MessageBox.Show("Are you sure you want to close region capture/image editor? All unsaved work will be lost.", "ShareX", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
+                {
+                    CloseWindow(RegionResult.Region);
+                }
+            }
         }
 
         private void MonitorKey(int index)


### PR DESCRIPTION
ShareX will now prompt the user if they want to close down the region capture/image editor after pressing right-click.