### PR TITLE
Added check box to make direct URL for SeaFile uploader

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Seafile.cs
+++ b/ShareX.UploadersLib/FileUploaders/Seafile.cs
@@ -58,7 +58,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 ShareDaysToExpire = config.SeafileShareDaysToExpire,
                 SharePassword = config.SeafileSharePassword,
                 CreateShareableURL = config.SeafileCreateShareableURL,
-                CreateShareableURLDirect = config.SeafileCreateShareableURLDirect,
+                CreateShareableURLRaw = config.SeafileCreateShareableURLRaw,
                 IgnoreInvalidCert = config.SeafileIgnoreInvalidCert
             };
         }
@@ -77,7 +77,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public int ShareDaysToExpire { get; set; }
         public string SharePassword { get; set; }
         public bool CreateShareableURL { get; set; }
-        public bool CreateShareableURLDirect { get; set; }
+        public bool CreateShareableURLRaw { get; set; }
         public bool IgnoreInvalidCert { get; set; }
 
         public Seafile(string apiurl, string authtoken, string repoid)
@@ -453,7 +453,7 @@ namespace ShareX.UploadersLib.FileUploaders
                         AllowReportProgress = false;
                         result.URL = ShareFile(Path + fileName);
 
-                        if (CreateShareableURLDirect)
+                        if (CreateShareableURLRaw)
                         {
                             var uriBuilder = new UriBuilder(result.URL);
                             var query = System.Web.HttpUtility.ParseQueryString(uriBuilder.Query);

--- a/ShareX.UploadersLib/FileUploaders/Seafile.cs
+++ b/ShareX.UploadersLib/FileUploaders/Seafile.cs
@@ -58,6 +58,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 ShareDaysToExpire = config.SeafileShareDaysToExpire,
                 SharePassword = config.SeafileSharePassword,
                 CreateShareableURL = config.SeafileCreateShareableURL,
+                CreateShareableURLDirect = config.SeafileCreateShareableURLDirect,
                 IgnoreInvalidCert = config.SeafileIgnoreInvalidCert
             };
         }
@@ -76,6 +77,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public int ShareDaysToExpire { get; set; }
         public string SharePassword { get; set; }
         public bool CreateShareableURL { get; set; }
+        public bool CreateShareableURLDirect { get; set; }
         public bool IgnoreInvalidCert { get; set; }
 
         public Seafile(string apiurl, string authtoken, string repoid)
@@ -450,6 +452,15 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         AllowReportProgress = false;
                         result.URL = ShareFile(Path + fileName);
