### PR TITLE
Improvements for OwnCloud / NextCloud

### DIFF
--- a/ShareX.HelpersLib/Extensions/StringExtensions.cs
+++ b/ShareX.HelpersLib/Extensions/StringExtensions.cs
@@ -26,7 +26,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ShareX.HelpersLib
 {
@@ -336,6 +338,71 @@ namespace ShareX.HelpersLib
         public static string ToBase(this string text, int from, int to, string digits)
         {
             return text.FromBase(from, digits).ToBase(to, digits);
+        }
+
+        public static string DPAPIProtectAndBase64(this string text)
+        {
+            return DPAPIProtectAndBase64(text, null, DataProtectionScope.CurrentUser);
+        }
+
+        public static string DPAPIProtectAndBase64(this string text, byte[] optionalEntropy)
+        {
+            return DPAPIProtectAndBase64(text, optionalEntropy, DataProtectionScope.CurrentUser);
+        }
+
+        public static string DPAPIProtectAndBase64(this string text, byte[] optionalEntropy, DataProtectionScope scope)
+        {
+            return Convert.ToBase64String(ProtectedData.Protect(Encoding.UTF8.GetBytes(text), optionalEntropy, scope));
+        }
+
+        public static string DPAPIUnprotectAndBase64(this string text)
+        {
+            return DPAPIUnprotectAndBase64(text, null, DataProtectionScope.CurrentUser);
+        }
+
+        public static string DPAPIUnprotectAndBase64(this string text, byte[] optionalEntropy)
+        {
+            return DPAPIUnprotectAndBase64(text, optionalEntropy, DataProtectionScope.CurrentUser);
+        }
+
+        public static string DPAPIUnprotectAndBase64(this string text, byte[] optionalEntropy, DataProtectionScope scope)
+        {
+            return Encoding.UTF8.GetString(ProtectedData.Unprotect(Convert.FromBase64String(text), optionalEntropy, scope));
+        }
+
+        public static bool TryDPAPIUnprotectAndBase64(this string text, out string result)
+        {
+            return TryDPAPIUnprotectAndBase64(text, null, DataProtectionScope.CurrentUser, out result);
+        }
+
+        public static bool TryDPAPIUnprotectAndBase64(this string text, byte[] optionalEntropy, out string result)
+        {
+            return TryDPAPIUnprotectAndBase64(text, optionalEntropy, DataProtectionScope.CurrentUser, out result);
+        }
+
+        public static bool TryDPAPIUnprotectAndBase64(this string text, byte[] optionalEntropy, DataProtectionScope scope, out string result)
+        {
+            bool success = text.IsBase64();
+            result = null;
+
+            if (success)
+            {
+                try
+                {
+                    result = DPAPIUnprotectAndBase64(text, optionalEntropy, scope);
+                }
+                catch
+                {
+                    success = false;
+                }
+            }
+
+            return success;
+        }
+
+        public static bool IsBase64(this string text)
+        {
+            return (text.Trim().Length % 4 == 0) && Regex.IsMatch(text.Trim(), @"^[a-zA-Z0-9\+/]*={0,3}$", RegexOptions.None);
         }
     }
 }

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -91,6 +91,7 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/ShareX.UploadersLib/Enums.cs
+++ b/ShareX.UploadersLib/Enums.cs
@@ -218,7 +218,9 @@ namespace ShareX.UploadersLib
         POST,
         PUT,
         PATCH,
-        DELETE
+        DELETE,
+        MKCOL,
+        PROPFIND
     }
 
     public enum ResponseType // Localized

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -23,6 +23,7 @@
 
 #endregion License Information (GPL v3)
 
+using FluentFTP;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ShareX.HelpersLib;
@@ -146,16 +147,19 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 foreach (OwnCloudPathFilterItem pathFilter in PathFilters)
                 {
-                    Match filterMatch = Regex.Match(fileName, pathFilter.Filter);
-
-                    if (filterMatch.Success)
+                    if (pathFilter.Filter.IsValidRegEx())
                     {
-                        string uploadPath = pathFilter.Path;
+                        Match filterMatch = Regex.Match(fileName, pathFilter.Filter);
 
-                        for (int i = 0; i < filterMatch.Groups.Count; i++)
-                            uploadPath = uploadPath.Replace($"%{i}", filterMatch.Groups[i].Value);
+                        if (filterMatch.Success)
+                        {
+                            string uploadPath = pathFilter.Path;
 
-                        return uploadPath;
+                            for (int i = 0; i < filterMatch.Groups.Count; i++)
+                                uploadPath = uploadPath.Replace($"%{i}", filterMatch.Groups[i].Value);
+
+                            return uploadPath;
+                        }
                     }
                 }
             }

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -58,7 +58,8 @@ namespace ShareX.UploadersLib.FileUploaders
                 IsCompatibility81 = config.OwnCloud81Compatibility,
                 AutoExpireTime = config.OwnCloudExpiryTime,
                 AutoExpire = config.OwnCloudAutoExpire,
-                UsePathFilter = config.OwnCloudUsePathFilter
+                UsePathFilter = config.OwnCloudUsePathFilter,
+                PathFilter = config.OwnCloudPathFilter
             };
         }
 
@@ -78,12 +79,14 @@ namespace ShareX.UploadersLib.FileUploaders
         public bool IsCompatibility81 { get; set; }
         public bool AutoExpire { get; set; }
         public bool UsePathFilter { get; set; }
+        public List<OwnCloudPathFilterItem> PathFilter { get; set; }
 
         public OwnCloud(string host, string username, string password)
         {
             Host = host;
             Username = username;
             Password = password;
+            PathFilter = new List<OwnCloudPathFilterItem>();
         }
 
         public override UploadResult Upload(Stream stream, string fileName)
@@ -226,6 +229,12 @@ namespace ShareX.UploadersLib.FileUploaders
             public int id { get; set; }
             public string url { get; set; }
             public string token { get; set; }
+        }
+
+        public class OwnCloudPathFilterItem
+        {
+            public string Path { get; set; }
+            public string Filter { get; set; }
         }
     }
 }

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -150,7 +150,12 @@ namespace ShareX.UploadersLib.FileUploaders
 
                     if (filterMatch.Success)
                     {
-                        return pathFilter.Path;
+                        string uploadPath = pathFilter.Path;
+
+                        for (int i = 0; i < filterMatch.Groups.Count; i++)
+                            uploadPath = uploadPath.Replace($"%{i}", filterMatch.Groups[i].Value);
+
+                        return uploadPath;
                     }
                 }
             }

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -57,7 +57,8 @@ namespace ShareX.UploadersLib.FileUploaders
                 PreviewLink = config.OwnCloudUsePreviewLinks,
                 IsCompatibility81 = config.OwnCloud81Compatibility,
                 AutoExpireTime = config.OwnCloudExpiryTime,
-                AutoExpire = config.OwnCloudAutoExpire
+                AutoExpire = config.OwnCloudAutoExpire,
+                UsePathFilter = config.OwnCloudUsePathFilter
             };
         }
 
@@ -76,6 +77,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public bool PreviewLink { get; set; }
         public bool IsCompatibility81 { get; set; }
         public bool AutoExpire { get; set; }
+        public bool UsePathFilter { get; set; }
 
         public OwnCloud(string host, string username, string password)
         {

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -59,7 +59,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 AutoExpireTime = config.OwnCloudExpiryTime,
                 AutoExpire = config.OwnCloudAutoExpire,
                 UsePathFilter = config.OwnCloudUsePathFilter,
-                PathFilter = config.OwnCloudPathFilter
+                PathFilters = config.OwnCloudPathFilters
             };
         }
 
@@ -79,14 +79,14 @@ namespace ShareX.UploadersLib.FileUploaders
         public bool IsCompatibility81 { get; set; }
         public bool AutoExpire { get; set; }
         public bool UsePathFilter { get; set; }
-        public List<OwnCloudPathFilterItem> PathFilter { get; set; }
+        public List<OwnCloudPathFilterItem> PathFilters { get; set; }
 
         public OwnCloud(string host, string username, string password)
         {
             Host = host;
             Username = username;
             Password = password;
-            PathFilter = new List<OwnCloudPathFilterItem>();
+            PathFilters = new List<OwnCloudPathFilterItem>();
         }
 
         public override UploadResult Upload(Stream stream, string fileName)

--- a/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
+++ b/ShareX.UploadersLib/FileUploaders/OwnCloud.cs
@@ -1,4 +1,4 @@
-#region License Information (GPL v3)
+﻿#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Drawing;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace ShareX.UploadersLib.FileUploaders
@@ -106,10 +107,12 @@ namespace ShareX.UploadersLib.FileUploaders
                 Path = "/";
             }
 
+            string uploadPath = GetUploadPath(Path, fileName);
+
             // Original, unencoded path. Necessary for shared files
-            string path = URLHelpers.CombineURL(Path, fileName);
+            string path = URLHelpers.CombineURL(uploadPath, fileName);
             // Encoded path, necessary when sent in the URL
-            string encodedPath = URLHelpers.CombineURL(Path, URLHelpers.URLEncode(fileName));
+            string encodedPath = URLHelpers.CombineURL(uploadPath, URLHelpers.URLEncode(fileName));
 
             string url = URLHelpers.CombineURL(Host, "remote.php/webdav", encodedPath);
             url = URLHelpers.FixPrefix(url);
@@ -135,6 +138,24 @@ namespace ShareX.UploadersLib.FileUploaders
             }
 
             return result;
+        }
+
+        private string GetUploadPath(string defaultPath, string fileName)
+        {
+            if (UsePathFilter)
+            {
+                foreach (OwnCloudPathFilterItem pathFilter in PathFilters)
+                {
+                    Match filterMatch = Regex.Match(fileName, pathFilter.Filter);
+
+                    if (filterMatch.Success)
+                    {
+                        return pathFilter.Path;
+                    }
+                }
+            }
+
+            return defaultPath;
         }
 
         // https://doc.owncloud.org/server/10.0/developer_manual/core/ocs-share-api.html#create-a-new-share

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -2529,6 +2529,7 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.tpOwnCloud, "tpOwnCloud");
             this.tpOwnCloud.Name = "tpOwnCloud";
             // 
+            this.cbOwnCloudPathFilter.CheckedChanged += new System.EventHandler(this.cbOwnCloudPathFilter_CheckedChanged);
             // txtOwnCloudExpiryTime
             // 
             resources.ApplyResources(this.txtOwnCloudExpiryTime, "txtOwnCloudExpiryTime");

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -298,6 +298,17 @@ namespace ShareX.UploadersLib
             this.txtMegaPassword = new System.Windows.Forms.TextBox();
             this.lblMegaPassword = new System.Windows.Forms.Label();
             this.tpOwnCloud = new System.Windows.Forms.TabPage();
+            this.txtOwnCloudPathFilterEditFilter = new System.Windows.Forms.TextBox();
+            this.txtOwnCloudPathFilterEditPath = new System.Windows.Forms.TextBox();
+            this.lblOwnCloudPathFilterEditFilter = new System.Windows.Forms.Label();
+            this.lblOwnCloudPathFilterEditPath = new System.Windows.Forms.Label();
+            this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
+            this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
+            this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
+            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
+            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.txtOwnCloudExpiryTime = new System.Windows.Forms.NumericUpDown();
             this.cbOwnCloudAutoExpire = new System.Windows.Forms.CheckBox();
             this.lblOwnCloudExpiryTime = new System.Windows.Forms.Label();
@@ -606,18 +617,9 @@ namespace ShareX.UploadersLib
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
-            this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
-            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
-            this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
-            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
-            this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
-            this.txtOwnCloudPathFilterEditFilter = new System.Windows.Forms.TextBox();
-            this.txtOwnCloudPathFilterEditPath = new System.Windows.Forms.TextBox();
-            this.lblOwnCloudPathFilterEditFilter = new System.Windows.Forms.Label();
-            this.lblOwnCloudPathFilterEditPath = new System.Windows.Forms.Label();
+            this.btnOwnCloudPathFilterSortDown = new System.Windows.Forms.Button();
+            this.btnOwnCloudPathFilterSortUp = new System.Windows.Forms.Button();
             this.atcImgurAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.oauth2Imgur = new ShareX.UploadersLib.OAuthControl();
             this.oauthFlickr = new ShareX.UploadersLib.OAuthControl();
@@ -2502,6 +2504,8 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortDown);
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortUp);
             this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditFilter);
             this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditPath);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterEditFilter);
@@ -2530,10 +2534,76 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.tpOwnCloud, "tpOwnCloud");
             this.tpOwnCloud.Name = "tpOwnCloud";
             // 
+            // txtOwnCloudPathFilterEditFilter
+            // 
+            resources.ApplyResources(this.txtOwnCloudPathFilterEditFilter, "txtOwnCloudPathFilterEditFilter");
+            this.txtOwnCloudPathFilterEditFilter.Name = "txtOwnCloudPathFilterEditFilter";
+            // 
+            // txtOwnCloudPathFilterEditPath
+            // 
+            resources.ApplyResources(this.txtOwnCloudPathFilterEditPath, "txtOwnCloudPathFilterEditPath");
+            this.txtOwnCloudPathFilterEditPath.Name = "txtOwnCloudPathFilterEditPath";
+            // 
+            // lblOwnCloudPathFilterEditFilter
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilterEditFilter, "lblOwnCloudPathFilterEditFilter");
+            this.lblOwnCloudPathFilterEditFilter.Name = "lblOwnCloudPathFilterEditFilter";
+            // 
+            // lblOwnCloudPathFilterEditPath
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilterEditPath, "lblOwnCloudPathFilterEditPath");
+            this.lblOwnCloudPathFilterEditPath.Name = "lblOwnCloudPathFilterEditPath";
+            // 
+            // btnOwnCloudPathFilterRemove
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterRemove, "btnOwnCloudPathFilterRemove");
+            this.btnOwnCloudPathFilterRemove.Name = "btnOwnCloudPathFilterRemove";
+            this.btnOwnCloudPathFilterRemove.UseVisualStyleBackColor = true;
             this.btnOwnCloudPathFilterRemove.Click += new System.EventHandler(this.btnOwnCloudPathFilterRemove_Click);
+            // 
+            // btnOwnCloudPathFilterAdd
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterAdd, "btnOwnCloudPathFilterAdd");
+            this.btnOwnCloudPathFilterAdd.Name = "btnOwnCloudPathFilterAdd";
+            this.btnOwnCloudPathFilterAdd.UseVisualStyleBackColor = true;
             this.btnOwnCloudPathFilterAdd.Click += new System.EventHandler(this.btnOwnCloudPathFilterAdd_Click);
+            // 
+            // lblOwnCloudPathFilter
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
+            this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
+            // 
+            // lvOwnCloudPathFilter
+            // 
+            this.lvOwnCloudPathFilter.AutoFillColumn = true;
+            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvOwnCloudPathFilterPathColumn,
+            this.lvOwnCloudPathFilterFilterColumn});
+            this.lvOwnCloudPathFilter.FullRowSelect = true;
+            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvOwnCloudPathFilter.HideSelection = false;
+            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
+            this.lvOwnCloudPathFilter.MultiSelect = false;
+            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
+            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
+            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
             this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
+            // 
+            // lvOwnCloudPathFilterPathColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
+            // 
+            // lvOwnCloudPathFilterFilterColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
+            // 
+            // cbOwnCloudPathFilter
+            // 
+            resources.ApplyResources(this.cbOwnCloudPathFilter, "cbOwnCloudPathFilter");
+            this.cbOwnCloudPathFilter.Name = "cbOwnCloudPathFilter";
+            this.cbOwnCloudPathFilter.UseVisualStyleBackColor = true;
             this.cbOwnCloudPathFilter.CheckedChanged += new System.EventHandler(this.cbOwnCloudPathFilter_CheckedChanged);
+            // 
             // txtOwnCloudExpiryTime
             // 
             resources.ApplyResources(this.txtOwnCloudExpiryTime, "txtOwnCloudExpiryTime");
@@ -4757,78 +4827,26 @@ namespace ShareX.UploadersLib
             this.tttvMain.TreeViewFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
             this.tttvMain.TreeViewSize = 210;
             // 
-            // cbOwnCloudPathFilter
-            // 
-            resources.ApplyResources(this.cbOwnCloudPathFilter, "cbOwnCloudPathFilter");
-            this.cbOwnCloudPathFilter.Name = "cbOwnCloudPathFilter";
-            this.cbOwnCloudPathFilter.UseVisualStyleBackColor = true;
-            // 
-            // lvOwnCloudPathFilter
-            // 
-            this.lvOwnCloudPathFilter.AutoFillColumn = true;
-            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.lvOwnCloudPathFilterPathColumn,
-            this.lvOwnCloudPathFilterFilterColumn});
-            this.lvOwnCloudPathFilter.FullRowSelect = true;
-            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lvOwnCloudPathFilter.HideSelection = false;
-            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
-            this.lvOwnCloudPathFilter.MultiSelect = false;
-            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
-            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
-            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
-            // 
-            // lblOwnCloudPathFilter
-            // 
-            resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
-            this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
-            // 
-            // lvOwnCloudPathFilterPathColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
-            // 
-            // lvOwnCloudPathFilterFilterColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
-            // 
-            // btnOwnCloudPathFilterAdd
-            // 
-            resources.ApplyResources(this.btnOwnCloudPathFilterAdd, "btnOwnCloudPathFilterAdd");
-            this.btnOwnCloudPathFilterAdd.Name = "btnOwnCloudPathFilterAdd";
-            this.btnOwnCloudPathFilterAdd.UseVisualStyleBackColor = true;
-            // 
-            // btnOwnCloudPathFilterRemove
-            // 
-            resources.ApplyResources(this.btnOwnCloudPathFilterRemove, "btnOwnCloudPathFilterRemove");
-            this.btnOwnCloudPathFilterRemove.Name = "btnOwnCloudPathFilterRemove";
-            this.btnOwnCloudPathFilterRemove.UseVisualStyleBackColor = true;
-            // 
-            // txtOwnCloudPathFilterEditFilter
-            // 
-            resources.ApplyResources(this.txtOwnCloudPathFilterEditFilter, "txtOwnCloudPathFilterEditFilter");
-            this.txtOwnCloudPathFilterEditFilter.Name = "txtOwnCloudPathFilterEditFilter";
-            // 
-            // txtOwnCloudPathFilterEditPath
-            // 
-            resources.ApplyResources(this.txtOwnCloudPathFilterEditPath, "txtOwnCloudPathFilterEditPath");
-            this.txtOwnCloudPathFilterEditPath.Name = "txtOwnCloudPathFilterEditPath";
-            // 
-            // lblOwnCloudPathFilterEditFilter
-            // 
-            resources.ApplyResources(this.lblOwnCloudPathFilterEditFilter, "lblOwnCloudPathFilterEditFilter");
-            this.lblOwnCloudPathFilterEditFilter.Name = "lblOwnCloudPathFilterEditFilter";
-            // 
-            // lblOwnCloudPathFilterEditPath
-            //
-            resources.ApplyResources(this.lblOwnCloudPathFilterEditPath, "lblOwnCloudPathFilterEditPath");
-            this.lblOwnCloudPathFilterEditPath.Name = "lblOwnCloudPathFilterEditPath";
-            //
             // btnOwnCloudPathFilterEditSave
