### PR TITLE
Allow "access level" selection for Box shareable link

### DIFF
--- a/ShareX.UploadersLib/Enums.cs
+++ b/ShareX.UploadersLib/Enums.cs
@@ -353,4 +353,14 @@ namespace ShareX.UploadersLib
         Unlisted,
         Private
     }
+
+    public enum BoxShareAccessLevel
+    {
+        [Description("Public - People with the link")]
+        Open,
+        [Description("Company - People in your company")]
+        Company,
+        [Description("Collaborators - Invited people only")]
+        Collaborators
+    }
 }

--- a/ShareX.UploadersLib/FileUploaders/Box.cs
+++ b/ShareX.UploadersLib/FileUploaders/Box.cs
@@ -50,7 +50,8 @@ namespace ShareX.UploadersLib.FileUploaders
             return new Box(config.BoxOAuth2Info)
             {
                 FolderID = config.BoxSelectedFolder.id,
-                Share = config.BoxShare
+                Share = config.BoxShare,
+                ShareAccessLevel = config.BoxShareAccessLevel
             };
         }
 
@@ -69,12 +70,14 @@ namespace ShareX.UploadersLib.FileUploaders
         public OAuth2Info AuthInfo { get; set; }
         public string FolderID { get; set; }
         public bool Share { get; set; }
+        public BoxShareAccessLevel ShareAccessLevel { get; set; }
 
         public Box(OAuth2Info oauth)
         {
             AuthInfo = oauth;
             FolderID = "0";
             Share = true;
+            ShareAccessLevel = BoxShareAccessLevel.Open;
         }
 
         public string GetAuthorizationURL()
@@ -189,9 +192,9 @@ namespace ShareX.UploadersLib.FileUploaders
             return null;
         }
 