+
+                        if (CreateShareableURLDirect)
+                        {
+                            var uriBuilder = new UriBuilder(result.URL);
+                            var query = System.Web.HttpUtility.ParseQueryString(uriBuilder.Query);
+                            query["raw"] = "1";
+                            uriBuilder.Query = query.ToString();
+                            result.URL = $"{uriBuilder.Scheme}://{uriBuilder.Host}{uriBuilder.Path}{uriBuilder.Query}";
+                        }
                     }
                     else
                     {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -425,6 +425,7 @@ namespace ShareX.UploadersLib
             this.lblSeafilePassword = new System.Windows.Forms.Label();
             this.cbSeafileIgnoreInvalidCert = new System.Windows.Forms.CheckBox();
             this.cbSeafileCreateShareableURL = new System.Windows.Forms.CheckBox();
+            this.cbSeafileCreateShareableURLDirect = new System.Windows.Forms.CheckBox();
             this.txtSeafileAuthToken = new System.Windows.Forms.TextBox();
             this.lblSeafileAuthToken = new System.Windows.Forms.Label();
             this.lblSeafileAPIURL = new System.Windows.Forms.Label();
@@ -3177,6 +3178,7 @@ namespace ShareX.UploadersLib
             this.tpSeafile.Controls.Add(this.grpSeafileObtainAuthToken);
             this.tpSeafile.Controls.Add(this.cbSeafileIgnoreInvalidCert);
             this.tpSeafile.Controls.Add(this.cbSeafileCreateShareableURL);
+            this.tpSeafile.Controls.Add(this.cbSeafileCreateShareableURLDirect);
             this.tpSeafile.Controls.Add(this.txtSeafileAuthToken);
             this.tpSeafile.Controls.Add(this.lblSeafileAuthToken);
             this.tpSeafile.Controls.Add(this.lblSeafileAPIURL);
@@ -3426,6 +3428,13 @@ namespace ShareX.UploadersLib
             this.cbSeafileCreateShareableURL.Name = "cbSeafileCreateShareableURL";
             this.cbSeafileCreateShareableURL.UseVisualStyleBackColor = true;
             this.cbSeafileCreateShareableURL.CheckedChanged += new System.EventHandler(this.cbSeafileCreateShareableURL_CheckedChanged);
+            // 
+            // cbSeafileCreateShareableURLDirect
+            // 
+            resources.ApplyResources(this.cbSeafileCreateShareableURLDirect, "cbSeafileCreateShareableURLDirect");
+            this.cbSeafileCreateShareableURLDirect.Name = "cbSeafileCreateShareableURLDirect";
+            this.cbSeafileCreateShareableURLDirect.UseVisualStyleBackColor = true;
+            this.cbSeafileCreateShareableURLDirect.CheckedChanged += new System.EventHandler(this.cbSeafileCreateShareableURLDirect_CheckedChanged);
             // 
             // txtSeafileAuthToken
             // 
@@ -5309,6 +5318,7 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblSeafilePassword;
         private System.Windows.Forms.CheckBox cbSeafileIgnoreInvalidCert;
         private System.Windows.Forms.CheckBox cbSeafileCreateShareableURL;
+        private System.Windows.Forms.CheckBox cbSeafileCreateShareableURLDirect;
         private System.Windows.Forms.TextBox txtSeafileAuthToken;
         private System.Windows.Forms.Label lblSeafileAuthToken;
         private System.Windows.Forms.Label lblSeafileAPIURL;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -425,7 +425,7 @@ namespace ShareX.UploadersLib
             this.lblSeafilePassword = new System.Windows.Forms.Label();
             this.cbSeafileIgnoreInvalidCert = new System.Windows.Forms.CheckBox();
             this.cbSeafileCreateShareableURL = new System.Windows.Forms.CheckBox();
-            this.cbSeafileCreateShareableURLDirect = new System.Windows.Forms.CheckBox();
+            this.cbSeafileCreateShareableURLRaw = new System.Windows.Forms.CheckBox();
             this.txtSeafileAuthToken = new System.Windows.Forms.TextBox();
             this.lblSeafileAuthToken = new System.Windows.Forms.Label();
             this.lblSeafileAPIURL = new System.Windows.Forms.Label();
@@ -3178,7 +3178,7 @@ namespace ShareX.UploadersLib
             this.tpSeafile.Controls.Add(this.grpSeafileObtainAuthToken);
             this.tpSeafile.Controls.Add(this.cbSeafileIgnoreInvalidCert);
             this.tpSeafile.Controls.Add(this.cbSeafileCreateShareableURL);
-            this.tpSeafile.Controls.Add(this.cbSeafileCreateShareableURLDirect);
+            this.tpSeafile.Controls.Add(this.cbSeafileCreateShareableURLRaw);
             this.tpSeafile.Controls.Add(this.txtSeafileAuthToken);
             this.tpSeafile.Controls.Add(this.lblSeafileAuthToken);
             this.tpSeafile.Controls.Add(this.lblSeafileAPIURL);
@@ -3429,12 +3429,12 @@ namespace ShareX.UploadersLib
             this.cbSeafileCreateShareableURL.UseVisualStyleBackColor = true;
             this.cbSeafileCreateShareableURL.CheckedChanged += new System.EventHandler(this.cbSeafileCreateShareableURL_CheckedChanged);
             // 
-            // cbSeafileCreateShareableURLDirect
+            // cbSeafileCreateShareableURLRaw
             // 
-            resources.ApplyResources(this.cbSeafileCreateShareableURLDirect, "cbSeafileCreateShareableURLDirect");
-            this.cbSeafileCreateShareableURLDirect.Name = "cbSeafileCreateShareableURLDirect";
-            this.cbSeafileCreateShareableURLDirect.UseVisualStyleBackColor = true;
-            this.cbSeafileCreateShareableURLDirect.CheckedChanged += new System.EventHandler(this.cbSeafileCreateShareableURLDirect_CheckedChanged);
+            resources.ApplyResources(this.cbSeafileCreateShareableURLRaw, "cbSeafileCreateShareableURLRaw");
+            this.cbSeafileCreateShareableURLRaw.Name = "cbSeafileCreateShareableURLRaw";
+            this.cbSeafileCreateShareableURLRaw.UseVisualStyleBackColor = true;
+            this.cbSeafileCreateShareableURLRaw.CheckedChanged += new System.EventHandler(this.cbSeafileCreateShareableURLRaw_CheckedChanged);
             // 
             // txtSeafileAuthToken
             // 
@@ -5318,7 +5318,7 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblSeafilePassword;
         private System.Windows.Forms.CheckBox cbSeafileIgnoreInvalidCert;
         private System.Windows.Forms.CheckBox cbSeafileCreateShareableURL;
-        private System.Windows.Forms.CheckBox cbSeafileCreateShareableURLDirect;
+        private System.Windows.Forms.CheckBox cbSeafileCreateShareableURLRaw;
         private System.Windows.Forms.TextBox txtSeafileAuthToken;
         private System.Windows.Forms.Label lblSeafileAuthToken;
         private System.Windows.Forms.Label lblSeafileAPIURL;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -639,8 +639,8 @@ namespace ShareX.UploadersLib
             txtSeafileLibraryPassword.ReadOnly = Config.SeafileIsLibraryEncrypted;
             btnSeafileLibraryPasswordValidate.Enabled = !Config.SeafileIsLibraryEncrypted;
             cbSeafileCreateShareableURL.Checked = Config.SeafileCreateShareableURL;
-            cbSeafileCreateShareableURLDirect.Checked = Config.SeafileCreateShareableURLDirect;
-            cbSeafileCreateShareableURLDirect.Enabled = cbSeafileCreateShareableURL.Checked;
+            cbSeafileCreateShareableURLRaw.Checked = Config.SeafileCreateShareableURLRaw;
+            cbSeafileCreateShareableURLRaw.Enabled = cbSeafileCreateShareableURL.Checked;
             cbSeafileIgnoreInvalidCert.Checked = Config.SeafileIgnoreInvalidCert;
             nudSeafileExpireDays.SetValue(Config.SeafileShareDaysToExpire);
             txtSeafileSharePassword.Text = Config.SeafileSharePassword;
@@ -2598,12 +2598,12 @@ namespace ShareX.UploadersLib
         private void cbSeafileCreateShareableURL_CheckedChanged(object sender, EventArgs e)
         {
             Config.SeafileCreateShareableURL = cbSeafileCreateShareableURL.Checked;
-            cbSeafileCreateShareableURLDirect.Enabled = cbSeafileCreateShareableURL.Checked;
+            cbSeafileCreateShareableURLRaw.Enabled = cbSeafileCreateShareableURL.Checked;
         }
 
-        private void cbSeafileCreateShareableURLDirect_CheckedChanged(object sender, EventArgs e)
+        private void cbSeafileCreateShareableURLRaw_CheckedChanged(object sender, EventArgs e)
         {
-            Config.SeafileCreateShareableURLDirect = cbSeafileCreateShareableURLDirect.Checked;
+            Config.SeafileCreateShareableURLRaw = cbSeafileCreateShareableURLRaw.Checked;
         }
 
         private void cbSeafileIgnoreInvalidCert_CheckedChanged(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -639,6 +639,8 @@ namespace ShareX.UploadersLib
             txtSeafileLibraryPassword.ReadOnly = Config.SeafileIsLibraryEncrypted;
             btnSeafileLibraryPasswordValidate.Enabled = !Config.SeafileIsLibraryEncrypted;
             cbSeafileCreateShareableURL.Checked = Config.SeafileCreateShareableURL;
+            cbSeafileCreateShareableURLDirect.Checked = Config.SeafileCreateShareableURLDirect;
+            cbSeafileCreateShareableURLDirect.Enabled = cbSeafileCreateShareableURL.Checked;
             cbSeafileIgnoreInvalidCert.Checked = Config.SeafileIgnoreInvalidCert;
             nudSeafileExpireDays.SetValue(Config.SeafileShareDaysToExpire);
             txtSeafileSharePassword.Text = Config.SeafileSharePassword;
@@ -2596,6 +2598,12 @@ namespace ShareX.UploadersLib
         private void cbSeafileCreateShareableURL_CheckedChanged(object sender, EventArgs e)
         {
             Config.SeafileCreateShareableURL = cbSeafileCreateShareableURL.Checked;
+            cbSeafileCreateShareableURLDirect.Enabled = cbSeafileCreateShareableURL.Checked;
+        }
+
+        private void cbSeafileCreateShareableURLDirect_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.SeafileCreateShareableURLDirect = cbSeafileCreateShareableURLDirect.Checked;
         }
 
         private void cbSeafileIgnoreInvalidCert_CheckedChanged(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -13365,7 +13365,7 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="btnSeafileLibraryPasswordValidate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>320, 456</value>
+    <value>320, 479</value>
   </data>
   <data name="btnSeafileLibraryPasswordValidate.Size" type="System.Drawing.Size, System.Drawing">
     <value>71, 22</value>
@@ -13389,7 +13389,7 @@ when you made the application key.</value>
     <value>2</value>
   </data>
   <data name="txtSeafileLibraryPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 457</value>
+    <value>16, 480</value>
   </data>
   <data name="txtSeafileLibraryPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>297, 20</value>
@@ -13416,7 +13416,7 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="lblSeafileLibraryPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 441</value>
+    <value>13, 464</value>
   </data>
   <data name="lblSeafileLibraryPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 13</value>
@@ -13440,7 +13440,7 @@ when you made the application key.</value>
     <value>4</value>
   </data>
   <data name="lvSeafileLibraries.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 162</value>
+    <value>16, 185</value>
   </data>
   <data name="lvSeafileLibraries.Size" type="System.Drawing.Size, System.Drawing">
     <value>375, 194</value>
@@ -13479,7 +13479,7 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="btnSeafilePathValidate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>320, 414</value>
+    <value>320, 437</value>
   </data>
   <data name="btnSeafilePathValidate.Size" type="System.Drawing.Size, System.Drawing">
     <value>71, 22</value>
@@ -13503,7 +13503,7 @@ when you made the application key.</value>
     <value>6</value>
   </data>
   <data name="txtSeafileDirectoryPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 415</value>
+    <value>16, 438</value>
   </data>
   <data name="txtSeafileDirectoryPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>297, 20</value>
@@ -13530,7 +13530,7 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="lblSeafileWritePermNotif.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 364</value>
+    <value>13, 387</value>
   </data>
   <data name="lblSeafileWritePermNotif.Size" type="System.Drawing.Size, System.Drawing">
     <value>221, 26</value>
@@ -13561,7 +13561,7 @@ Using an encrypted library disables sharing.</value>
     <value>NoControl</value>
   </data>
   <data name="lblSeafilePath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 398</value>
+    <value>13, 421</value>
   </data>
   <data name="lblSeafilePath.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 13</value>
@@ -13588,7 +13588,7 @@ Using an encrypted library disables sharing.</value>
     <value>NoControl</value>
   </data>
   <data name="txtSeafileUploadLocationRefresh.Location" type="System.Drawing.Point, System.Drawing">
-    <value>320, 365</value>
+    <value>320, 388</value>
   </data>
   <data name="txtSeafileUploadLocationRefresh.Size" type="System.Drawing.Size, System.Drawing">
     <value>71, 23</value>
@@ -13618,7 +13618,7 @@ Using an encrypted library disables sharing.</value>
     <value>NoControl</value>
   </data>
   <data name="lblSeafileSelectLibrary.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 146</value>
+    <value>13, 169</value>
   </data>
   <data name="lblSeafileSelectLibrary.Size" type="System.Drawing.Size, System.Drawing">
     <value>70, 13</value>
@@ -14128,7 +14128,7 @@ Using an encrypted library disables sharing.</value>
     <value>NoControl</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 126</value>
+    <value>16, 149</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 17</value>
@@ -14188,7 +14188,7 @@ Using an encrypted library disables sharing.</value>
     <value>NoControl</value>
   </data>
   <data name="cbSeafileCreateShareableURLRaw.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 103</value>
+    <value>16, 126</value>
   </data>
   <data name="cbSeafileCreateShareableURLRaw.Size" type="System.Drawing.Size, System.Drawing">
     <value>131, 17</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -13085,6 +13085,18 @@ when you made the application key.</value>
   <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Name" xml:space="preserve">
+    <value>cbSeafileCreateShareableURLDirect</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
   <data name="&gt;&gt;txtSeafileAuthToken.Name" xml:space="preserve">
     <value>txtSeafileAuthToken</value>
   </data>
@@ -14167,6 +14179,36 @@ Using an encrypted library disables sharing.</value>
     <value>tpSeafile</value>
   </data>
   <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 103</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 17</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="cbSeafileCreateShareableURLDirect.Text" xml:space="preserve">
+    <value>Direct URL</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Name" xml:space="preserve">
+    <value>cbSeafileCreateShareableURLDirect</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Parent" xml:space="preserve">
+    <value>tpSeafile</value>
+  </data>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
   <data name="txtSeafileAuthToken.Location" type="System.Drawing.Point, System.Drawing">

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -13085,16 +13085,16 @@ when you made the application key.</value>
   <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Name" xml:space="preserve">
-    <value>cbSeafileCreateShareableURLDirect</value>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Name" xml:space="preserve">
+    <value>cbSeafileCreateShareableURLRaw</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Type" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Parent" xml:space="preserve">
     <value>tpSeafile</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
   <data name="&gt;&gt;txtSeafileAuthToken.Name" xml:space="preserve">
@@ -14181,34 +14181,34 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;cbSeafileCreateShareableURL.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.AutoSize" type="System.Boolean, mscorlib">
+  <data name="cbSeafileCreateShareableURLRaw.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="cbSeafileCreateShareableURLRaw.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="cbSeafileCreateShareableURLRaw.Location" type="System.Drawing.Point, System.Drawing">
     <value>160, 103</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="cbSeafileCreateShareableURLRaw.Size" type="System.Drawing.Size, System.Drawing">
     <value>131, 17</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.TabIndex" type="System.Int32, mscorlib">
+  <data name="cbSeafileCreateShareableURLRaw.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="cbSeafileCreateShareableURLDirect.Text" xml:space="preserve">
-    <value>Direct URL</value>
+  <data name="cbSeafileCreateShareableURLRaw.Text" xml:space="preserve">
+    <value>Use raw URL</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Name" xml:space="preserve">
-    <value>cbSeafileCreateShareableURLDirect</value>
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Name" xml:space="preserve">
+    <value>cbSeafileCreateShareableURLRaw</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Type" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.Parent" xml:space="preserve">
     <value>tpSeafile</value>
   </data>
-  <data name="&gt;&gt;cbSeafileCreateShareableURLDirect.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cbSeafileCreateShareableURLRaw.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
   <data name="txtSeafileAuthToken.Location" type="System.Drawing.Point, System.Drawing">

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -359,6 +359,7 @@ namespace ShareX.UploadersLib
         public bool SeafileIsLibraryEncrypted = false;
         public string SeafileEncryptedLibraryPassword = "";
         public bool SeafileCreateShareableURL = true;
+        public bool SeafileCreateShareableURLDirect = false;
         public bool SeafileIgnoreInvalidCert = false;
         public int SeafileShareDaysToExpire = 0;
         public string SeafileSharePassword = "";

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -359,7 +359,7 @@ namespace ShareX.UploadersLib
         public bool SeafileIsLibraryEncrypted = false;
         public string SeafileEncryptedLibraryPassword = "";
         public bool SeafileCreateShareableURL = true;
-        public bool SeafileCreateShareableURLDirect = false;
+        public bool SeafileCreateShareableURLRaw = false;
         public bool SeafileIgnoreInvalidCert = false;
         public int SeafileShareDaysToExpire = 0;
         public string SeafileSharePassword = "";


### PR DESCRIPTION
Now ShareX create link for SeaFile uploader which lead to SeaFile page.
The problem that if the image is larger than the available space on the SeaFile page than the image is shrunk. There is no ability to view it in full size without downloading first, what is inconvenient.

But there is the ability to create a direct link by adding "raw=1" parameter for the url.
Example:
"http://example.com/f/af416996a8064ada9c7c/" - leads to SeaFile page.
![1588434030](https://user-images.githubusercontent.com/10479545/80868637-0b989000-8cad-11ea-9aa8-4ce095fbc6fb.png)
"http://example.com/f/af416996a8064ada9c7c/?raw=1" - leads to file directly.
![1588434095](https://user-images.githubusercontent.com/10479545/80868763-9bd6d500-8cad-11ea-8426-38114a78fb0c.png)

I added a checkbox called "Direct URL" to the SeaFile uploader configuration so that the parameter "raw" is added to the address. 
![ShareX_YQHzMiVxWB](https://user-images.githubusercontent.com/10479545/80869101-70ed8080-8caf-11ea-84c4-fa7eb8d65c59.png)

Now it is possible to get direct link right after uploading.