-            //
+            // 
             resources.ApplyResources(this.btnOwnCloudPathFilterEditSave, "btnOwnCloudPathFilterEditSave");
             this.btnOwnCloudPathFilterEditSave.Name = "btnOwnCloudPathFilterEditSave";
             this.btnOwnCloudPathFilterEditSave.UseVisualStyleBackColor = true;
             this.btnOwnCloudPathFilterEditSave.Click += new System.EventHandler(this.btnOwnCloudPathFilterEditSave_Click);
+            // 
+            // btnOwnCloudPathFilterSortDown
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterSortDown, "btnOwnCloudPathFilterSortDown");
+            this.btnOwnCloudPathFilterSortDown.Name = "btnOwnCloudPathFilterSortDown";
+            this.btnOwnCloudPathFilterSortDown.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterSortDown.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortDown_Click);
+            // 
+            // btnOwnCloudPathFilterSortUp
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterSortUp, "btnOwnCloudPathFilterSortUp");
+            this.btnOwnCloudPathFilterSortUp.Name = "btnOwnCloudPathFilterSortUp";
+            this.btnOwnCloudPathFilterSortUp.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterSortUp.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortUp_Click);
             // 
             // atcImgurAccountType
             // 
@@ -5758,5 +5776,7 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblOwnCloudPathFilterEditFilter;
         private System.Windows.Forms.Label lblOwnCloudPathFilterEditPath;
         private System.Windows.Forms.Button btnOwnCloudPathFilterEditSave;
+        private System.Windows.Forms.Button btnOwnCloudPathFilterSortDown;
+        private System.Windows.Forms.Button btnOwnCloudPathFilterSortUp;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -640,6 +640,7 @@ namespace ShareX.UploadersLib
             this.oauthTeknik = new ShareX.UploadersLib.OAuthControl();
             this.oauth2YouTube = new ShareX.UploadersLib.OAuthControl();
             this.actRapidShareAccountType = new ShareX.UploadersLib.AccountTypeControl();
+            this.cbOwnCloudCreateFolderIfNonExistent = new System.Windows.Forms.CheckBox();
             this.tpOtherUploaders.SuspendLayout();
             this.tcOtherUploaders.SuspendLayout();
             this.tpTwitter.SuspendLayout();
@@ -2455,6 +2456,7 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.cbOwnCloudCreateFolderIfNonExistent);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterInvalid);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortDown);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortUp);
@@ -5035,6 +5037,13 @@ namespace ShareX.UploadersLib
             this.actRapidShareAccountType.Name = "actRapidShareAccountType";
             this.actRapidShareAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
             // 
+            // cbOwnCloudCreateFolderIfNonExistent
+            // 
+            resources.ApplyResources(this.cbOwnCloudCreateFolderIfNonExistent, "cbOwnCloudCreateFolderIfNonExistent");
+            this.cbOwnCloudCreateFolderIfNonExistent.Name = "cbOwnCloudCreateFolderIfNonExistent";
+            this.cbOwnCloudCreateFolderIfNonExistent.UseVisualStyleBackColor = true;
+            this.cbOwnCloudCreateFolderIfNonExistent.CheckedChanged += new System.EventHandler(this.cbOwnCloudCreateFolderIfNonExistent_CheckedChanged);
+            // 
             // UploadersConfigForm
             // 
             resources.ApplyResources(this, "$this");
@@ -5789,5 +5798,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Button btnOwnCloudPathFilterSortDown;
         private System.Windows.Forms.Button btnOwnCloudPathFilterSortUp;
         private System.Windows.Forms.Label lblOwnCloudPathFilterInvalid;
+        private System.Windows.Forms.CheckBox cbOwnCloudCreateFolderIfNonExistent;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -606,6 +606,17 @@ namespace ShareX.UploadersLib
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
+            this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
+            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
+            this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
+            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
+            this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
+            this.txtOwnCloudPathFilterEditFilter = new System.Windows.Forms.TextBox();
+            this.txtOwnCloudPathFilterEditPath = new System.Windows.Forms.TextBox();
+            this.lblOwnCloudPathFilterEditFilter = new System.Windows.Forms.Label();
+            this.lblOwnCloudPathFilterEditPath = new System.Windows.Forms.Label();
             this.atcImgurAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.oauth2Imgur = new ShareX.UploadersLib.OAuthControl();
             this.oauthFlickr = new ShareX.UploadersLib.OAuthControl();
@@ -2490,6 +2501,15 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditFilter);
+            this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditPath);
+            this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterEditFilter);
+            this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterEditPath);
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterRemove);
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterAdd);
+            this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilter);
+            this.tpOwnCloud.Controls.Add(this.lvOwnCloudPathFilter);
+            this.tpOwnCloud.Controls.Add(this.cbOwnCloudPathFilter);
             this.tpOwnCloud.Controls.Add(this.txtOwnCloudExpiryTime);
             this.tpOwnCloud.Controls.Add(this.cbOwnCloudAutoExpire);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudExpiryTime);
@@ -4732,6 +4752,72 @@ namespace ShareX.UploadersLib
             this.tttvMain.TreeViewFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
             this.tttvMain.TreeViewSize = 210;
             // 
+            // cbOwnCloudPathFilter
+            // 
+            resources.ApplyResources(this.cbOwnCloudPathFilter, "cbOwnCloudPathFilter");
+            this.cbOwnCloudPathFilter.Name = "cbOwnCloudPathFilter";
+            this.cbOwnCloudPathFilter.UseVisualStyleBackColor = true;
+            // 
+            // lvOwnCloudPathFilter
+            // 
+            this.lvOwnCloudPathFilter.AutoFillColumn = true;
+            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvOwnCloudPathFilterPathColumn,
+            this.lvOwnCloudPathFilterFilterColumn});
+            this.lvOwnCloudPathFilter.FullRowSelect = true;
+            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvOwnCloudPathFilter.HideSelection = false;
+            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
+            this.lvOwnCloudPathFilter.MultiSelect = false;
+            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
+            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
+            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
+            // 
+            // lblOwnCloudPathFilter
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
+            this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
+            // 
+            // lvOwnCloudPathFilterPathColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
+            // 
+            // lvOwnCloudPathFilterFilterColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
+            // 
+            // btnOwnCloudPathFilterAdd
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterAdd, "btnOwnCloudPathFilterAdd");
+            this.btnOwnCloudPathFilterAdd.Name = "btnOwnCloudPathFilterAdd";
+            this.btnOwnCloudPathFilterAdd.UseVisualStyleBackColor = true;
+            // 
+            // btnOwnCloudPathFilterRemove
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterRemove, "btnOwnCloudPathFilterRemove");
+            this.btnOwnCloudPathFilterRemove.Name = "btnOwnCloudPathFilterRemove";
+            this.btnOwnCloudPathFilterRemove.UseVisualStyleBackColor = true;
+            // 
+            // txtOwnCloudPathFilterEditFilter
+            // 
+            resources.ApplyResources(this.txtOwnCloudPathFilterEditFilter, "txtOwnCloudPathFilterEditFilter");
+            this.txtOwnCloudPathFilterEditFilter.Name = "txtOwnCloudPathFilterEditFilter";
+            // 
+            // txtOwnCloudPathFilterEditPath
+            // 
+            resources.ApplyResources(this.txtOwnCloudPathFilterEditPath, "txtOwnCloudPathFilterEditPath");
+            this.txtOwnCloudPathFilterEditPath.Name = "txtOwnCloudPathFilterEditPath";
+            // 
+            // lblOwnCloudPathFilterEditFilter
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilterEditFilter, "lblOwnCloudPathFilterEditFilter");
+            this.lblOwnCloudPathFilterEditFilter.Name = "lblOwnCloudPathFilterEditFilter";
+            // 
+            // lblOwnCloudPathFilterEditPath
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilterEditPath, "lblOwnCloudPathFilterEditPath");
+            this.lblOwnCloudPathFilterEditPath.Name = "lblOwnCloudPathFilterEditPath";
+            // 
             // atcImgurAccountType
             // 
             resources.ApplyResources(this.atcImgurAccountType, "atcImgurAccountType");
@@ -5648,5 +5734,16 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.CheckBox cbGoogleCloudStorageStripExtensionImage;
         private System.Windows.Forms.Label lblB2UrlPreview;
         private HelpersLib.TabToTreeView tttvMain;
+        private System.Windows.Forms.CheckBox cbOwnCloudPathFilter;
+        private HelpersLib.MyListView lvOwnCloudPathFilter;
+        private System.Windows.Forms.Label lblOwnCloudPathFilter;
+        private System.Windows.Forms.ColumnHeader lvOwnCloudPathFilterPathColumn;
+        private System.Windows.Forms.ColumnHeader lvOwnCloudPathFilterFilterColumn;
+        private System.Windows.Forms.Button btnOwnCloudPathFilterRemove;
+        private System.Windows.Forms.Button btnOwnCloudPathFilterAdd;
+        private System.Windows.Forms.TextBox txtOwnCloudPathFilterEditFilter;
+        private System.Windows.Forms.TextBox txtOwnCloudPathFilterEditPath;
+        private System.Windows.Forms.Label lblOwnCloudPathFilterEditFilter;
+        private System.Windows.Forms.Label lblOwnCloudPathFilterEditPath;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -135,7 +135,6 @@ namespace ShareX.UploadersLib
             this.cbFTPRemoveFileExtension = new System.Windows.Forms.CheckBox();
             this.txtFTPName = new System.Windows.Forms.TextBox();
             this.lblFTPHost = new System.Windows.Forms.Label();
-            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
             this.pFTPTransferMode = new System.Windows.Forms.Panel();
             this.rbFTPTransferModeActive = new System.Windows.Forms.RadioButton();
             this.rbFTPTransferModePassive = new System.Windows.Forms.RadioButton();
@@ -189,9 +188,6 @@ namespace ShareX.UploadersLib
             this.cbGoogleDriveUseFolder = new System.Windows.Forms.CheckBox();
             this.txtGoogleDriveFolderID = new System.Windows.Forms.TextBox();
             this.lblGoogleDriveFolderID = new System.Windows.Forms.Label();
-            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
-            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnGoogleDriveRefreshFolders = new System.Windows.Forms.Button();
             this.cbGoogleDriveIsPublic = new System.Windows.Forms.CheckBox();
             this.tpPuush = new System.Windows.Forms.TabPage();
@@ -208,8 +204,6 @@ namespace ShareX.UploadersLib
             this.cbBoxShare = new System.Windows.Forms.CheckBox();
             this.cbBoxShareAccessLevel = new System.Windows.Forms.ComboBox();
             this.lblBoxShareAccessLevel = new System.Windows.Forms.Label();
-            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
-            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lblBoxFolderID = new System.Windows.Forms.Label();
             this.btnBoxRefreshFolders = new System.Windows.Forms.Button();
             this.tpAmazonS3 = new System.Windows.Forms.TabPage();
@@ -310,9 +304,6 @@ namespace ShareX.UploadersLib
             this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
             this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
             this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
-            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
-            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.txtOwnCloudExpiryTime = new System.Windows.Forms.NumericUpDown();
             this.cbOwnCloudAutoExpire = new System.Windows.Forms.CheckBox();
@@ -405,10 +396,6 @@ namespace ShareX.UploadersLib
             this.btnSeafileLibraryPasswordValidate = new System.Windows.Forms.Button();
             this.txtSeafileLibraryPassword = new System.Windows.Forms.TextBox();
             this.lblSeafileLibraryPassword = new System.Windows.Forms.Label();
-            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
-            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnSeafilePathValidate = new System.Windows.Forms.Button();
             this.txtSeafileDirectoryPath = new System.Windows.Forms.TextBox();
             this.lblSeafileWritePermNotif = new System.Windows.Forms.Label();
@@ -560,10 +547,6 @@ namespace ShareX.UploadersLib
             this.cbImgurUseGIFV = new System.Windows.Forms.CheckBox();
             this.cbImgurUploadSelectedAlbum = new System.Windows.Forms.CheckBox();
             this.cbImgurDirectLink = new System.Windows.Forms.CheckBox();
-            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
-            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnImgurRefreshAlbumList = new System.Windows.Forms.Button();
             this.cbImgurThumbnailType = new System.Windows.Forms.ComboBox();
             this.lblImgurThumbnailType = new System.Windows.Forms.Label();
@@ -621,8 +604,26 @@ namespace ShareX.UploadersLib
             this.txtVgymeUserKey = new System.Windows.Forms.TextBox();
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
-            this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
             this.cbOwnCloudEncryptPassword = new System.Windows.Forms.CheckBox();
+            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
+            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
+            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
+            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
+            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
+            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
+            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
+            this.btnOwnCloudRevealPassword = new System.Windows.Forms.Button();
             this.atcImgurAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.oauth2Imgur = new ShareX.UploadersLib.OAuthControl();
             this.oauthFlickr = new ShareX.UploadersLib.OAuthControl();
@@ -1356,16 +1357,6 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblFTPHost, "lblFTPHost");
             this.lblFTPHost.Name = "lblFTPHost";
             // 
-            // eiFTP
-            // 
-            this.eiFTP.DefaultFileName = null;
-            resources.ApplyResources(this.eiFTP, "eiFTP");
-            this.eiFTP.Name = "eiFTP";
-            this.eiFTP.ObjectType = null;
-            this.eiFTP.SerializationBinder = null;
-            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
-            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
-            // 
             // pFTPTransferMode
             // 
             resources.ApplyResources(this.pFTPTransferMode, "pFTPTransferMode");
@@ -1739,29 +1730,6 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblGoogleDriveFolderID, "lblGoogleDriveFolderID");
             this.lblGoogleDriveFolderID.Name = "lblGoogleDriveFolderID";
             // 
-            // lvGoogleDriveFoldersList
-            // 
-            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
-            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chGoogleDriveTitle,
-            this.chGoogleDriveDescription});
-            this.lvGoogleDriveFoldersList.FullRowSelect = true;
-            this.lvGoogleDriveFoldersList.HideSelection = false;
-            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
-            this.lvGoogleDriveFoldersList.MultiSelect = false;
-            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
-            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
-            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
-            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
-            // 
-            // chGoogleDriveTitle
-            // 
-            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
-            // 
-            // chGoogleDriveDescription
-            // 
-            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
-            // 
             // btnGoogleDriveRefreshFolders
             // 
             resources.ApplyResources(this.btnGoogleDriveRefreshFolders, "btnGoogleDriveRefreshFolders");
@@ -1875,24 +1843,6 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblBoxShareAccessLevel, "lblBoxShareAccessLevel");
             this.lblBoxShareAccessLevel.Name = "lblBoxShareAccessLevel";
-            // 
-            // lvBoxFolders
-            // 
-            this.lvBoxFolders.AutoFillColumn = true;
-            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chBoxFoldersName});
-            this.lvBoxFolders.FullRowSelect = true;
-            this.lvBoxFolders.HideSelection = false;
-            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
-            this.lvBoxFolders.Name = "lvBoxFolders";
-            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
-            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
-            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
-            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
-            // 
-            // chBoxFoldersName
-            // 
-            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
             // 
             // lblBoxFolderID
             // 
@@ -2508,6 +2458,7 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudRevealPassword);
             this.tpOwnCloud.Controls.Add(this.cbOwnCloudEncryptPassword);
             this.tpOwnCloud.Controls.Add(this.cbOwnCloudCreateFolderIfNonExistent);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterInvalid);
@@ -2614,30 +2565,6 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
             this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
-            // 
-            // lvOwnCloudPathFilter
-            // 
-            this.lvOwnCloudPathFilter.AutoFillColumn = true;
-            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.lvOwnCloudPathFilterPathColumn,
-            this.lvOwnCloudPathFilterFilterColumn});
-            this.lvOwnCloudPathFilter.FullRowSelect = true;
-            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lvOwnCloudPathFilter.HideSelection = false;
-            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
-            this.lvOwnCloudPathFilter.MultiSelect = false;
-            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
-            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
-            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
-            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
-            // 
-            // lvOwnCloudPathFilterPathColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
-            // 
-            // lvOwnCloudPathFilterFilterColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
             // 
             // cbOwnCloudPathFilter
             // 
@@ -3306,35 +3233,6 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblSeafileLibraryPassword, "lblSeafileLibraryPassword");
             this.lblSeafileLibraryPassword.Name = "lblSeafileLibraryPassword";