-        public string CreateSharedLink(string id)
+        public string CreateSharedLink(string id, BoxShareAccessLevel accessLevel)
         {
-            string response = SendRequest(HttpMethod.PUT, "https://api.box.com/2.0/files/" + id, "{\"shared_link\": {\"access\": \"open\"}}", headers: GetAuthHeaders());
+            string response = SendRequest(HttpMethod.PUT, "https://api.box.com/2.0/files/" + id, "{\"shared_link\": {\"access\": \"" + accessLevel.ToString().ToLower() +"\"}}", headers: GetAuthHeaders());
 
             if (!string.IsNullOrEmpty(response))
             {
@@ -234,7 +237,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     if (Share)
                     {
                         AllowReportProgress = false;
-                        result.URL = CreateSharedLink(fileEntry.id);
+                        result.URL = CreateSharedLink(fileEntry.id, ShareAccessLevel);
                     }
                     else
                     {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -206,6 +206,8 @@ namespace ShareX.UploadersLib
             this.tpBox = new System.Windows.Forms.TabPage();
             this.lblBoxFolderTip = new System.Windows.Forms.Label();
             this.cbBoxShare = new System.Windows.Forms.CheckBox();
+            this.cbBoxShareAccessLevel = new System.Windows.Forms.ComboBox();
+            this.lblBoxShareAccessLevel = new System.Windows.Forms.Label();
             this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
             this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lblBoxFolderID = new System.Windows.Forms.Label();
@@ -1822,6 +1824,8 @@ namespace ShareX.UploadersLib
             this.tpBox.BackColor = System.Drawing.SystemColors.Window;
             this.tpBox.Controls.Add(this.lblBoxFolderTip);
             this.tpBox.Controls.Add(this.cbBoxShare);
+            this.tpBox.Controls.Add(this.cbBoxShareAccessLevel);
+            this.tpBox.Controls.Add(this.lblBoxShareAccessLevel);
             this.tpBox.Controls.Add(this.lvBoxFolders);
             this.tpBox.Controls.Add(this.lblBoxFolderID);
             this.tpBox.Controls.Add(this.btnBoxRefreshFolders);
@@ -1840,6 +1844,19 @@ namespace ShareX.UploadersLib
             this.cbBoxShare.Name = "cbBoxShare";
             this.cbBoxShare.UseVisualStyleBackColor = true;
             this.cbBoxShare.CheckedChanged += new System.EventHandler(this.cbBoxShare_CheckedChanged);
+            // 
+            // cbBoxShareAccessLevel
+            // 
+            this.cbBoxShareAccessLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbBoxShareAccessLevel.FormattingEnabled = true;
+            resources.ApplyResources(this.cbBoxShareAccessLevel, "cbBoxShareAccessLevel");
+            this.cbBoxShareAccessLevel.Name = "cbBoxShareAccessLevel";
+            this.cbBoxShareAccessLevel.SelectedIndexChanged += new System.EventHandler(this.cbBoxShareAccessLevel_SelectedIndexChanged);
+            // 
+            // lblBoxShareAccessLevel
+            //
+            resources.ApplyResources(this.lblBoxShareAccessLevel, "lblBoxShareAccessLevel");
+            this.lblBoxShareAccessLevel.Name = "lblBoxShareAccessLevel";
             // 
             // lvBoxFolders
             // 
@@ -5126,6 +5143,8 @@ namespace ShareX.UploadersLib
         private OAuthControl oauth2GoogleDrive;
         private System.Windows.Forms.Label lblBoxFolderTip;
         private System.Windows.Forms.CheckBox cbBoxShare;
+        private System.Windows.Forms.ComboBox cbBoxShareAccessLevel;
+        private System.Windows.Forms.Label lblBoxShareAccessLevel;
         private ShareX.HelpersLib.MyListView lvBoxFolders;
         private System.Windows.Forms.ColumnHeader chBoxFoldersName;
         private System.Windows.Forms.Label lblBoxFolderID;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -415,6 +415,11 @@ namespace ShareX.UploadersLib
             }
 
             cbBoxShare.Checked = Config.BoxShare;
+            cbBoxShareAccessLevel.Items.Clear();
+            cbBoxShareAccessLevel.Items.AddRange(Helpers.GetEnumDescriptions<BoxShareAccessLevel>());
+            cbBoxShareAccessLevel.SelectedIndex = (int)Config.BoxShareAccessLevel;
+            cbBoxShareAccessLevel.Enabled = Config.BoxShare;
+            lblBoxShareAccessLevel.Enabled = Config.BoxShare;
             lblBoxFolderID.Text = Resources.UploadersConfigForm_LoadSettings_Selected_folder_ + " " + Config.BoxSelectedFolder.name;
 
             #endregion Box
@@ -1857,6 +1862,13 @@ namespace ShareX.UploadersLib
         private void cbBoxShare_CheckedChanged(object sender, EventArgs e)
         {
             Config.BoxShare = cbBoxShare.Checked;
+            cbBoxShareAccessLevel.Enabled = Config.BoxShare;
+            lblBoxShareAccessLevel.Enabled = Config.BoxShare;
+        }
+
+        private void cbBoxShareAccessLevel_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Config.BoxShareAccessLevel = (BoxShareAccessLevel)cbBoxShareAccessLevel.SelectedIndex;
         }
 
         private void btnBoxRefreshFolders_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -4121,6 +4121,57 @@ when you made the application key.</value>
   <data name="&gt;&gt;cbBoxShare.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="cbBoxShareAccessLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 308</value>
+  </data>
+  <data name="cbBoxShareAccessLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
+  </data>
+  <data name="cbBoxShareAccessLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>250, 24</value>
+  </data>
+  <data name="cbBoxShareAccessLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShareAccessLevel.Name" xml:space="preserve">
+    <value>cbBoxShareAccessLevel</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShareAccessLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShareAccessLevel.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;cbBoxShareAccessLevel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblBoxShareAccessLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 290</value>
+  </data>
+  <data name="lblBoxShareAccessLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="lblBoxShareAccessLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 19</value>
+  </data>
+  <data name="lblBoxShareAccessLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="lblBoxShareAccessLevel.Text" xml:space="preserve">
+    <value>Shared link access level:</value>
+  </data>
+  <data name="&gt;&gt;lblBoxShareAccessLevel.Name" xml:space="preserve">
+    <value>lblBoxShareAccessLevel</value>
+  </data>
+  <data name="&gt;&gt;lblBoxShareAccessLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblBoxShareAccessLevel.Parent" xml:space="preserve">
+    <value>tpBox</value>
+  </data>
+  <data name="&gt;&gt;lblBoxShareAccessLevel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="chBoxFoldersName.Text" xml:space="preserve">
     <value>Folder name</value>
   </data>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -217,6 +217,7 @@ namespace ShareX.UploadersLib
         public OAuth2Info BoxOAuth2Info = null;
         public BoxFileEntry BoxSelectedFolder = Box.RootFolder;
         public bool BoxShare = true;
+        public BoxShareAccessLevel BoxShareAccessLevel = BoxShareAccessLevel.Open;
 
         #endregion Box
 


### PR DESCRIPTION
Adds a dropdown box to the Box file uploader settings under the "Create shareable link" checkbox.

![sharex_box_share_link_access_level](https://user-images.githubusercontent.com/6776118/82095464-f3862f00-96f6-11ea-8131-0198df208076.PNG)

This has been tested with all 3 access levels and I saw each successfully upload with the correct share link setting in the Box web interface.

See Box API for reference about access levels: https://developer.box.com/guides/shared-links/create/
**Please note** the "collaboration" access level in the Box docs should actually be "collaborators" as seen in their own API implementations (e.g. https://github.com/box/box-node-sdk/blob/b06f4041d54fb2b102603edd2624876d25500e9a/lib/box-client.js#L392).
I have tested and made sure I to add the correct "collaborators" value.