### PR TITLE
Added functionality to enable hand cursor on pressed shift key for cursor stamp tool in editor.

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -555,6 +555,7 @@ namespace ShareX.ScreenCaptureLib
                     break;
                 case Keys.ShiftKey:
                     IsProportionalResizing = true;
+                    ChangeCursorIndexDependingOnCurrentTool(4);
                     break;
                 case Keys.Menu:
                     IsSnapResizing = true;
@@ -797,6 +798,7 @@ namespace ShareX.ScreenCaptureLib
                     break;
                 case Keys.ShiftKey:
                     IsProportionalResizing = false;
+                    ChangeCursorIndexDependingOnCurrentTool(3);
                     break;
                 case Keys.Menu:
                     IsSnapResizing = false;
@@ -836,6 +838,15 @@ namespace ShareX.ScreenCaptureLib
                 {
                     shape.OnMoved();
                 }
+            }
+        }
+        private void ChangeCursorIndexDependingOnCurrentTool(int cursorIndex)
+        {
+            switch (CurrentTool)
+            {
+                case ShapeType.DrawingCursor:
+                    setCurrentCursorIndex(cursorIndex);
+                    break;
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -1472,5 +1472,13 @@ namespace ShareX.ScreenCaptureLib
 
             return Cursors.Default;
         }
+
+        internal void setCurrentCursorIndex(int cursorIndex)
+        {
+            if (cursorIndex < Helpers.CursorList.Length)
+            {
+                tscbCursorTypes.Content.SelectedIndex = cursorIndex;
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi maintainers,

as i use ShareX for documentation purposes, i wanted to show also a hand cursor which indicates better that a user should click on something or the screenshotted tool also shows a hand cursor which would then match the edited screenshot.

I compiled and tested the submitted code on my pc.

Best regards,
Johannes