-            // 
-            // lvSeafileLibraries
-            // 
-            this.lvSeafileLibraries.AllowColumnSort = true;
-            this.lvSeafileLibraries.AutoFillColumn = true;
-            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.colSeafileLibraryName,
-            this.colSeafileLibrarySize,
-            this.colSeafileLibraryEncrypted});
-            this.lvSeafileLibraries.DisableDeselect = true;
-            this.lvSeafileLibraries.FullRowSelect = true;
-            this.lvSeafileLibraries.HideSelection = false;
-            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
-            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
-            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
-            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
-            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
-            // 
-            // colSeafileLibraryName
-            // 
-            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
-            // 
-            // colSeafileLibrarySize
-            // 
-            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
-            // 
-            // colSeafileLibraryEncrypted
-            // 
-            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
             // 
             // btnSeafilePathValidate
             // 
@@ -4430,35 +4328,6 @@ namespace ShareX.UploadersLib
             this.cbImgurDirectLink.UseVisualStyleBackColor = true;
             this.cbImgurDirectLink.CheckedChanged += new System.EventHandler(this.cbImgurDirectLink_CheckedChanged);
             // 
-            // lvImgurAlbumList
-            // 
-            this.lvImgurAlbumList.AllowColumnSort = true;
-            this.lvImgurAlbumList.AutoFillColumn = true;
-            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chImgurID,
-            this.chImgurTitle,
-            this.chImgurDescription});
-            this.lvImgurAlbumList.FullRowSelect = true;
-            this.lvImgurAlbumList.HideSelection = false;
-            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
-            this.lvImgurAlbumList.MultiSelect = false;
-            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
-            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
-            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
-            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
-            // 
-            // chImgurID
-            // 
-            resources.ApplyResources(this.chImgurID, "chImgurID");
-            // 
-            // chImgurTitle
-            // 
-            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
-            // 
-            // chImgurDescription
-            // 
-            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
-            // 
             // btnImgurRefreshAlbumList
             // 
             resources.ApplyResources(this.btnImgurRefreshAlbumList, "btnImgurRefreshAlbumList");
@@ -4859,6 +4728,146 @@ namespace ShareX.UploadersLib
             this.tcUploaders.Name = "tcUploaders";
             this.tcUploaders.SelectedIndex = 0;
             // 
+            // cbOwnCloudEncryptPassword
+            // 
+            resources.ApplyResources(this.cbOwnCloudEncryptPassword, "cbOwnCloudEncryptPassword");
+            this.cbOwnCloudEncryptPassword.Name = "cbOwnCloudEncryptPassword";
+            this.cbOwnCloudEncryptPassword.UseVisualStyleBackColor = true;
+            this.cbOwnCloudEncryptPassword.CheckedChanged += new System.EventHandler(this.cbOwnCloudEncryptPassword_CheckedChanged);
+            // 
+            // lvImgurAlbumList
+            // 
+            this.lvImgurAlbumList.AllowColumnSort = true;
+            this.lvImgurAlbumList.AutoFillColumn = true;
+            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chImgurID,
+            this.chImgurTitle,
+            this.chImgurDescription});
+            this.lvImgurAlbumList.FullRowSelect = true;
+            this.lvImgurAlbumList.HideSelection = false;
+            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
+            this.lvImgurAlbumList.MultiSelect = false;
+            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
+            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
+            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
+            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
+            // 
+            // chImgurID
+            // 
+            resources.ApplyResources(this.chImgurID, "chImgurID");
+            // 
+            // chImgurTitle
+            // 
+            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
+            // 
+            // chImgurDescription
+            // 
+            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
+            // 
+            // eiFTP
+            // 
+            this.eiFTP.DefaultFileName = null;
+            resources.ApplyResources(this.eiFTP, "eiFTP");
+            this.eiFTP.Name = "eiFTP";
+            this.eiFTP.ObjectType = null;
+            this.eiFTP.SerializationBinder = null;
+            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
+            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
+            // 
+            // lvGoogleDriveFoldersList
+            // 
+            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
+            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chGoogleDriveTitle,
+            this.chGoogleDriveDescription});
+            this.lvGoogleDriveFoldersList.FullRowSelect = true;
+            this.lvGoogleDriveFoldersList.HideSelection = false;
+            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
+            this.lvGoogleDriveFoldersList.MultiSelect = false;
+            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
+            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
+            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
+            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
+            // 
+            // chGoogleDriveTitle
+            // 
+            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
+            // 
+            // chGoogleDriveDescription
+            // 
+            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
+            // 
+            // lvBoxFolders
+            // 
+            this.lvBoxFolders.AutoFillColumn = true;
+            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chBoxFoldersName});
+            this.lvBoxFolders.FullRowSelect = true;
+            this.lvBoxFolders.HideSelection = false;
+            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
+            this.lvBoxFolders.Name = "lvBoxFolders";
+            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
+            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
+            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
+            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
+            // 
+            // chBoxFoldersName
+            // 
+            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
+            // 
+            // lvOwnCloudPathFilter
+            // 
+            this.lvOwnCloudPathFilter.AutoFillColumn = true;
+            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvOwnCloudPathFilterPathColumn,
+            this.lvOwnCloudPathFilterFilterColumn});
+            this.lvOwnCloudPathFilter.FullRowSelect = true;
+            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvOwnCloudPathFilter.HideSelection = false;
+            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
+            this.lvOwnCloudPathFilter.MultiSelect = false;
+            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
+            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
+            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
+            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
+            // 
+            // lvOwnCloudPathFilterPathColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
+            // 
+            // lvOwnCloudPathFilterFilterColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
+            // 
+            // lvSeafileLibraries
+            // 
+            this.lvSeafileLibraries.AllowColumnSort = true;
+            this.lvSeafileLibraries.AutoFillColumn = true;
+            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.colSeafileLibraryName,
+            this.colSeafileLibrarySize,
+            this.colSeafileLibraryEncrypted});
+            this.lvSeafileLibraries.DisableDeselect = true;
+            this.lvSeafileLibraries.FullRowSelect = true;
+            this.lvSeafileLibraries.HideSelection = false;
+            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
+            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
+            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
+            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
+            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
+            // 
+            // colSeafileLibraryName
+            // 
+            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
+            // 
+            // colSeafileLibrarySize
+            // 
+            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
+            // 
+            // colSeafileLibraryEncrypted
+            // 
+            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
+            // 
             // tttvMain
             // 
             this.tttvMain.AutoSelectChild = true;
@@ -4869,12 +4878,12 @@ namespace ShareX.UploadersLib
             this.tttvMain.TreeViewFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
             this.tttvMain.TreeViewSize = 210;
             // 
-            // cbOwnCloudEncryptPassword
+            // btnOwnCloudRevealPassword
             // 
-            resources.ApplyResources(this.cbOwnCloudEncryptPassword, "cbOwnCloudEncryptPassword");
-            this.cbOwnCloudEncryptPassword.Name = "cbOwnCloudEncryptPassword";
-            this.cbOwnCloudEncryptPassword.UseVisualStyleBackColor = true;
-            this.cbOwnCloudEncryptPassword.CheckedChanged += new System.EventHandler(this.cbOwnCloudEncryptPassword_CheckedChanged);
+            resources.ApplyResources(this.btnOwnCloudRevealPassword, "btnOwnCloudRevealPassword");
+            this.btnOwnCloudRevealPassword.Name = "btnOwnCloudRevealPassword";
+            this.btnOwnCloudRevealPassword.UseVisualStyleBackColor = true;
+            this.btnOwnCloudRevealPassword.Click += new System.EventHandler(this.btnOwnCloudRevealPassword_Click);
             // 
             // atcImgurAccountType
             // 
@@ -5809,5 +5818,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblOwnCloudPathFilterInvalid;
         private System.Windows.Forms.CheckBox cbOwnCloudCreateFolderIfNonExistent;
         private System.Windows.Forms.CheckBox cbOwnCloudEncryptPassword;
+        private System.Windows.Forms.Button btnOwnCloudRevealPassword;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -135,6 +135,7 @@ namespace ShareX.UploadersLib
             this.cbFTPRemoveFileExtension = new System.Windows.Forms.CheckBox();
             this.txtFTPName = new System.Windows.Forms.TextBox();
             this.lblFTPHost = new System.Windows.Forms.Label();
+            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
             this.pFTPTransferMode = new System.Windows.Forms.Panel();
             this.rbFTPTransferModeActive = new System.Windows.Forms.RadioButton();
             this.rbFTPTransferModePassive = new System.Windows.Forms.RadioButton();
@@ -188,6 +189,9 @@ namespace ShareX.UploadersLib
             this.cbGoogleDriveUseFolder = new System.Windows.Forms.CheckBox();
             this.txtGoogleDriveFolderID = new System.Windows.Forms.TextBox();
             this.lblGoogleDriveFolderID = new System.Windows.Forms.Label();
+            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
+            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnGoogleDriveRefreshFolders = new System.Windows.Forms.Button();
             this.cbGoogleDriveIsPublic = new System.Windows.Forms.CheckBox();
             this.tpPuush = new System.Windows.Forms.TabPage();
@@ -204,6 +208,8 @@ namespace ShareX.UploadersLib
             this.cbBoxShare = new System.Windows.Forms.CheckBox();
             this.cbBoxShareAccessLevel = new System.Windows.Forms.ComboBox();
             this.lblBoxShareAccessLevel = new System.Windows.Forms.Label();
+            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
+            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lblBoxFolderID = new System.Windows.Forms.Label();
             this.btnBoxRefreshFolders = new System.Windows.Forms.Button();
             this.tpAmazonS3 = new System.Windows.Forms.TabPage();
@@ -292,6 +298,8 @@ namespace ShareX.UploadersLib
             this.txtMegaPassword = new System.Windows.Forms.TextBox();
             this.lblMegaPassword = new System.Windows.Forms.Label();
             this.tpOwnCloud = new System.Windows.Forms.TabPage();
+            this.cbOwnCloudCreateFolderIfNonExistent = new System.Windows.Forms.CheckBox();
+            this.lblOwnCloudPathFilterInvalid = new System.Windows.Forms.Label();
             this.btnOwnCloudPathFilterSortDown = new System.Windows.Forms.Button();
             this.btnOwnCloudPathFilterSortUp = new System.Windows.Forms.Button();
             this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
@@ -302,6 +310,9 @@ namespace ShareX.UploadersLib
             this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
             this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
             this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
+            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
+            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.txtOwnCloudExpiryTime = new System.Windows.Forms.NumericUpDown();
             this.cbOwnCloudAutoExpire = new System.Windows.Forms.CheckBox();
@@ -394,6 +405,10 @@ namespace ShareX.UploadersLib
             this.btnSeafileLibraryPasswordValidate = new System.Windows.Forms.Button();
             this.txtSeafileLibraryPassword = new System.Windows.Forms.TextBox();
             this.lblSeafileLibraryPassword = new System.Windows.Forms.Label();
+            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
+            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnSeafilePathValidate = new System.Windows.Forms.Button();
             this.txtSeafileDirectoryPath = new System.Windows.Forms.TextBox();
             this.lblSeafileWritePermNotif = new System.Windows.Forms.Label();
@@ -545,6 +560,10 @@ namespace ShareX.UploadersLib
             this.cbImgurUseGIFV = new System.Windows.Forms.CheckBox();
             this.cbImgurUploadSelectedAlbum = new System.Windows.Forms.CheckBox();
             this.cbImgurDirectLink = new System.Windows.Forms.CheckBox();
+            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
+            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnImgurRefreshAlbumList = new System.Windows.Forms.Button();
             this.cbImgurThumbnailType = new System.Windows.Forms.ComboBox();
             this.lblImgurThumbnailType = new System.Windows.Forms.Label();
@@ -602,25 +621,8 @@ namespace ShareX.UploadersLib
             this.txtVgymeUserKey = new System.Windows.Forms.TextBox();
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
-            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
-            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
-            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
-            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
-            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
-            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
-            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
-            this.lblOwnCloudPathFilterInvalid = new System.Windows.Forms.Label();
+            this.cbOwnCloudEncryptPassword = new System.Windows.Forms.CheckBox();
             this.atcImgurAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.oauth2Imgur = new ShareX.UploadersLib.OAuthControl();
             this.oauthFlickr = new ShareX.UploadersLib.OAuthControl();
@@ -640,7 +642,6 @@ namespace ShareX.UploadersLib
             this.oauthTeknik = new ShareX.UploadersLib.OAuthControl();
             this.oauth2YouTube = new ShareX.UploadersLib.OAuthControl();
             this.actRapidShareAccountType = new ShareX.UploadersLib.AccountTypeControl();
-            this.cbOwnCloudCreateFolderIfNonExistent = new System.Windows.Forms.CheckBox();
             this.tpOtherUploaders.SuspendLayout();
             this.tcOtherUploaders.SuspendLayout();
             this.tpTwitter.SuspendLayout();
@@ -1355,6 +1356,16 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblFTPHost, "lblFTPHost");
             this.lblFTPHost.Name = "lblFTPHost";
             // 
+            // eiFTP
+            // 
+            this.eiFTP.DefaultFileName = null;
+            resources.ApplyResources(this.eiFTP, "eiFTP");
+            this.eiFTP.Name = "eiFTP";
+            this.eiFTP.ObjectType = null;
+            this.eiFTP.SerializationBinder = null;
+            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
+            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
+            // 
             // pFTPTransferMode
             // 
             resources.ApplyResources(this.pFTPTransferMode, "pFTPTransferMode");
@@ -1728,6 +1739,29 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblGoogleDriveFolderID, "lblGoogleDriveFolderID");
             this.lblGoogleDriveFolderID.Name = "lblGoogleDriveFolderID";
             // 
+            // lvGoogleDriveFoldersList
+            // 
+            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
+            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chGoogleDriveTitle,
+            this.chGoogleDriveDescription});
+            this.lvGoogleDriveFoldersList.FullRowSelect = true;
+            this.lvGoogleDriveFoldersList.HideSelection = false;
+            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
+            this.lvGoogleDriveFoldersList.MultiSelect = false;
+            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
+            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
+            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
+            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
+            // 
+            // chGoogleDriveTitle
+            // 
+            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
+            // 
+            // chGoogleDriveDescription
+            // 
+            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
+            // 
             // btnGoogleDriveRefreshFolders
             // 
             resources.ApplyResources(this.btnGoogleDriveRefreshFolders, "btnGoogleDriveRefreshFolders");
@@ -1841,6 +1875,24 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblBoxShareAccessLevel, "lblBoxShareAccessLevel");
             this.lblBoxShareAccessLevel.Name = "lblBoxShareAccessLevel";
+            // 
+            // lvBoxFolders
+            // 
+            this.lvBoxFolders.AutoFillColumn = true;
+            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chBoxFoldersName});
+            this.lvBoxFolders.FullRowSelect = true;
+            this.lvBoxFolders.HideSelection = false;
+            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
+            this.lvBoxFolders.Name = "lvBoxFolders";
+            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
+            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
+            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
+            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
+            // 
+            // chBoxFoldersName
+            // 
+            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
             // 
             // lblBoxFolderID
             // 
@@ -2456,6 +2508,7 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.cbOwnCloudEncryptPassword);
             this.tpOwnCloud.Controls.Add(this.cbOwnCloudCreateFolderIfNonExistent);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterInvalid);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortDown);
@@ -2488,6 +2541,18 @@ namespace ShareX.UploadersLib
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudHost);
             resources.ApplyResources(this.tpOwnCloud, "tpOwnCloud");
             this.tpOwnCloud.Name = "tpOwnCloud";
+            // 
+            // cbOwnCloudCreateFolderIfNonExistent
+            // 
+            resources.ApplyResources(this.cbOwnCloudCreateFolderIfNonExistent, "cbOwnCloudCreateFolderIfNonExistent");
+            this.cbOwnCloudCreateFolderIfNonExistent.Name = "cbOwnCloudCreateFolderIfNonExistent";
+            this.cbOwnCloudCreateFolderIfNonExistent.UseVisualStyleBackColor = true;
+            this.cbOwnCloudCreateFolderIfNonExistent.CheckedChanged += new System.EventHandler(this.cbOwnCloudCreateFolderIfNonExistent_CheckedChanged);
+            // 
+            // lblOwnCloudPathFilterInvalid
+            // 
+            resources.ApplyResources(this.lblOwnCloudPathFilterInvalid, "lblOwnCloudPathFilterInvalid");
+            this.lblOwnCloudPathFilterInvalid.Name = "lblOwnCloudPathFilterInvalid";
             // 
             // btnOwnCloudPathFilterSortDown
             // 
@@ -2549,6 +2614,30 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
             this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
+            // 
+            // lvOwnCloudPathFilter
+            // 
+            this.lvOwnCloudPathFilter.AutoFillColumn = true;
+            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvOwnCloudPathFilterPathColumn,
+            this.lvOwnCloudPathFilterFilterColumn});
+            this.lvOwnCloudPathFilter.FullRowSelect = true;
+            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvOwnCloudPathFilter.HideSelection = false;
+            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
+            this.lvOwnCloudPathFilter.MultiSelect = false;
+            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
+            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
+            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
+            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
+            // 
+            // lvOwnCloudPathFilterPathColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
+            // 
+            // lvOwnCloudPathFilterFilterColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
             // 
             // cbOwnCloudPathFilter
             // 
@@ -3217,6 +3306,35 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblSeafileLibraryPassword, "lblSeafileLibraryPassword");
             this.lblSeafileLibraryPassword.Name = "lblSeafileLibraryPassword";
+            // 
+            // lvSeafileLibraries
+            // 
+            this.lvSeafileLibraries.AllowColumnSort = true;
+            this.lvSeafileLibraries.AutoFillColumn = true;
+            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.colSeafileLibraryName,
+            this.colSeafileLibrarySize,
+            this.colSeafileLibraryEncrypted});
+            this.lvSeafileLibraries.DisableDeselect = true;
+            this.lvSeafileLibraries.FullRowSelect = true;
+            this.lvSeafileLibraries.HideSelection = false;
+            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
+            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
+            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
+            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
+            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
+            // 
+            // colSeafileLibraryName
+            // 
+            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
+            // 
+            // colSeafileLibrarySize
+            // 
+            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
+            // 
+            // colSeafileLibraryEncrypted
+            // 
+            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
             // 
             // btnSeafilePathValidate
             // 
