### PR TITLE
Refresh action icon only on context menu call and only once per path change

### DIFF
--- a/ShareX.HelpersLib/ExternalProgram.cs
+++ b/ShareX.HelpersLib/ExternalProgram.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -34,12 +35,48 @@ namespace ShareX.HelpersLib
     {
         public bool IsActive { get; set; }
         public string Name { get; set; }
-        public string Path { get; set; }
+        private string _Path { get; set; }
+        public string Path
+        {
+            get => _Path;
+            set
+            {
+                _Path = value;
+                IsIconInitialized = false;
+            }
+        }
         public string Args { get; set; }
         public string OutputExtension { get; set; }
         public string Extensions { get; set; }
         public bool HiddenWindow { get; set; }
         public bool DeleteInputFile { get; set; }
+        private Bitmap _Icon { get; set; }
+        private bool IsIconInitialized = false;
+        public Bitmap Icon
+        {
+            get
+            {
+                if (!IsIconInitialized)
+                {
+                    try
+                    {
+                        using (Icon icon = NativeMethods.GetFileIcon(GetFullPath(), true))
+                        {
+                            if (icon != null && icon.Width > 0 && icon.Height > 0)
+                            {
+                                _Icon = icon.ToBitmap();
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        DebugHelper.WriteException(e);
+                    }
+                    IsIconInitialized = true;
+                }
+                return _Icon;
+            }
+        }
 
         public ExternalProgram()
         {


### PR DESCRIPTION
There is a visible delay on every click and right click on upload element before the preview is shown.
![1588875259](https://user-images.githubusercontent.com/10479545/81331203-45ed9d00-90b2-11ea-9e44-295ebe9205d6.gif)

I have 6 external programs added as actions. I figured out what on every click program loading every image for every external program.
The more these programs, the longer is delay.

At first, i am storing received bitmaps in ExternalProgram model. ShareX now can reuse it. If the path changes then ShareX will retrieve new images with changed path.

Second, looks like the icons for external images used only in context menu, in "Run action" submenu.
So, action menu now filled only on right mouse click, or Keys.Apps key (used for keyboard context key).

Third, i moved visibility control of tsmiRunAction inside a single method because i encounter a bug about wrong visibility when i open context menu one by one very fast. This change fixes this.

Now thumbnails loaded almost instantly on click:
![1588875019](https://user-images.githubusercontent.com/10479545/81331912-57837480-90b3-11ea-93da-1c8f7bbe0179.gif)