@@ -4312,6 +4430,35 @@ namespace ShareX.UploadersLib
             this.cbImgurDirectLink.UseVisualStyleBackColor = true;
             this.cbImgurDirectLink.CheckedChanged += new System.EventHandler(this.cbImgurDirectLink_CheckedChanged);
             // 
+            // lvImgurAlbumList
+            // 
+            this.lvImgurAlbumList.AllowColumnSort = true;
+            this.lvImgurAlbumList.AutoFillColumn = true;
+            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chImgurID,
+            this.chImgurTitle,
+            this.chImgurDescription});
+            this.lvImgurAlbumList.FullRowSelect = true;
+            this.lvImgurAlbumList.HideSelection = false;
+            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
+            this.lvImgurAlbumList.MultiSelect = false;
+            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
+            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
+            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
+            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
+            // 
+            // chImgurID
+            // 
+            resources.ApplyResources(this.chImgurID, "chImgurID");
+            // 
+            // chImgurTitle
+            // 
+            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
+            // 
+            // chImgurDescription
+            // 
+            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
+            // 
             // btnImgurRefreshAlbumList
             // 
             resources.ApplyResources(this.btnImgurRefreshAlbumList, "btnImgurRefreshAlbumList");
@@ -4712,139 +4859,6 @@ namespace ShareX.UploadersLib
             this.tcUploaders.Name = "tcUploaders";
             this.tcUploaders.SelectedIndex = 0;
             // 
-            // lvImgurAlbumList
-            // 
-            this.lvImgurAlbumList.AllowColumnSort = true;
-            this.lvImgurAlbumList.AutoFillColumn = true;
-            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chImgurID,
-            this.chImgurTitle,
-            this.chImgurDescription});
-            this.lvImgurAlbumList.FullRowSelect = true;
-            this.lvImgurAlbumList.HideSelection = false;
-            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
-            this.lvImgurAlbumList.MultiSelect = false;
-            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
-            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
-            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
-            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
-            // 
-            // chImgurID
-            // 
-            resources.ApplyResources(this.chImgurID, "chImgurID");
-            // 
-            // chImgurTitle
-            // 
-            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
-            // 
-            // chImgurDescription
-            // 
-            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
-            // 
-            // eiFTP
-            // 
-            this.eiFTP.DefaultFileName = null;
-            resources.ApplyResources(this.eiFTP, "eiFTP");
-            this.eiFTP.Name = "eiFTP";
-            this.eiFTP.ObjectType = null;
-            this.eiFTP.SerializationBinder = null;
-            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
-            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
-            // 
-            // lvGoogleDriveFoldersList
-            // 
-            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
-            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chGoogleDriveTitle,
-            this.chGoogleDriveDescription});
-            this.lvGoogleDriveFoldersList.FullRowSelect = true;
-            this.lvGoogleDriveFoldersList.HideSelection = false;
-            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
-            this.lvGoogleDriveFoldersList.MultiSelect = false;
-            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
-            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
-            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
-            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
-            // 
-            // chGoogleDriveTitle
-            // 
-            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
-            // 
-            // chGoogleDriveDescription
-            // 
-            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
-            // 
-            // lvBoxFolders
-            // 
-            this.lvBoxFolders.AutoFillColumn = true;
-            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chBoxFoldersName});
-            this.lvBoxFolders.FullRowSelect = true;
-            this.lvBoxFolders.HideSelection = false;
-            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
-            this.lvBoxFolders.Name = "lvBoxFolders";
-            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
-            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
-            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
-            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
-            // 
-            // chBoxFoldersName
-            // 
-            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
-            // 
-            // lvOwnCloudPathFilter
-            // 
-            this.lvOwnCloudPathFilter.AutoFillColumn = true;
-            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.lvOwnCloudPathFilterPathColumn,
-            this.lvOwnCloudPathFilterFilterColumn});
-            this.lvOwnCloudPathFilter.FullRowSelect = true;
-            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lvOwnCloudPathFilter.HideSelection = false;
-            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
-            this.lvOwnCloudPathFilter.MultiSelect = false;
-            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
-            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
-            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
-            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
-            // 
-            // lvOwnCloudPathFilterPathColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
-            // 
-            // lvOwnCloudPathFilterFilterColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
-            // 
-            // lvSeafileLibraries
-            // 
-            this.lvSeafileLibraries.AllowColumnSort = true;
-            this.lvSeafileLibraries.AutoFillColumn = true;
-            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.colSeafileLibraryName,
-            this.colSeafileLibrarySize,
-            this.colSeafileLibraryEncrypted});
-            this.lvSeafileLibraries.DisableDeselect = true;
-            this.lvSeafileLibraries.FullRowSelect = true;
-            this.lvSeafileLibraries.HideSelection = false;
-            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
-            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
-            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
-            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
-            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
-            // 
-            // colSeafileLibraryName
-            // 
-            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
-            // 
-            // colSeafileLibrarySize
-            // 
-            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
-            // 
-            // colSeafileLibraryEncrypted
-            // 
-            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
-            // 
             // tttvMain
             // 
             this.tttvMain.AutoSelectChild = true;
@@ -4855,10 +4869,12 @@ namespace ShareX.UploadersLib
             this.tttvMain.TreeViewFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
             this.tttvMain.TreeViewSize = 210;
             // 
-            // lblOwnCloudPathFilterInvalid
+            // cbOwnCloudEncryptPassword
             // 
-            resources.ApplyResources(this.lblOwnCloudPathFilterInvalid, "lblOwnCloudPathFilterInvalid");
-            this.lblOwnCloudPathFilterInvalid.Name = "lblOwnCloudPathFilterInvalid";
+            resources.ApplyResources(this.cbOwnCloudEncryptPassword, "cbOwnCloudEncryptPassword");
+            this.cbOwnCloudEncryptPassword.Name = "cbOwnCloudEncryptPassword";
+            this.cbOwnCloudEncryptPassword.UseVisualStyleBackColor = true;
+            this.cbOwnCloudEncryptPassword.CheckedChanged += new System.EventHandler(this.cbOwnCloudEncryptPassword_CheckedChanged);
             // 
             // atcImgurAccountType
             // 
@@ -5036,13 +5052,6 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.actRapidShareAccountType, "actRapidShareAccountType");
             this.actRapidShareAccountType.Name = "actRapidShareAccountType";
             this.actRapidShareAccountType.SelectedAccountType = ShareX.UploadersLib.AccountType.Anonymous;
-            // 
-            // cbOwnCloudCreateFolderIfNonExistent
-            // 
-            resources.ApplyResources(this.cbOwnCloudCreateFolderIfNonExistent, "cbOwnCloudCreateFolderIfNonExistent");
-            this.cbOwnCloudCreateFolderIfNonExistent.Name = "cbOwnCloudCreateFolderIfNonExistent";
-            this.cbOwnCloudCreateFolderIfNonExistent.UseVisualStyleBackColor = true;
-            this.cbOwnCloudCreateFolderIfNonExistent.CheckedChanged += new System.EventHandler(this.cbOwnCloudCreateFolderIfNonExistent_CheckedChanged);
             // 
             // UploadersConfigForm
             // 
@@ -5799,5 +5808,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Button btnOwnCloudPathFilterSortUp;
         private System.Windows.Forms.Label lblOwnCloudPathFilterInvalid;
         private System.Windows.Forms.CheckBox cbOwnCloudCreateFolderIfNonExistent;
+        private System.Windows.Forms.CheckBox cbOwnCloudEncryptPassword;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -606,7 +606,7 @@ namespace ShareX.UploadersLib
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
-            this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
+            this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
             this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
             this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
             this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -4819,8 +4819,10 @@ namespace ShareX.UploadersLib
             // 
             // lblOwnCloudPathFilterEditPath
             // 
-            resources.ApplyResources(this.lblOwnCloudPathFilterEditPath, "lblOwnCloudPathFilterEditPath");
-            this.lblOwnCloudPathFilterEditPath.Name = "lblOwnCloudPathFilterEditPath";
+            resources.ApplyResources(this.btnOwnCloudPathFilterEditSave, "btnOwnCloudPathFilterEditSave");
+            this.btnOwnCloudPathFilterEditSave.Name = "btnOwnCloudPathFilterEditSave";
+            this.btnOwnCloudPathFilterEditSave.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterEditSave.Click += new System.EventHandler(this.btnOwnCloudPathFilterEditSave_Click);
             // 
             // atcImgurAccountType
             // 
@@ -5749,5 +5751,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.TextBox txtOwnCloudPathFilterEditPath;
         private System.Windows.Forms.Label lblOwnCloudPathFilterEditFilter;
         private System.Windows.Forms.Label lblOwnCloudPathFilterEditPath;
+        private System.Windows.Forms.Button btnOwnCloudPathFilterEditSave;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -606,6 +606,7 @@ namespace ShareX.UploadersLib
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
+            this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
             this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
             this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
@@ -4818,7 +4819,12 @@ namespace ShareX.UploadersLib
             this.lblOwnCloudPathFilterEditFilter.Name = "lblOwnCloudPathFilterEditFilter";
             // 
             // lblOwnCloudPathFilterEditPath
-            // 
+            //
+            resources.ApplyResources(this.lblOwnCloudPathFilterEditPath, "lblOwnCloudPathFilterEditPath");
+            this.lblOwnCloudPathFilterEditPath.Name = "lblOwnCloudPathFilterEditPath";
+            //
+            // btnOwnCloudPathFilterEditSave
+            //
             resources.ApplyResources(this.btnOwnCloudPathFilterEditSave, "btnOwnCloudPathFilterEditSave");
             this.btnOwnCloudPathFilterEditSave.Name = "btnOwnCloudPathFilterEditSave";
             this.btnOwnCloudPathFilterEditSave.UseVisualStyleBackColor = true;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -2506,6 +2506,7 @@ namespace ShareX.UploadersLib
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortDown);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortUp);
+            this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterEditSave);
             this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditFilter);
             this.tpOwnCloud.Controls.Add(this.txtOwnCloudPathFilterEditPath);
             this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterEditFilter);

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -135,7 +135,6 @@ namespace ShareX.UploadersLib
             this.cbFTPRemoveFileExtension = new System.Windows.Forms.CheckBox();
             this.txtFTPName = new System.Windows.Forms.TextBox();
             this.lblFTPHost = new System.Windows.Forms.Label();
-            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
             this.pFTPTransferMode = new System.Windows.Forms.Panel();
             this.rbFTPTransferModeActive = new System.Windows.Forms.RadioButton();
             this.rbFTPTransferModePassive = new System.Windows.Forms.RadioButton();
@@ -189,9 +188,6 @@ namespace ShareX.UploadersLib
             this.cbGoogleDriveUseFolder = new System.Windows.Forms.CheckBox();
             this.txtGoogleDriveFolderID = new System.Windows.Forms.TextBox();
             this.lblGoogleDriveFolderID = new System.Windows.Forms.Label();
-            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
-            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnGoogleDriveRefreshFolders = new System.Windows.Forms.Button();
             this.cbGoogleDriveIsPublic = new System.Windows.Forms.CheckBox();
             this.tpPuush = new System.Windows.Forms.TabPage();
@@ -208,8 +204,6 @@ namespace ShareX.UploadersLib
             this.cbBoxShare = new System.Windows.Forms.CheckBox();
             this.cbBoxShareAccessLevel = new System.Windows.Forms.ComboBox();
             this.lblBoxShareAccessLevel = new System.Windows.Forms.Label();
-            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
-            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lblBoxFolderID = new System.Windows.Forms.Label();
             this.btnBoxRefreshFolders = new System.Windows.Forms.Button();
             this.tpAmazonS3 = new System.Windows.Forms.TabPage();
@@ -298,6 +292,9 @@ namespace ShareX.UploadersLib
             this.txtMegaPassword = new System.Windows.Forms.TextBox();
             this.lblMegaPassword = new System.Windows.Forms.Label();
             this.tpOwnCloud = new System.Windows.Forms.TabPage();
+            this.btnOwnCloudPathFilterSortDown = new System.Windows.Forms.Button();
+            this.btnOwnCloudPathFilterSortUp = new System.Windows.Forms.Button();
+            this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
             this.txtOwnCloudPathFilterEditFilter = new System.Windows.Forms.TextBox();
             this.txtOwnCloudPathFilterEditPath = new System.Windows.Forms.TextBox();
             this.lblOwnCloudPathFilterEditFilter = new System.Windows.Forms.Label();
@@ -305,9 +302,6 @@ namespace ShareX.UploadersLib
             this.btnOwnCloudPathFilterRemove = new System.Windows.Forms.Button();
             this.btnOwnCloudPathFilterAdd = new System.Windows.Forms.Button();
             this.lblOwnCloudPathFilter = new System.Windows.Forms.Label();
-            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
-            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.cbOwnCloudPathFilter = new System.Windows.Forms.CheckBox();
             this.txtOwnCloudExpiryTime = new System.Windows.Forms.NumericUpDown();
             this.cbOwnCloudAutoExpire = new System.Windows.Forms.CheckBox();
@@ -400,10 +394,6 @@ namespace ShareX.UploadersLib
             this.btnSeafileLibraryPasswordValidate = new System.Windows.Forms.Button();
             this.txtSeafileLibraryPassword = new System.Windows.Forms.TextBox();
             this.lblSeafileLibraryPassword = new System.Windows.Forms.Label();
-            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
-            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnSeafilePathValidate = new System.Windows.Forms.Button();
             this.txtSeafileDirectoryPath = new System.Windows.Forms.TextBox();
             this.lblSeafileWritePermNotif = new System.Windows.Forms.Label();
@@ -555,10 +545,6 @@ namespace ShareX.UploadersLib
             this.cbImgurUseGIFV = new System.Windows.Forms.CheckBox();
             this.cbImgurUploadSelectedAlbum = new System.Windows.Forms.CheckBox();
             this.cbImgurDirectLink = new System.Windows.Forms.CheckBox();
-            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
-            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnImgurRefreshAlbumList = new System.Windows.Forms.Button();
             this.cbImgurThumbnailType = new System.Windows.Forms.ComboBox();
             this.lblImgurThumbnailType = new System.Windows.Forms.Label();
@@ -616,10 +602,25 @@ namespace ShareX.UploadersLib
             this.txtVgymeUserKey = new System.Windows.Forms.TextBox();
             this.lvlVgymeUserKey = new System.Windows.Forms.Label();
             this.tcUploaders = new System.Windows.Forms.TabControl();
+            this.lvImgurAlbumList = new ShareX.HelpersLib.MyListView();
+            this.chImgurID = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chImgurDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.eiFTP = new ShareX.HelpersLib.ExportImportControl();
+            this.lvGoogleDriveFoldersList = new ShareX.HelpersLib.MyListView();
+            this.chGoogleDriveTitle = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chGoogleDriveDescription = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvBoxFolders = new ShareX.HelpersLib.MyListView();
+            this.chBoxFoldersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilter = new ShareX.HelpersLib.MyListView();
+            this.lvOwnCloudPathFilterPathColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvOwnCloudPathFilterFilterColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lvSeafileLibraries = new ShareX.HelpersLib.MyListView();
+            this.colSeafileLibraryName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibrarySize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colSeafileLibraryEncrypted = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.tttvMain = new ShareX.HelpersLib.TabToTreeView();
-            this.btnOwnCloudPathFilterEditSave = new System.Windows.Forms.Button();
-            this.btnOwnCloudPathFilterSortDown = new System.Windows.Forms.Button();
-            this.btnOwnCloudPathFilterSortUp = new System.Windows.Forms.Button();
+            this.lblOwnCloudPathFilterInvalid = new System.Windows.Forms.Label();
             this.atcImgurAccountType = new ShareX.UploadersLib.AccountTypeControl();
             this.oauth2Imgur = new ShareX.UploadersLib.OAuthControl();
             this.oauthFlickr = new ShareX.UploadersLib.OAuthControl();
@@ -1353,15 +1354,6 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblFTPHost, "lblFTPHost");
             this.lblFTPHost.Name = "lblFTPHost";
             // 
-            // eiFTP
-            // 
-            this.eiFTP.DefaultFileName = null;
-            resources.ApplyResources(this.eiFTP, "eiFTP");
-            this.eiFTP.Name = "eiFTP";
-            this.eiFTP.ObjectType = null;
-            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
-            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
-            // 
             // pFTPTransferMode
             // 
             resources.ApplyResources(this.pFTPTransferMode, "pFTPTransferMode");
@@ -1735,29 +1727,6 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.lblGoogleDriveFolderID, "lblGoogleDriveFolderID");
             this.lblGoogleDriveFolderID.Name = "lblGoogleDriveFolderID";
             // 
-            // lvGoogleDriveFoldersList
-            // 
-            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
-            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chGoogleDriveTitle,
-            this.chGoogleDriveDescription});
-            this.lvGoogleDriveFoldersList.FullRowSelect = true;
-            this.lvGoogleDriveFoldersList.HideSelection = false;
-            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
-            this.lvGoogleDriveFoldersList.MultiSelect = false;
-            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
-            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
-            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
-            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
-            // 
-            // chGoogleDriveTitle
-            // 
-            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
-            // 
-            // chGoogleDriveDescription
-            // 
-            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
-            // 
             // btnGoogleDriveRefreshFolders
             // 
             resources.ApplyResources(this.btnGoogleDriveRefreshFolders, "btnGoogleDriveRefreshFolders");
@@ -1868,27 +1837,9 @@ namespace ShareX.UploadersLib
             this.cbBoxShareAccessLevel.SelectedIndexChanged += new System.EventHandler(this.cbBoxShareAccessLevel_SelectedIndexChanged);
             // 
             // lblBoxShareAccessLevel
-            //
+            // 
             resources.ApplyResources(this.lblBoxShareAccessLevel, "lblBoxShareAccessLevel");
             this.lblBoxShareAccessLevel.Name = "lblBoxShareAccessLevel";
-            // 
-            // lvBoxFolders
-            // 
-            this.lvBoxFolders.AutoFillColumn = true;
-            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chBoxFoldersName});
-            this.lvBoxFolders.FullRowSelect = true;
-            this.lvBoxFolders.HideSelection = false;
-            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
-            this.lvBoxFolders.Name = "lvBoxFolders";
-            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
-            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
-            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
-            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
-            // 
-            // chBoxFoldersName
-            // 
-            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
             // 
             // lblBoxFolderID
             // 
@@ -2504,6 +2455,7 @@ namespace ShareX.UploadersLib
             // tpOwnCloud
             // 
             this.tpOwnCloud.BackColor = System.Drawing.SystemColors.Window;
+            this.tpOwnCloud.Controls.Add(this.lblOwnCloudPathFilterInvalid);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortDown);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterSortUp);
             this.tpOwnCloud.Controls.Add(this.btnOwnCloudPathFilterEditSave);
@@ -2535,10 +2487,32 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.tpOwnCloud, "tpOwnCloud");
             this.tpOwnCloud.Name = "tpOwnCloud";
             // 
+            // btnOwnCloudPathFilterSortDown
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterSortDown, "btnOwnCloudPathFilterSortDown");
+            this.btnOwnCloudPathFilterSortDown.Name = "btnOwnCloudPathFilterSortDown";
+            this.btnOwnCloudPathFilterSortDown.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterSortDown.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortDown_Click);
+            // 
+            // btnOwnCloudPathFilterSortUp
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterSortUp, "btnOwnCloudPathFilterSortUp");
+            this.btnOwnCloudPathFilterSortUp.Name = "btnOwnCloudPathFilterSortUp";
+            this.btnOwnCloudPathFilterSortUp.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterSortUp.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortUp_Click);
+            // 
+            // btnOwnCloudPathFilterEditSave
+            // 
+            resources.ApplyResources(this.btnOwnCloudPathFilterEditSave, "btnOwnCloudPathFilterEditSave");
+            this.btnOwnCloudPathFilterEditSave.Name = "btnOwnCloudPathFilterEditSave";
+            this.btnOwnCloudPathFilterEditSave.UseVisualStyleBackColor = true;
+            this.btnOwnCloudPathFilterEditSave.Click += new System.EventHandler(this.btnOwnCloudPathFilterEditSave_Click);
+            // 
             // txtOwnCloudPathFilterEditFilter
             // 
             resources.ApplyResources(this.txtOwnCloudPathFilterEditFilter, "txtOwnCloudPathFilterEditFilter");
             this.txtOwnCloudPathFilterEditFilter.Name = "txtOwnCloudPathFilterEditFilter";
+            this.txtOwnCloudPathFilterEditFilter.TextChanged += new System.EventHandler(this.txtOwnCloudPathFilterEditFilter_TextChanged);
             // 
             // txtOwnCloudPathFilterEditPath
             // 
@@ -2573,30 +2547,6 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblOwnCloudPathFilter, "lblOwnCloudPathFilter");
             this.lblOwnCloudPathFilter.Name = "lblOwnCloudPathFilter";
-            // 
-            // lvOwnCloudPathFilter
-            // 
-            this.lvOwnCloudPathFilter.AutoFillColumn = true;
-            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.lvOwnCloudPathFilterPathColumn,
-            this.lvOwnCloudPathFilterFilterColumn});
-            this.lvOwnCloudPathFilter.FullRowSelect = true;
-            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-            this.lvOwnCloudPathFilter.HideSelection = false;
-            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
-            this.lvOwnCloudPathFilter.MultiSelect = false;
-            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
-            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
-            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
-            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
-            // 
-            // lvOwnCloudPathFilterPathColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
-            // 
-            // lvOwnCloudPathFilterFilterColumn
-            // 
-            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
             // 
             // cbOwnCloudPathFilter
             // 
@@ -3265,35 +3215,6 @@ namespace ShareX.UploadersLib
             // 
             resources.ApplyResources(this.lblSeafileLibraryPassword, "lblSeafileLibraryPassword");
             this.lblSeafileLibraryPassword.Name = "lblSeafileLibraryPassword";
-            // 
-            // lvSeafileLibraries
-            // 
-            this.lvSeafileLibraries.AllowColumnSort = true;
-            this.lvSeafileLibraries.AutoFillColumn = true;
-            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.colSeafileLibraryName,
-            this.colSeafileLibrarySize,
-            this.colSeafileLibraryEncrypted});
-            this.lvSeafileLibraries.DisableDeselect = true;
-            this.lvSeafileLibraries.FullRowSelect = true;
-            this.lvSeafileLibraries.HideSelection = false;
-            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
-            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
-            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
-            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
-            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
-            // 
-            // colSeafileLibraryName
-            // 
-            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
-            // 
-            // colSeafileLibrarySize
-            // 
-            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
-            // 
-            // colSeafileLibraryEncrypted
-            // 
-            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
             // 
             // btnSeafilePathValidate
             // 
@@ -4389,35 +4310,6 @@ namespace ShareX.UploadersLib
             this.cbImgurDirectLink.UseVisualStyleBackColor = true;
             this.cbImgurDirectLink.CheckedChanged += new System.EventHandler(this.cbImgurDirectLink_CheckedChanged);
             // 
-            // lvImgurAlbumList
-            // 
-            this.lvImgurAlbumList.AllowColumnSort = true;
-            this.lvImgurAlbumList.AutoFillColumn = true;
-            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chImgurID,
-            this.chImgurTitle,
-            this.chImgurDescription});
-            this.lvImgurAlbumList.FullRowSelect = true;
-            this.lvImgurAlbumList.HideSelection = false;
-            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
-            this.lvImgurAlbumList.MultiSelect = false;
-            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
-            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
-            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
-            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
-            // 
-            // chImgurID
-            // 
-            resources.ApplyResources(this.chImgurID, "chImgurID");
-            // 
-            // chImgurTitle
-            // 
-            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
-            // 
-            // chImgurDescription
-            // 
-            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
-            // 
             // btnImgurRefreshAlbumList
             // 
             resources.ApplyResources(this.btnImgurRefreshAlbumList, "btnImgurRefreshAlbumList");
@@ -4818,6 +4710,139 @@ namespace ShareX.UploadersLib
             this.tcUploaders.Name = "tcUploaders";
             this.tcUploaders.SelectedIndex = 0;
             // 
+            // lvImgurAlbumList
+            // 
+            this.lvImgurAlbumList.AllowColumnSort = true;
+            this.lvImgurAlbumList.AutoFillColumn = true;
+            this.lvImgurAlbumList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chImgurID,
+            this.chImgurTitle,
+            this.chImgurDescription});
+            this.lvImgurAlbumList.FullRowSelect = true;
+            this.lvImgurAlbumList.HideSelection = false;
+            resources.ApplyResources(this.lvImgurAlbumList, "lvImgurAlbumList");
+            this.lvImgurAlbumList.MultiSelect = false;
+            this.lvImgurAlbumList.Name = "lvImgurAlbumList";
+            this.lvImgurAlbumList.UseCompatibleStateImageBehavior = false;
+            this.lvImgurAlbumList.View = System.Windows.Forms.View.Details;
+            this.lvImgurAlbumList.SelectedIndexChanged += new System.EventHandler(this.lvImgurAlbumList_SelectedIndexChanged);
+            // 
+            // chImgurID
+            // 
+            resources.ApplyResources(this.chImgurID, "chImgurID");
+            // 
+            // chImgurTitle
+            // 
+            resources.ApplyResources(this.chImgurTitle, "chImgurTitle");
+            // 
+            // chImgurDescription
+            // 
+            resources.ApplyResources(this.chImgurDescription, "chImgurDescription");
+            // 
+            // eiFTP
+            // 
+            this.eiFTP.DefaultFileName = null;
+            resources.ApplyResources(this.eiFTP, "eiFTP");
+            this.eiFTP.Name = "eiFTP";
+            this.eiFTP.ObjectType = null;
+            this.eiFTP.SerializationBinder = null;
+            this.eiFTP.ExportRequested += new ShareX.HelpersLib.ExportImportControl.ExportEventHandler(this.eiFTP_ExportRequested);
+            this.eiFTP.ImportRequested += new ShareX.HelpersLib.ExportImportControl.ImportEventHandler(this.eiFTP_ImportRequested);
+            // 
+            // lvGoogleDriveFoldersList
+            // 
+            this.lvGoogleDriveFoldersList.AutoFillColumn = true;
+            this.lvGoogleDriveFoldersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chGoogleDriveTitle,
+            this.chGoogleDriveDescription});
+            this.lvGoogleDriveFoldersList.FullRowSelect = true;
+            this.lvGoogleDriveFoldersList.HideSelection = false;
+            resources.ApplyResources(this.lvGoogleDriveFoldersList, "lvGoogleDriveFoldersList");
+            this.lvGoogleDriveFoldersList.MultiSelect = false;
+            this.lvGoogleDriveFoldersList.Name = "lvGoogleDriveFoldersList";
+            this.lvGoogleDriveFoldersList.UseCompatibleStateImageBehavior = false;
+            this.lvGoogleDriveFoldersList.View = System.Windows.Forms.View.Details;
+            this.lvGoogleDriveFoldersList.SelectedIndexChanged += new System.EventHandler(this.lvGoogleDriveFoldersList_SelectedIndexChanged);
+            // 
+            // chGoogleDriveTitle
+            // 
+            resources.ApplyResources(this.chGoogleDriveTitle, "chGoogleDriveTitle");
+            // 
+            // chGoogleDriveDescription
+            // 
+            resources.ApplyResources(this.chGoogleDriveDescription, "chGoogleDriveDescription");
+            // 
+            // lvBoxFolders
+            // 
+            this.lvBoxFolders.AutoFillColumn = true;
+            this.lvBoxFolders.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chBoxFoldersName});
+            this.lvBoxFolders.FullRowSelect = true;
+            this.lvBoxFolders.HideSelection = false;
+            resources.ApplyResources(this.lvBoxFolders, "lvBoxFolders");
+            this.lvBoxFolders.Name = "lvBoxFolders";
+            this.lvBoxFolders.UseCompatibleStateImageBehavior = false;
+            this.lvBoxFolders.View = System.Windows.Forms.View.Details;
+            this.lvBoxFolders.SelectedIndexChanged += new System.EventHandler(this.lvBoxFolders_SelectedIndexChanged);
+            this.lvBoxFolders.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.lvBoxFolders_MouseDoubleClick);
+            // 
+            // chBoxFoldersName
+            // 
+            resources.ApplyResources(this.chBoxFoldersName, "chBoxFoldersName");
+            // 
+            // lvOwnCloudPathFilter
+            // 
+            this.lvOwnCloudPathFilter.AutoFillColumn = true;
+            this.lvOwnCloudPathFilter.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvOwnCloudPathFilterPathColumn,
+            this.lvOwnCloudPathFilterFilterColumn});
+            this.lvOwnCloudPathFilter.FullRowSelect = true;
+            this.lvOwnCloudPathFilter.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvOwnCloudPathFilter.HideSelection = false;
+            resources.ApplyResources(this.lvOwnCloudPathFilter, "lvOwnCloudPathFilter");
+            this.lvOwnCloudPathFilter.MultiSelect = false;
+            this.lvOwnCloudPathFilter.Name = "lvOwnCloudPathFilter";
+            this.lvOwnCloudPathFilter.UseCompatibleStateImageBehavior = false;
+            this.lvOwnCloudPathFilter.View = System.Windows.Forms.View.Details;
+            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
+            // 
+            // lvOwnCloudPathFilterPathColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterPathColumn, "lvOwnCloudPathFilterPathColumn");
+            // 
+            // lvOwnCloudPathFilterFilterColumn
+            // 
+            resources.ApplyResources(this.lvOwnCloudPathFilterFilterColumn, "lvOwnCloudPathFilterFilterColumn");
+            // 
+            // lvSeafileLibraries
+            // 
+            this.lvSeafileLibraries.AllowColumnSort = true;
+            this.lvSeafileLibraries.AutoFillColumn = true;
+            this.lvSeafileLibraries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.colSeafileLibraryName,
+            this.colSeafileLibrarySize,
+            this.colSeafileLibraryEncrypted});
+            this.lvSeafileLibraries.DisableDeselect = true;
+            this.lvSeafileLibraries.FullRowSelect = true;
+            this.lvSeafileLibraries.HideSelection = false;
+            resources.ApplyResources(this.lvSeafileLibraries, "lvSeafileLibraries");
+            this.lvSeafileLibraries.Name = "lvSeafileLibraries";
+            this.lvSeafileLibraries.UseCompatibleStateImageBehavior = false;
+            this.lvSeafileLibraries.View = System.Windows.Forms.View.Details;
+            this.lvSeafileLibraries.SelectedIndexChanged += new System.EventHandler(this.lvSeafileLibraries_SelectedIndexChanged);
+            // 
+            // colSeafileLibraryName
+            // 
+            resources.ApplyResources(this.colSeafileLibraryName, "colSeafileLibraryName");
+            // 
+            // colSeafileLibrarySize
+            // 
+            resources.ApplyResources(this.colSeafileLibrarySize, "colSeafileLibrarySize");
+            // 
+            // colSeafileLibraryEncrypted
+            // 
+            resources.ApplyResources(this.colSeafileLibraryEncrypted, "colSeafileLibraryEncrypted");
+            // 
             // tttvMain
             // 
             this.tttvMain.AutoSelectChild = true;
@@ -4828,26 +4853,10 @@ namespace ShareX.UploadersLib
             this.tttvMain.TreeViewFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
             this.tttvMain.TreeViewSize = 210;
             // 
-            // btnOwnCloudPathFilterEditSave
+            // lblOwnCloudPathFilterInvalid
             // 
-            resources.ApplyResources(this.btnOwnCloudPathFilterEditSave, "btnOwnCloudPathFilterEditSave");
-            this.btnOwnCloudPathFilterEditSave.Name = "btnOwnCloudPathFilterEditSave";
-            this.btnOwnCloudPathFilterEditSave.UseVisualStyleBackColor = true;
-            this.btnOwnCloudPathFilterEditSave.Click += new System.EventHandler(this.btnOwnCloudPathFilterEditSave_Click);
-            // 
-            // btnOwnCloudPathFilterSortDown
-            // 
-            resources.ApplyResources(this.btnOwnCloudPathFilterSortDown, "btnOwnCloudPathFilterSortDown");
-            this.btnOwnCloudPathFilterSortDown.Name = "btnOwnCloudPathFilterSortDown";
-            this.btnOwnCloudPathFilterSortDown.UseVisualStyleBackColor = true;
-            this.btnOwnCloudPathFilterSortDown.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortDown_Click);
-            // 
-            // btnOwnCloudPathFilterSortUp
-            // 
-            resources.ApplyResources(this.btnOwnCloudPathFilterSortUp, "btnOwnCloudPathFilterSortUp");
-            this.btnOwnCloudPathFilterSortUp.Name = "btnOwnCloudPathFilterSortUp";
-            this.btnOwnCloudPathFilterSortUp.UseVisualStyleBackColor = true;
-            this.btnOwnCloudPathFilterSortUp.Click += new System.EventHandler(this.btnOwnCloudPathFilterSortUp_Click);
+            resources.ApplyResources(this.lblOwnCloudPathFilterInvalid, "lblOwnCloudPathFilterInvalid");
+            this.lblOwnCloudPathFilterInvalid.Name = "lblOwnCloudPathFilterInvalid";
             // 
             // atcImgurAccountType
             // 
@@ -5779,5 +5788,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Button btnOwnCloudPathFilterEditSave;
         private System.Windows.Forms.Button btnOwnCloudPathFilterSortDown;
         private System.Windows.Forms.Button btnOwnCloudPathFilterSortUp;
+        private System.Windows.Forms.Label lblOwnCloudPathFilterInvalid;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -2529,6 +2529,9 @@ namespace ShareX.UploadersLib
             resources.ApplyResources(this.tpOwnCloud, "tpOwnCloud");
             this.tpOwnCloud.Name = "tpOwnCloud";
             // 
+            this.btnOwnCloudPathFilterRemove.Click += new System.EventHandler(this.btnOwnCloudPathFilterRemove_Click);
+            this.btnOwnCloudPathFilterAdd.Click += new System.EventHandler(this.btnOwnCloudPathFilterAdd_Click);
+            this.lvOwnCloudPathFilter.SelectedIndexChanged += new System.EventHandler(this.lvOwnCloudPathFilter_SelectedIndexChanged);
             this.cbOwnCloudPathFilter.CheckedChanged += new System.EventHandler(this.cbOwnCloudPathFilter_CheckedChanged);
             // txtOwnCloudExpiryTime
             // 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2289,6 +2289,11 @@ namespace ShareX.UploadersLib
             Config.OwnCloudPassword = Config.OwnCloudEncryptPassword ? txtOwnCloudPassword.Text.DPAPIProtectAndBase64() : txtOwnCloudPassword.Text;
         }
 
+        private void btnOwnCloudRevealPassword_Click(object sender, EventArgs e)
+        {
+            txtOwnCloudPassword.UseSystemPasswordChar = !txtOwnCloudPassword.UseSystemPasswordChar;
+        }
+
         private void txtOwnCloudPath_TextChanged(object sender, EventArgs e)
         {
             Config.OwnCloudPath = txtOwnCloudPath.Text;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -582,6 +582,12 @@ namespace ShareX.UploadersLib
             cbOwnCloudUsePreviewLinks.Checked = Config.OwnCloudUsePreviewLinks;
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
             cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
+
+            foreach (OwnCloud.OwnCloudPathFilterItem pathFilterItem in Config.OwnCloudPathFilter)
+            {
+                ListViewItem item = lvOwnCloudPathFilter.Items.Add(pathFilterItem.Path);
+                item.SubItems.Add(pathFilterItem.Filter);
+            }
 
             #endregion ownCloud / Nextcloud
 
@@ -2314,6 +2320,46 @@ namespace ShareX.UploadersLib
             txtOwnCloudPathFilterEditPath.Visible = cbOwnCloudPathFilter.Checked;
             lblOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
             txtOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
+        }
+
+        private void btnOwnCloudPathFilterAdd_Click(object sender, EventArgs e)
+        {
+            ListViewItem newPathFilterItem = new ListViewItem("/");
+            newPathFilterItem.SubItems.Add("*.*");
+
+            lvOwnCloudPathFilter.Items.Add(newPathFilterItem);
+            lvOwnCloudPathFilter.SelectSingle(newPathFilterItem);
+
+            OwnCloudSavePathFilters();
+        }
+
+        private void btnOwnCloudPathFilterRemove_Click(object sender, EventArgs e)
+        {
+            ListViewItem removeItem = lvOwnCloudPathFilter.SelectedItems[0];
+            int nextSelectIndex = (removeItem.Index == lvOwnCloudPathFilter.Items.Count - 1) ? removeItem.Index - 1 : removeItem.Index + 1;
+            lvOwnCloudPathFilter.Select(nextSelectIndex);
+            lvOwnCloudPathFilter.Items.Remove(removeItem);
+
+            OwnCloudSavePathFilters();
+        }
+
+        private void OwnCloudSavePathFilters()
+        {
+            Config.OwnCloudPathFilter.Clear();
+
+            foreach (ListViewItem item in lvOwnCloudPathFilter.Items)
+            {
+                Config.OwnCloudPathFilter.Add(new OwnCloud.OwnCloudPathFilterItem()
+                {
+                    Path = item.Text,
+                    Filter = item.SubItems[1].Text
+                });
+            }
+        }
+
+        private void lvOwnCloudPathFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            btnOwnCloudPathFilterRemove.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;
         }
 
         #endregion ownCloud / Nextcloud

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2345,7 +2345,33 @@ namespace ShareX.UploadersLib
 
         private void lvOwnCloudPathFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            btnOwnCloudPathFilterRemove.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;
+            btnOwnCloudPathFilterRemove.Enabled = lblOwnCloudPathFilterEditPath.Enabled = txtOwnCloudPathFilterEditPath.Enabled = lblOwnCloudPathFilterEditFilter.Enabled = txtOwnCloudPathFilterEditFilter.Enabled = btnOwnCloudPathFilterEditSave.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;
+
+            if (txtOwnCloudPathFilterEditPath.Enabled)
+            {
+                txtOwnCloudPathFilterEditPath.Text = lvOwnCloudPathFilter.SelectedItems[0].Text;
+            }
+            else
+            {
+                txtOwnCloudPathFilterEditPath.Text = null;
+            }
+
+            if (txtOwnCloudPathFilterEditFilter.Enabled)
+            {
+                txtOwnCloudPathFilterEditFilter.Text = lvOwnCloudPathFilter.SelectedItems[0].SubItems[1].Text;
+            }
+            else
+            {
+                txtOwnCloudPathFilterEditFilter.Text = null;
+            }
+        }
+
+        private void btnOwnCloudPathFilterEditSave_Click(object sender, EventArgs e)
+        {
+            lvOwnCloudPathFilter.SelectedItems[0].Text = txtOwnCloudPathFilterEditPath.Text;
+            lvOwnCloudPathFilter.SelectedItems[0].SubItems[1].Text = txtOwnCloudPathFilterEditFilter.Text;
+
+            OwnCloudSavePathFilters();
         }
 
         #endregion ownCloud / Nextcloud

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -574,7 +574,16 @@ namespace ShareX.UploadersLib
 
             txtOwnCloudHost.Text = Config.OwnCloudHost;
             txtOwnCloudUsername.Text = Config.OwnCloudUsername;
-            txtOwnCloudPassword.Text = Config.OwnCloudPassword;
+
+            if (Config.OwnCloudEncryptPassword && Config.OwnCloudPassword.TryDPAPIUnprotectAndBase64(out string password))
+            {
+                txtOwnCloudPassword.Text = password;
+            }
+            else
+            {
+                txtOwnCloudPassword.Text = Config.OwnCloudPassword;
+            }
+
             txtOwnCloudPath.Text = Config.OwnCloudPath;
             txtOwnCloudExpiryTime.Value = Config.OwnCloudExpiryTime;
             cbOwnCloudCreateShare.Checked = Config.OwnCloudCreateShare;
@@ -584,6 +593,7 @@ namespace ShareX.UploadersLib
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
             cbOwnCloudCreateFolderIfNonExistent.Checked = Config.OwnCloudCreateFolderOfNonExistent;
             cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
+            cbOwnCloudEncryptPassword.Checked = Config.OwnCloudEncryptPassword;
             lblOwnCloudPathFilterInvalid.ForeColor = Color.Red;
 
             foreach (OwnCloud.OwnCloudPathFilterItem pathFilterItem in Config.OwnCloudPathFilters)
@@ -2276,7 +2286,7 @@ namespace ShareX.UploadersLib
 
         private void txtOwnCloudPassword_TextChanged(object sender, EventArgs e)
         {
-            Config.OwnCloudPassword = txtOwnCloudPassword.Text;
+            Config.OwnCloudPassword = Config.OwnCloudEncryptPassword ? txtOwnCloudPassword.Text.DPAPIProtectAndBase64() : txtOwnCloudPassword.Text;
         }
 
         private void txtOwnCloudPath_TextChanged(object sender, EventArgs e)
@@ -2334,6 +2344,12 @@ namespace ShareX.UploadersLib
             lblOwnCloudPathFilterEditFilter.Visible =
             txtOwnCloudPathFilterEditFilter.Visible =
             btnOwnCloudPathFilterEditSave.Visible = cbOwnCloudPathFilter.Checked;
+        }
+
+        private void cbOwnCloudEncryptPassword_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.OwnCloudEncryptPassword = cbOwnCloudEncryptPassword.Checked;
+            Config.OwnCloudPassword = Config.OwnCloudEncryptPassword ? txtOwnCloudPassword.Text.DPAPIProtectAndBase64() : txtOwnCloudPassword.Text;
         }
 
         private void btnOwnCloudPathFilterAdd_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2312,13 +2312,15 @@ namespace ShareX.UploadersLib
         {
             Config.OwnCloudUsePathFilter = cbOwnCloudPathFilter.Checked;
 
-            lblOwnCloudPathFilter.Visible = cbOwnCloudPathFilter.Checked;
-            lvOwnCloudPathFilter.Visible = cbOwnCloudPathFilter.Checked;
-            btnOwnCloudPathFilterAdd.Visible = cbOwnCloudPathFilter.Checked;
-            btnOwnCloudPathFilterRemove.Visible = cbOwnCloudPathFilter.Checked;
-            lblOwnCloudPathFilterEditPath.Visible = cbOwnCloudPathFilter.Checked;
-            txtOwnCloudPathFilterEditPath.Visible = cbOwnCloudPathFilter.Checked;
-            lblOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
+            lblOwnCloudPathFilter.Visible =
+            lvOwnCloudPathFilter.Visible =
+            btnOwnCloudPathFilterAdd.Visible =
+            btnOwnCloudPathFilterRemove.Visible =
+            btnOwnCloudPathFilterSortUp.Visible =
+            btnOwnCloudPathFilterSortDown.Visible =
+            lblOwnCloudPathFilterEditPath.Visible =
+            txtOwnCloudPathFilterEditPath.Visible =
+            lblOwnCloudPathFilterEditFilter.Visible =
             txtOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
         }
 
@@ -2343,9 +2345,33 @@ namespace ShareX.UploadersLib
             OwnCloudSavePathFilters();
         }
 
+        private void btnOwnCloudPathFilterSortUp_Click(object sender, EventArgs e)
+        {
+            OwnCloudSwapPathFilters(lvOwnCloudPathFilter.SelectedIndex, lvOwnCloudPathFilter.SelectedIndex - 1, true);
+
+            OwnCloudSavePathFilters();
+        }
+
+        private void btnOwnCloudPathFilterSortDown_Click(object sender, EventArgs e)
+        {
+            OwnCloudSwapPathFilters(lvOwnCloudPathFilter.SelectedIndex, lvOwnCloudPathFilter.SelectedIndex + 1, true);
+
+            OwnCloudSavePathFilters();
+        }
+
         private void lvOwnCloudPathFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            btnOwnCloudPathFilterRemove.Enabled = lblOwnCloudPathFilterEditPath.Enabled = txtOwnCloudPathFilterEditPath.Enabled = lblOwnCloudPathFilterEditFilter.Enabled = txtOwnCloudPathFilterEditFilter.Enabled = btnOwnCloudPathFilterEditSave.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;
+            btnOwnCloudPathFilterRemove.Enabled =
+            btnOwnCloudPathFilterSortUp.Enabled =
+            btnOwnCloudPathFilterSortDown.Enabled =
+            lblOwnCloudPathFilterEditPath.Enabled =
+            txtOwnCloudPathFilterEditPath.Enabled =
+            lblOwnCloudPathFilterEditFilter.Enabled =
+            txtOwnCloudPathFilterEditFilter.Enabled =
+            btnOwnCloudPathFilterEditSave.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;
+
+            btnOwnCloudPathFilterSortUp.Enabled &= lvOwnCloudPathFilter.SelectedIndex > 0;
+            btnOwnCloudPathFilterSortDown.Enabled &= lvOwnCloudPathFilter.SelectedIndex < lvOwnCloudPathFilter.Items.Count - 1;
 
             if (txtOwnCloudPathFilterEditPath.Enabled)
             {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -582,6 +582,7 @@ namespace ShareX.UploadersLib
             cbOwnCloud81Compatibility.Checked = Config.OwnCloud81Compatibility;
             cbOwnCloudUsePreviewLinks.Checked = Config.OwnCloudUsePreviewLinks;
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
+            cbOwnCloudCreateFolderIfNonExistent.Checked = Config.OwnCloudCreateFolderOfNonExistent;
             cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
             lblOwnCloudPathFilterInvalid.ForeColor = Color.Red;
 
@@ -2311,6 +2312,11 @@ namespace ShareX.UploadersLib
         private void cbOwnCloudAutoExpire_CheckedChanged(object sender, EventArgs e)
         {
             Config.OwnCloudAutoExpire = cbOwnCloudAutoExpire.Checked;
+        }
+
+        private void cbOwnCloudCreateFolderIfNonExistent_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.OwnCloudCreateFolderOfNonExistent = cbOwnCloudCreateFolderIfNonExistent.Checked;
         }
 
         private void cbOwnCloudPathFilter_CheckedChanged(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using CG.Web.MegaApiClient;
+using FluentFTP;
 using ShareX.HelpersLib;
 using ShareX.UploadersLib.FileUploaders;
 using ShareX.UploadersLib.ImageUploaders;
@@ -582,6 +583,7 @@ namespace ShareX.UploadersLib
             cbOwnCloudUsePreviewLinks.Checked = Config.OwnCloudUsePreviewLinks;
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
             cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
+            lblOwnCloudPathFilterInvalid.ForeColor = Color.Red;
 
             foreach (OwnCloud.OwnCloudPathFilterItem pathFilterItem in Config.OwnCloudPathFilters)
             {
@@ -2398,6 +2400,20 @@ namespace ShareX.UploadersLib
             else
             {
                 txtOwnCloudPathFilterEditFilter.Text = null;
+            }
+        }
+
+        private void txtOwnCloudPathFilterEditFilter_TextChanged(object sender, EventArgs e)
+        {
+            if (!txtOwnCloudPathFilterEditFilter.Enabled || txtOwnCloudPathFilterEditFilter.Text.IsValidRegEx())
+            {
+                txtOwnCloudPathFilterEditFilter.BackColor = ShareXResources.Theme.BackgroundColor;
+                lblOwnCloudPathFilterInvalid.Visible = false;
+            }
+            else
+            {
+                txtOwnCloudPathFilterEditFilter.BackColor = Color.DarkRed;
+                lblOwnCloudPathFilterInvalid.Visible = true;
             }
         }
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2343,20 +2343,6 @@ namespace ShareX.UploadersLib
             OwnCloudSavePathFilters();
         }
 
-        private void OwnCloudSavePathFilters()
-        {
-            Config.OwnCloudPathFilter.Clear();
-
-            foreach (ListViewItem item in lvOwnCloudPathFilter.Items)
-            {
-                Config.OwnCloudPathFilter.Add(new OwnCloud.OwnCloudPathFilterItem()
-                {
-                    Path = item.Text,
-                    Filter = item.SubItems[1].Text
-                });
-            }
-        }
-
         private void lvOwnCloudPathFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
             btnOwnCloudPathFilterRemove.Enabled = lvOwnCloudPathFilter.SelectedIndex >= 0;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2272,7 +2272,7 @@ namespace ShareX.UploadersLib
 
         #endregion Amazon S3
 
-        #region ownCloud / Nextcloud
+        #region OwnCloud / Nextcloud
 
         private void txtOwnCloudHost_TextChanged(object sender, EventArgs e)
         {
@@ -2348,7 +2348,10 @@ namespace ShareX.UploadersLib
             txtOwnCloudPathFilterEditPath.Visible =
             lblOwnCloudPathFilterEditFilter.Visible =
             txtOwnCloudPathFilterEditFilter.Visible =
+            lblOwnCloudPathFilterInvalid.Visible =
             btnOwnCloudPathFilterEditSave.Visible = cbOwnCloudPathFilter.Checked;
+
+            lblOwnCloudPathFilterInvalid.Visible &= !(!txtOwnCloudPathFilterEditFilter.Enabled || txtOwnCloudPathFilterEditFilter.Text.IsValidRegEx());
         }
 
         private void cbOwnCloudEncryptPassword_CheckedChanged(object sender, EventArgs e)
@@ -2453,7 +2456,7 @@ namespace ShareX.UploadersLib
             OwnCloudSavePathFilters();
         }
 
-        #endregion ownCloud / Nextcloud
+        #endregion OwnCloud / Nextcloud
 
         #region Pushbullet
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2330,7 +2330,7 @@ namespace ShareX.UploadersLib
         private void btnOwnCloudPathFilterAdd_Click(object sender, EventArgs e)
         {
             ListViewItem newPathFilterItem = new ListViewItem("/");
-            newPathFilterItem.SubItems.Add("*.*");
+            newPathFilterItem.SubItems.Add(".*");
 
             newPathFilterItem.UseItemStyleForSubItems = false;
             newPathFilterItem.SubItems[1].Font = txtOwnCloudPathFilterEditFilter.Font;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -587,6 +587,9 @@ namespace ShareX.UploadersLib
             {
                 ListViewItem item = lvOwnCloudPathFilter.Items.Add(pathFilterItem.Path);
                 item.SubItems.Add(pathFilterItem.Filter);
+
+                item.UseItemStyleForSubItems = false;
+                item.SubItems[1].Font = txtOwnCloudPathFilterEditFilter.Font;
             }
 
             #endregion ownCloud / Nextcloud
@@ -2328,6 +2331,9 @@ namespace ShareX.UploadersLib
         {
             ListViewItem newPathFilterItem = new ListViewItem("/");
             newPathFilterItem.SubItems.Add("*.*");
+
+            newPathFilterItem.UseItemStyleForSubItems = false;
+            newPathFilterItem.SubItems[1].Font = txtOwnCloudPathFilterEditFilter.Font;
 
             lvOwnCloudPathFilter.Items.Add(newPathFilterItem);
             lvOwnCloudPathFilter.SelectSingle(newPathFilterItem);

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -581,6 +581,7 @@ namespace ShareX.UploadersLib
             cbOwnCloud81Compatibility.Checked = Config.OwnCloud81Compatibility;
             cbOwnCloudUsePreviewLinks.Checked = Config.OwnCloudUsePreviewLinks;
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
+            cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
 
             #endregion ownCloud / Nextcloud
 
@@ -2299,6 +2300,20 @@ namespace ShareX.UploadersLib
         private void cbOwnCloudAutoExpire_CheckedChanged(object sender, EventArgs e)
         {
             Config.OwnCloudAutoExpire = cbOwnCloudAutoExpire.Checked;
+        }
+
+        private void cbOwnCloudPathFilter_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.OwnCloudUsePathFilter = cbOwnCloudPathFilter.Checked;
+
+            lblOwnCloudPathFilter.Visible = cbOwnCloudPathFilter.Checked;
+            lvOwnCloudPathFilter.Visible = cbOwnCloudPathFilter.Checked;
+            btnOwnCloudPathFilterAdd.Visible = cbOwnCloudPathFilter.Checked;
+            btnOwnCloudPathFilterRemove.Visible = cbOwnCloudPathFilter.Checked;
+            lblOwnCloudPathFilterEditPath.Visible = cbOwnCloudPathFilter.Checked;
+            txtOwnCloudPathFilterEditPath.Visible = cbOwnCloudPathFilter.Checked;
+            lblOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
+            txtOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
         }
 
         #endregion ownCloud / Nextcloud

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2332,7 +2332,8 @@ namespace ShareX.UploadersLib
             lblOwnCloudPathFilterEditPath.Visible =
             txtOwnCloudPathFilterEditPath.Visible =
             lblOwnCloudPathFilterEditFilter.Visible =
-            txtOwnCloudPathFilterEditFilter.Visible = cbOwnCloudPathFilter.Checked;
+            txtOwnCloudPathFilterEditFilter.Visible =
+            btnOwnCloudPathFilterEditSave.Visible = cbOwnCloudPathFilter.Checked;
         }
 
         private void btnOwnCloudPathFilterAdd_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -2342,6 +2342,9 @@ namespace ShareX.UploadersLib
             lvOwnCloudPathFilter.Select(nextSelectIndex);
             lvOwnCloudPathFilter.Items.Remove(removeItem);
 
+            btnOwnCloudPathFilterSortUp.Enabled &= lvOwnCloudPathFilter.SelectedIndex > 0;
+            btnOwnCloudPathFilterSortDown.Enabled &= lvOwnCloudPathFilter.SelectedIndex < lvOwnCloudPathFilter.Items.Count - 1;
+
             OwnCloudSavePathFilters();
         }
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -583,7 +583,7 @@ namespace ShareX.UploadersLib
             cbOwnCloudAutoExpire.Checked = Config.OwnCloudAutoExpire;
             cbOwnCloudPathFilter.Checked = Config.OwnCloudUsePathFilter;
 
-            foreach (OwnCloud.OwnCloudPathFilterItem pathFilterItem in Config.OwnCloudPathFilter)
+            foreach (OwnCloud.OwnCloudPathFilterItem pathFilterItem in Config.OwnCloudPathFilters)
             {
                 ListViewItem item = lvOwnCloudPathFilter.Items.Add(pathFilterItem.Path);
                 item.SubItems.Add(pathFilterItem.Filter);

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -436,7 +436,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Benutze langen Link, der den Dateinamen beinhaltet</value>
   </data>
   <data name="lblOwnCloudHost.Text" xml:space="preserve">
-    <value>Host:</value>
+    <value>Server-Addresse:</value>
   </data>
   <data name="lblOwnCloudUsername.Text" xml:space="preserve">
     <value>Benutzername:</value>
@@ -448,13 +448,13 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Allgemeiner Pfad:</value>
   </data>
   <data name="cbOwnCloudCreateShare.Text" xml:space="preserve">
-    <value>Erstelle teilbare URL</value>
+    <value>Teilbaren Link erstellen</value>
   </data>
   <data name="cbOwnCloudDirectLink.Text" xml:space="preserve">
     <value>Direkter Link (Fügt "&amp;download" zur URL hinzu)</value>
   </data>
   <data name="cbOwnCloud81Compatibility.Text" xml:space="preserve">
-    <value>ownCloud 8.1+ Unterstützung</value>
+    <value>Unterstützung für OwnCloud 8.1+</value>
   </data>
   <data name="lblMegaPassword.Text" xml:space="preserve">
     <value>Passwort:</value>
@@ -760,7 +760,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Ablaufzeit des geteilten Links (in Tagen):</value>
   </data>
   <data name="lblOwnCloudHostExample.Text" xml:space="preserve">
-    <value>Beispiel: http://example.com/owncloud</value>
+    <value>Beispiel: http://meine-webseite.de/owncloud</value>
   </data>
   <data name="cbOwnCloudCreateFolderIfNonExistent.Text" xml:space="preserve">
     <value>Ordner automatisch erstellen, wenn er nicht existiert</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -736,7 +736,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Pfadfilter:</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
-    <value>Filter (getrennt durch Komma, z.B. "*.jpg, *.png, ..."):</value>
+    <value>Filter (der normale C# Regex kann hier genutzt werden):</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.Text" xml:space="preserve">
     <value>Pfad:</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -750,4 +750,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="btnOwnCloudPathFilterEditSave.Text" xml:space="preserve">
     <value>Speichern</value>
   </data>
+  <data name="lblOwnCloudPathFilterInvalid.Text" xml:space="preserve">
+    <value>Ungültiger Regex-Syntax!</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -445,7 +445,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Passwort:</value>
   </data>
   <data name="lblOwnCloudPath.Text" xml:space="preserve">
-    <value>Pfad:</value>
+    <value>Allgemeiner Pfad:</value>
   </data>
   <data name="cbOwnCloudCreateShare.Text" xml:space="preserve">
     <value>Erstelle teilbare URL</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -762,4 +762,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="lblOwnCloudHostExample.Text" xml:space="preserve">
     <value>Beispiel: http://example.com/owncloud</value>
   </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.Text" xml:space="preserve">
+    <value>Ordner automatisch erstellen, wenn er nicht existiert</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -753,4 +753,13 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="lblOwnCloudPathFilterInvalid.Text" xml:space="preserve">
     <value>Ungültiger Regex-Syntax!</value>
   </data>
+  <data name="cbOwnCloudAutoExpire.Text" xml:space="preserve">
+    <value>Geteilte Links automatisch ablaufen lassen</value>
+  </data>
+  <data name="lblOwnCloudExpiryTime.Text" xml:space="preserve">
+    <value>Ablaufzeit des geteilten Links (in Tagen):</value>
+  </data>
+  <data name="lblOwnCloudHostExample.Text" xml:space="preserve">
+    <value>Beispiel: http://example.com/owncloud</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -736,7 +736,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Pfadfilter:</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
-    <value>Filter (der normale C# Regex kann hier genutzt werden):</value>
+    <value>Filter (der normale C# RegEx kann hier genutzt werden):</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.Text" xml:space="preserve">
     <value>Pfad:</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -736,7 +736,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
     <value>Pfadfilter:</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
-    <value>Filter:</value>
+    <value>Filter (getrennt durch Komma, z.B. "*.jpg, *.png, ..."):</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.Text" xml:space="preserve">
     <value>Pfad:</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -747,4 +747,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="lvOwnCloudPathFilterPathColumn.Text" xml:space="preserve">
     <value>Pfad</value>
   </data>
+  <data name="btnOwnCloudPathFilterEditSave.Text" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -729,4 +729,22 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="cbFTPRemoveFileExtension.Text" xml:space="preserve">
     <value>Dateierweiterung vom URL-Pfad entfernen</value>
   </data>
+  <data name="cbOwnCloudPathFilter.Text" xml:space="preserve">
+    <value>Pfadfilter aktivieren</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.Text" xml:space="preserve">
+    <value>Pfadfilter:</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Text" xml:space="preserve">
+    <value>Pfad:</value>
+  </data>
+  <data name="lvOwnCloudPathFilterFilterColumn" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="lvOwnCloudPathFilterPathColumn.Text" xml:space="preserve">
+    <value>Pfad</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.de.resx
@@ -765,4 +765,7 @@ Das Benutzen einer verschlüsselten Bibliothek deaktiviert das Teilen.</value>
   <data name="cbOwnCloudCreateFolderIfNonExistent.Text" xml:space="preserve">
     <value>Ordner automatisch erstellen, wenn er nicht existiert</value>
   </data>
+  <data name="cbOwnCloudEncryptPassword.Text" xml:space="preserve">
+    <value>Passwort in der Einstellungsdatei verschlüsseln</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6824,6 +6824,9 @@ when you made the application key.</value>
   <data name="&gt;&gt;btnOwnCloudPathFilterSortUp.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="btnOwnCloudPathFilterEditSave.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="txtOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -7095,7 +7095,7 @@ when you made the application key.</value>
     <value>23</value>
   </data>
   <data name="lblOwnCloudPathFilter.Text" xml:space="preserve">
-    <value>Path filter:</value>
+    <value>Path filters:</value>
   </data>
   <data name="lblOwnCloudPathFilter.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -7164,7 +7164,7 @@ when you made the application key.</value>
     <value>21</value>
   </data>
   <data name="cbOwnCloudPathFilter.Text" xml:space="preserve">
-    <value>Enable path filter</value>
+    <value>Enable path filters</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudPathFilter.Name" xml:space="preserve">
     <value>cbOwnCloudPathFilter</value>
@@ -7626,7 +7626,7 @@ when you made the application key.</value>
     <value>15</value>
   </data>
   <data name="tpOwnCloud.Text" xml:space="preserve">
-    <value>ownCloud / Nextcloud</value>
+    <value>OwnCloud / Nextcloud</value>
   </data>
   <data name="&gt;&gt;tpOwnCloud.Name" xml:space="preserve">
     <value>tpOwnCloud</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,6 +6695,36 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="btnOwnCloudRevealPassword.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9pt</value>
+  </data>
+  <data name="btnOwnCloudRevealPassword.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudRevealPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 123</value>
+  </data>
+  <data name="btnOwnCloudRevealPassword.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 30</value>
+  </data>
+  <data name="btnOwnCloudRevealPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="btnOwnCloudRevealPassword.Text" xml:space="preserve">
+    <value>👁</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudRevealPassword.Name" xml:space="preserve">
+    <value>btnOwnCloudRevealPassword</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudRevealPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudRevealPassword.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudRevealPassword.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbOwnCloudEncryptPassword.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6765,7 +6765,7 @@ when you made the application key.</value>
     <value>27</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
-    <value>Filter:</value>
+    <value>Filter (comma seperated, e.g. "*.jpg, *.png, ..."):</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6834,7 +6834,7 @@ when you made the application key.</value>
     <value>27</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
-    <value>Filter (comma seperated, e.g. "*.jpg, *.png, ..."):</value>
+    <value>Filter (use normal C# regex):</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -6695,6 +6695,288 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="txtOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>382, 474</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>346, 20</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditFilter.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditFilter.Name" xml:space="preserve">
+    <value>txtOwnCloudPathFilterEditFilter</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditFilter.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditFilter.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditPath.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>382, 426</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>346, 20</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditPath.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="txtOwnCloudPathFilterEditPath.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditPath.Name" xml:space="preserve">
+    <value>txtOwnCloudPathFilterEditPath</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditPath.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;txtOwnCloudPathFilterEditPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>379, 458</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 13</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditFilter.Name" xml:space="preserve">
+    <value>lblOwnCloudPathFilterEditFilter</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditFilter.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditFilter.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>379, 410</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 13</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Text" xml:space="preserve">
+    <value>Path:</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditPath.Name" xml:space="preserve">
+    <value>lblOwnCloudPathFilterEditPath</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditPath.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterEditPath.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.Location" type="System.Drawing.Point, System.Drawing">
+    <value>734, 205</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.Text" xml:space="preserve">
+    <value>-</value>
+  </data>
+  <data name="btnOwnCloudPathFilterRemove.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterRemove.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterRemove</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterRemove.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterRemove.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>734, 176</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.Text" xml:space="preserve">
+    <value>+</value>
+  </data>
+  <data name="btnOwnCloudPathFilterAdd.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterAdd.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterAdd</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterAdd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterAdd.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterAdd.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>379, 160</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>54, 13</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.Text" xml:space="preserve">
+    <value>Path filter:</value>
+  </data>
+  <data name="lblOwnCloudPathFilter.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilter.Name" xml:space="preserve">
+    <value>lblOwnCloudPathFilter</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilter.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilter.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="lvOwnCloudPathFilterPathColumn.Text" xml:space="preserve">
+    <value>Path</value>
+  </data>
+  <data name="lvOwnCloudPathFilterPathColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="lvOwnCloudPathFilterFilterColumn.Text" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="lvOwnCloudPathFilterFilterColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="lvOwnCloudPathFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>382, 176</value>
+  </data>
+  <data name="lvOwnCloudPathFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>346, 221</value>
+  </data>
+  <data name="lvOwnCloudPathFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="lvOwnCloudPathFilter.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilter.Name" xml:space="preserve">
+    <value>lvOwnCloudPathFilter</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilter.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=13.1.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilter.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilter.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 380</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 17</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="cbOwnCloudPathFilter.Text" xml:space="preserve">
+    <value>Enable path filter</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudPathFilter.Name" xml:space="preserve">
+    <value>cbOwnCloudPathFilter</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudPathFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudPathFilter.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudPathFilter.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <data name="txtOwnCloudExpiryTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 224</value>
   </data>
@@ -7020,13 +7302,13 @@ when you made the application key.</value>
     <value>13, 160</value>
   </data>
   <data name="lblOwnCloudPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>75, 13</value>
   </data>
   <data name="lblOwnCloudPath.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="lblOwnCloudPath.Text" xml:space="preserve">
-    <value>Path:</value>
+    <value>Common path:</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPath.Name" xml:space="preserve">
     <value>lblOwnCloudPath</value>
@@ -15049,6 +15331,18 @@ Using an encrypted library disables sharing.</value>
     <value>chPicasaDescription</value>
   </data>
   <data name="&gt;&gt;chPicasaDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Name" xml:space="preserve">
+    <value>lvOwnCloudPathFilterPathColumn</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Name" xml:space="preserve">
+    <value>lvOwnCloudPathFilterFilterColumn</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,6 +6695,36 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 380</value>
+  </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>163, 17</value>
+  </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbOwnCloudCreateFolderIfNonExistent.Text" xml:space="preserve">
+    <value>Create folder if it doesn't exist</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateFolderIfNonExistent.Name" xml:space="preserve">
+    <value>cbOwnCloudCreateFolderIfNonExistent</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateFolderIfNonExistent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateFolderIfNonExistent.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudCreateFolderIfNonExistent.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblOwnCloudPathFilterInvalid.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -7062,7 +7092,7 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="cbOwnCloudPathFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 380</value>
+    <value>16, 403</value>
   </data>
   <data name="cbOwnCloudPathFilter.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 17</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,6 +6695,36 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="cbOwnCloudEncryptPassword.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbOwnCloudEncryptPassword.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbOwnCloudEncryptPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 426</value>
+  </data>
+  <data name="cbOwnCloudEncryptPassword.Size" type="System.Drawing.Size, System.Drawing">
+    <value>169, 17</value>
+  </data>
+  <data name="cbOwnCloudEncryptPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="cbOwnCloudEncryptPassword.Text" xml:space="preserve">
+    <value>Encrypt password in config file</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudEncryptPassword.Name" xml:space="preserve">
+    <value>cbOwnCloudEncryptPassword</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudEncryptPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudEncryptPassword.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;cbOwnCloudEncryptPassword.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbOwnCloudCreateFolderIfNonExistent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,6 +6695,39 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="lblOwnCloudPathFilterInvalid.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.Location" type="System.Drawing.Point, System.Drawing">
+    <value>379, 502</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 13</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.Text" xml:space="preserve">
+    <value>Invalid regex syntax!</value>
+  </data>
+  <data name="lblOwnCloudPathFilterInvalid.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterInvalid.Name" xml:space="preserve">
+    <value>lblOwnCloudPathFilterInvalid</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterInvalid.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterInvalid.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;lblOwnCloudPathFilterInvalid.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="btnOwnCloudPathFilterSortDown.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,35 +6695,71 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.Enabled" type="System.Boolean, mscorlib">
+  <data name="btnOwnCloudPathFilterSortDown.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="btnOwnCloudPathFilterSortDown.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>732, 473</value>
+  <data name="btnOwnCloudPathFilterSortDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>734, 374</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 23</value>
+  <data name="btnOwnCloudPathFilterSortDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
+  <data name="btnOwnCloudPathFilterSortDown.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
   </data>
-  <data name="btnOwnCloudPathFilterEditSave.Text" xml:space="preserve">
-    <value>Save</value>
+  <data name="btnOwnCloudPathFilterSortDown.Text" xml:space="preserve">
+    <value>˅</value>
   </data>
-  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Name" xml:space="preserve">
-    <value>btnOwnCloudPathFilterEditSave</value>
+  <data name="btnOwnCloudPathFilterSortDown.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortDown.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterSortDown</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortDown.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Parent" xml:space="preserve">
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortDown.Parent" xml:space="preserve">
     <value>tpOwnCloud</value>
   </data>
-  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortDown.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>734, 345</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.Text" xml:space="preserve">
+    <value>˄</value>
+  </data>
+  <data name="btnOwnCloudPathFilterSortUp.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortUp.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterSortUp</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortUp.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterSortUp.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="txtOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -6750,7 +6786,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudPathFilterEditFilter.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="txtOwnCloudPathFilterEditPath.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -6777,7 +6813,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudPathFilterEditPath.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6792,7 +6828,7 @@ when you made the application key.</value>
     <value>379, 458</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>229, 13</value>
   </data>
   <data name="lblOwnCloudPathFilterEditFilter.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -6813,7 +6849,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPathFilterEditFilter.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6849,7 +6885,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPathFilterEditPath.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="btnOwnCloudPathFilterRemove.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -6882,7 +6918,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;btnOwnCloudPathFilterRemove.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="btnOwnCloudPathFilterAdd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6912,7 +6948,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;btnOwnCloudPathFilterAdd.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblOwnCloudPathFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6945,7 +6981,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPathFilter.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="lvOwnCloudPathFilterPathColumn.Text" xml:space="preserve">
     <value>Path</value>
@@ -6981,7 +7017,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lvOwnCloudPathFilter.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="cbOwnCloudPathFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7011,7 +7047,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudPathFilter.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="txtOwnCloudExpiryTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 224</value>
@@ -7032,7 +7068,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudExpiryTime.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>11</value>
   </data>
   <data name="cbOwnCloudAutoExpire.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7062,7 +7098,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudAutoExpire.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>12</value>
   </data>
   <data name="lblOwnCloudExpiryTime.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7092,7 +7128,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudExpiryTime.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>13</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7122,7 +7158,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudUsePreviewLinks.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>14</value>
   </data>
   <data name="lblOwnCloudHostExample.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7152,7 +7188,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudHostExample.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>15</value>
   </data>
   <data name="cbOwnCloud81Compatibility.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7182,7 +7218,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloud81Compatibility.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>16</value>
   </data>
   <data name="cbOwnCloudDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7212,7 +7248,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudDirectLink.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>17</value>
   </data>
   <data name="cbOwnCloudCreateShare.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7242,7 +7278,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;cbOwnCloudCreateShare.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>18</value>
   </data>
   <data name="txtOwnCloudPath.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 176</value>
@@ -7263,7 +7299,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudPath.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>19</value>
   </data>
   <data name="txtOwnCloudPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 128</value>
@@ -7284,7 +7320,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudPassword.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>20</value>
   </data>
   <data name="txtOwnCloudUsername.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 80</value>
@@ -7305,7 +7341,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudUsername.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>21</value>
   </data>
   <data name="txtOwnCloudHost.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 32</value>
@@ -7326,7 +7362,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;txtOwnCloudHost.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>22</value>
   </data>
   <data name="lblOwnCloudPath.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7356,7 +7392,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPath.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>23</value>
   </data>
   <data name="lblOwnCloudPassword.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7386,7 +7422,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudPassword.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>24</value>
   </data>
   <data name="lblOwnCloudUsername.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7416,7 +7452,7 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudUsername.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>25</value>
   </data>
   <data name="lblOwnCloudHost.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -7446,16 +7482,16 @@ when you made the application key.</value>
     <value>tpOwnCloud</value>
   </data>
   <data name="&gt;&gt;lblOwnCloudHost.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>26</value>
   </data>
   <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
+    <value>4, 58</value>
   </data>
   <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tpOwnCloud.Size" type="System.Drawing.Size, System.Drawing">
-    <value>803, 519</value>
+    <value>803, 501</value>
   </data>
   <data name="tpOwnCloud.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -15249,6 +15285,30 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;tttvMain.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="btnOwnCloudPathFilterEditSave.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>732, 473</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 23</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterEditSave</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="actRapidShareAccountType.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 16</value>
   </data>
@@ -15315,6 +15375,18 @@ Using an encrypted library disables sharing.</value>
   <data name="&gt;&gt;chBoxFoldersName.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Name" xml:space="preserve">
+    <value>lvOwnCloudPathFilterPathColumn</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Name" xml:space="preserve">
+    <value>lvOwnCloudPathFilterFilterColumn</value>
+  </data>
+  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;colSeafileLibraryName.Name" xml:space="preserve">
     <value>colSeafileLibraryName</value>
   </data>
@@ -15367,18 +15439,6 @@ Using an encrypted library disables sharing.</value>
     <value>chPicasaDescription</value>
   </data>
   <data name="&gt;&gt;chPicasaDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Name" xml:space="preserve">
-    <value>lvOwnCloudPathFilterPathColumn</value>
-  </data>
-  <data name="&gt;&gt;lvOwnCloudPathFilterPathColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Name" xml:space="preserve">
-    <value>lvOwnCloudPathFilterFilterColumn</value>
-  </data>
-  <data name="&gt;&gt;lvOwnCloudPathFilterFilterColumn.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6764,6 +6764,9 @@ when you made the application key.</value>
   <data name="txtOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
+  <data name="txtOwnCloudPathFilterEditFilter.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Consolas, 9.75pt</value>
+  </data>
   <data name="txtOwnCloudPathFilterEditFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>382, 474</value>
   </data>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6801,7 +6801,7 @@ when you made the application key.</value>
     <value>32</value>
   </data>
   <data name="lblOwnCloudPathFilterInvalid.Text" xml:space="preserve">
-    <value>Invalid regex syntax!</value>
+    <value>Invalid RegEx syntax!</value>
   </data>
   <data name="lblOwnCloudPathFilterInvalid.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -6695,6 +6695,36 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpMega.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="btnOwnCloudPathFilterEditSave.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>732, 473</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 23</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="btnOwnCloudPathFilterEditSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Name" xml:space="preserve">
+    <value>btnOwnCloudPathFilterEditSave</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.Parent" xml:space="preserve">
+    <value>tpOwnCloud</value>
+  </data>
+  <data name="&gt;&gt;btnOwnCloudPathFilterEditSave.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="txtOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -6752,6 +6782,9 @@ when you made the application key.</value>
   <data name="lblOwnCloudPathFilterEditFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="lblOwnCloudPathFilterEditFilter.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="lblOwnCloudPathFilterEditFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -6784,6 +6817,9 @@ when you made the application key.</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="lblOwnCloudPathFilterEditPath.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="lblOwnCloudPathFilterEditPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -950,6 +950,24 @@ namespace ShareX.UploadersLib
 
         #endregion Jira
 
+        #region ownCloud / Nextcloud
+
+        private void OwnCloudSavePathFilters()
+        {
+            Config.OwnCloudPathFilter.Clear();
+
+            foreach (ListViewItem item in lvOwnCloudPathFilter.Items)
+            {
+                Config.OwnCloudPathFilter.Add(new OwnCloud.OwnCloudPathFilterItem()
+                {
+                    Path = item.Text,
+                    Filter = item.SubItems[1].Text
+                });
+            }
+        }
+
+        #endregion ownCloud / Nextcloud
+
         #region Shared folder
 
         private void SharedFolderUpdateControls()

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -966,6 +966,18 @@ namespace ShareX.UploadersLib
             }
         }
 
+        private void OwnCloudSwapPathFilters(int indexA, int indexB, bool selectIndexB)
+        {
+            ListViewItem selectedItem = lvOwnCloudPathFilter.Items[indexA];
+            lvOwnCloudPathFilter.Items.Remove(selectedItem);
+            lvOwnCloudPathFilter.Items.Insert(indexB, selectedItem);
+
+            if (selectIndexB)
+            {
+                lvOwnCloudPathFilter.Select(indexB);
+            }
+        }
+
         #endregion ownCloud / Nextcloud
 
         #region Shared folder

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -954,11 +954,11 @@ namespace ShareX.UploadersLib
 
         private void OwnCloudSavePathFilters()
         {
-            Config.OwnCloudPathFilter.Clear();
+            Config.OwnCloudPathFilters.Clear();
 
             foreach (ListViewItem item in lvOwnCloudPathFilter.Items)
             {
-                Config.OwnCloudPathFilter.Add(new OwnCloud.OwnCloudPathFilterItem()
+                Config.OwnCloudPathFilters.Add(new OwnCloud.OwnCloudPathFilterItem()
                 {
                     Path = item.Text,
                     Filter = item.SubItems[1].Text

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -296,7 +296,15 @@ namespace ShareX.UploadersLib
         public bool OwnCloudUsePreviewLinks = false;
         public bool OwnCloudAutoExpire = false;
         public bool OwnCloudUsePathFilter = false;
-        public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilters = new List<OwnCloud.OwnCloudPathFilterItem>();
+        public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilters = new List<OwnCloud.OwnCloudPathFilterItem>()
+        {
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Archives", Filter = "\\.(7z|bz2|cab|dmg|gz|iso|lz|lz4|lzma|pak|rar|tar|xz|zip|zst)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Audio", Filter = "\\.(3gp|aa|aa3|aac|aax|aiff|flac|m4a|mp3|ogg|oga|opus|tta|wav|wma)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Documents", Filter = "\\.(doc|docm|docx|pages|pdf|ppt|pptx|latex|odp|ods|odt|rtf|tex|xls|xlsx)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Images", Filter = "\\.(ai|bmp|dds|eps|gif|ico|jpg|jpeg|png|psd|svg|tga|tiff)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Text", Filter = "\\.(bat|c|cfg|cpp|cs|csv|h|hh|hpp|ini|java|js|log|lua|md|pl|py|rb|sh|txt|vb|xml)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Videos", Filter = "\\.(3g2|3gp|amv|asf|avi|flv|m4v|mkv|mov|mp4||mpg|mpeg|ogv|webm|wmv)$" },
+        };
 
         #endregion ownCloud / Nextcloud
 

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -296,6 +296,7 @@ namespace ShareX.UploadersLib
         public bool OwnCloudUsePreviewLinks = false;
         public bool OwnCloudAutoExpire = false;
         public bool OwnCloudUsePathFilter = false;
+        public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilter = new List<OwnCloud.OwnCloudPathFilterItem>();
 
         #endregion ownCloud / Nextcloud
 

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -288,7 +288,7 @@ namespace ShareX.UploadersLib
         public string OwnCloudHost = "";
         public string OwnCloudUsername = "";
         public string OwnCloudPassword = "";
-        public bool OwnCloudEncryptPassword = false;
+        public bool OwnCloudEncryptPassword = true;
         public string OwnCloudPath = "/";
         public int OwnCloudExpiryTime = 7;
         public bool OwnCloudCreateShare = true;

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -296,7 +296,7 @@ namespace ShareX.UploadersLib
         public bool OwnCloudUsePreviewLinks = false;
         public bool OwnCloudAutoExpire = false;
         public bool OwnCloudUsePathFilter = false;
-        public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilter = new List<OwnCloud.OwnCloudPathFilterItem>();
+        public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilters = new List<OwnCloud.OwnCloudPathFilterItem>();
 
         #endregion ownCloud / Nextcloud
 

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -288,6 +288,7 @@ namespace ShareX.UploadersLib
         public string OwnCloudHost = "";
         public string OwnCloudUsername = "";
         public string OwnCloudPassword = "";
+        public bool OwnCloudEncryptPassword = false;
         public string OwnCloudPath = "/";
         public int OwnCloudExpiryTime = 7;
         public bool OwnCloudCreateShare = true;
@@ -303,8 +304,8 @@ namespace ShareX.UploadersLib
             new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Audio", Filter = "\\.(3gp|aa|aa3|aac|aax|aiff|flac|m4a|mp3|ogg|oga|opus|tta|wav|wma)$" },
             new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Documents", Filter = "\\.(doc|docm|docx|pages|pdf|ppt|pptx|latex|odp|ods|odt|rtf|tex|xls|xlsx)$" },
             new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Images", Filter = "\\.(ai|bmp|dds|eps|gif|ico|jpg|jpeg|png|psd|svg|tga|tiff)$" },
-            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Text", Filter = "\\.(bat|c|cfg|cpp|cs|csv|h|hh|hpp|ini|java|js|log|lua|md|pl|py|rb|sh|txt|vb|xml)$" },
-            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Videos", Filter = "\\.(3g2|3gp|amv|asf|avi|flv|m4v|mkv|mov|mp4||mpg|mpeg|ogv|webm|wmv)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Text", Filter = "\\.(bat|c|cfg|cpp|cs|csv|h|hh|hpp|htm|html|ini|java|js|log|lua|md|php|pl|py|rb|sh|txt|vb|xml)$" },
+            new OwnCloud.OwnCloudPathFilterItem() { Path = "/Share/Videos", Filter = "\\.(3g2|3gp|amv|asf|avi|flv|m4v|mkv|mov|mp4|mpg|mpeg|ogv|webm|wmv)$" },
         };
 
         #endregion ownCloud / Nextcloud

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -295,6 +295,7 @@ namespace ShareX.UploadersLib
         public bool OwnCloud81Compatibility = true;
         public bool OwnCloudUsePreviewLinks = false;
         public bool OwnCloudAutoExpire = false;
+        public bool OwnCloudUsePathFilter = false;
 
         #endregion ownCloud / Nextcloud
 

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -295,6 +295,7 @@ namespace ShareX.UploadersLib
         public bool OwnCloud81Compatibility = true;
         public bool OwnCloudUsePreviewLinks = false;
         public bool OwnCloudAutoExpire = false;
+        public bool OwnCloudCreateFolderOfNonExistent = false;
         public bool OwnCloudUsePathFilter = false;
         public List<OwnCloud.OwnCloudPathFilterItem> OwnCloudPathFilters = new List<OwnCloud.OwnCloudPathFilterItem>()
         {

--- a/ShareX/Forms/AboutForm.cs
+++ b/ShareX/Forms/AboutForm.cs
@@ -85,7 +85,7 @@ https://github.com/ShareX/ShareX/graphs/contributors
 {Resources.AboutForm_AboutForm_Translators}:
 
 {Resources.AboutForm_AboutForm_Language_tr}: https://github.com/Jaex & https://github.com/muratmoon
-{Resources.AboutForm_AboutForm_Language_de}: https://github.com/Starbug2 & https://github.com/Kaeltis
+{Resources.AboutForm_AboutForm_Language_de}: https://github.com/Starbug2 & https://github.com/Kaeltis & https://github.com/pathosDev
 {Resources.AboutForm_AboutForm_Language_fr}: https://github.com/nwies & https://github.com/Shadorc
 {Resources.AboutForm_AboutForm_Language_zh_CH}: https://github.com/jiajiechan
 {Resources.AboutForm_AboutForm_Language_hu}: https://github.com/devBluestar

--- a/ShareX/SettingManager.cs
+++ b/ShareX/SettingManager.cs
@@ -271,6 +271,14 @@ namespace ShareX
                 }
             }
 
+            if (UploadersConfig.IsUpgradeFrom("13.1.0"))
+            {
+                if (UploadersConfig.OwnCloudEncryptPassword)
+                {
+                    UploadersConfig.OwnCloudPassword = UploadersConfig.OwnCloudPassword.DPAPIProtectAndBase64();
+                }
+            }
+
             if (UploadersConfig.CustomUploadersList != null)
             {
                 foreach (CustomUploaderItem cui in UploadersConfig.CustomUploadersList)


### PR DESCRIPTION
**Hi there :wave:**

in the last few days I added some features to the OwnCloud / NextCloud uploader.

## 1) Path filtering

Some time ago I and a friend of mine (thanks to @anaether at this point) talked about the possibility to upload different files into different folders in OwnCloud / NextCloud like its done for "FTP / FTPS / SFTP". For example uploading images, text files and other files to different locations. This is why I added a path filtering feature to OwnCloud / NextCloud. Therefore just tick the checkbox "Enable path filters" and some new controls will appear:

![Imgur](https://i.imgur.com/hO23bXD.png)

#### But how do they work?

To add a new filter just click the "+" button to the right of the list. Now you have a new filter! You can also remove filters by clicking "-". A filter uses the **regular C# RegEx** to upload different files to different locations. If uploading an image the filters will be applied to the filename. The first filter that matches the filename with a given RegEx will be used for uploading (going through from top to bottom). That's why I also added buttons to sort the filters. To edit the filters use the textboxes below. If no filter matches the file the default folder ("Common path") will be selected for uploading.

### 1.1) Some example filters

If enabling the path filters for the first time I added some example filters:

![Imgur](https://imgur.com/aW8Cswr.png)

These sample filters just sort the files based on their file extension in different folders (I just added the most common file extensions). The filters themselfes are very self explanatory. Here are the complete filters:

```
Path: "/Share/Archives"
Filter: "\.(7z|bz2|cab|dmg|gz|iso|lz|lz4|lzma|pak|rar|tar|xz|zip|zst)$"

Path: "/Share/Audio"
Filter: "\.(3gp|aa|aa3|aac|aax|aiff|flac|m4a|mp3|ogg|oga|opus|tta|wav|wma)$"

Path: "/Share/Documents"
Filter: "\.(doc|docm|docx|pages|pdf|ppt|pptx|latex|odp|ods|odt|rtf|tex|xls|xlsx)$"

Path: "/Share/Images"
Filter: "\.(ai|bmp|dds|eps|gif|ico|jpg|jpeg|png|psd|svg|tga|tiff)$"

Path: "/Share/Text"
Filter: "\.(bat|c|cfg|cpp|cs|csv|h|hh|hpp|htm|html|ini|java|js|log|lua|md|php|pl|py|rb|sh|txt|vb|xml)$"

Path: "/Share/Videos"
Filter: "\.(3g2|3gp|amv|asf|avi|flv|m4v|mkv|mov|mp4|mpg|mpeg|ogv|webm|wmv)$"
```

### 1.2) Realtime RegEx validation

RegEx can be frustrating some time. So as a little gimmick I implemented a realtime RegEx validation. If you enter an invalid C# RegEx ShareX will now tell you:

![Imgur](https://imgur.com/11KGybo.png)

> **Tip:** You can also check your RegEx on this awesome site: https://regex101.com/

### 1.3) Using RegEx groups

It is also possible to sort files to filename specific folders. That can be done using RegEx group matching. E.g. lets have a look at this filter:

```
Path: "/Share/Files/%1"
Filter: "\.(.*)$"
```

If you would now upload a `.png` file the upload folder would be `/Share/Files/png`. This works for all file extensions because RegEx is universal. Another example: Uploading files based on their beginning and then sorting them after their extension:

```
Path: "/Share/Files/%1/%2"
Filter: "^(.*)_.*\.(.*)$"
```

As you already saw matched groups will be replaced by `%{group_number}`. The full match is represented by `%0` respectively.

This feature _could_ be extended in the future with uppercase, lowercase, pascalcase string replacement etc.

## 2) Automatically create folders

The RegEx group replacement feature (see 1.3) is only very useful if ShareX creates the folders by itself if they do not already exist. Otherwise that feature would be very limited.

![Imgur](https://imgur.com/qNKv3TE.png)

When enabling this option and a folder doesn't already exist it can take some seconds. I managed to improve the performance of the folder creation to a maximum and the number of requests to a minimum. If a folder already exists the folder check is not very noticeable (less than half a second).

## 3) Password encryption

When developing these features I noticed that all passwords were stored as clear text in the settings file and I'm not a big fan of this. So I added the possibility to encrypt your OwnCloud / NextCloud password in the settings file.

![Imgur](https://imgur.com/uGj4bzi.png)

For the encryption I used [DPAPI](https://en.wikipedia.org/wiki/Data_Protection_API) ([Link to C# reference](https://en.wikipedia.org/wiki/Data_Protection_API) (https://docs.microsoft.com/en-US/dotnet/api/system.security.cryptography.protecteddata)). It is very simple to use and secure. It can only be decrypted on your personal user account and machine. But it is important to mention that this will maybe only work on windows machines since this is a microsoft only feature. I enabled this option as default. This is how it looks:

```
Without encryption: "abcdefg"
With encryption: "AQAAANCMnd8BFdERjHoAwE/Cl+sBAAAALOu0fb+UCkeq9kFohmRDqAAA..."
```

Maybe this is some food for thought and it can be implemented for all passwords and other sensitive data in the settings file. I didn't have the time so I just implemented it for OwnCloud / NextCloud.

## 4) Reveal password

While implementing the password encryption I often struggled with the question "Did it now use the correct password or not?". So I quickly build a solution for this and left it in there. You can now reveal your password when clicking on the eye next to the password field.

![Imgur](https://imgur.com/olh8KzY.png)

## 5) German translation

Because I'm a german citizen I updated the german translation a little bit. I will maybe update it a little bit more in the future :wink:

---

I hope you find this features as usefull as I do :smile:

Best greetings and stay healthy :v: