### PR TITLE
Abort (中止) and Stop (停止) have different meaning

### DIFF
--- a/ShareX/Forms/ScreenRecordForm.zh-TW.resx
+++ b/ShareX/Forms/ScreenRecordForm.zh-TW.resx
@@ -121,7 +121,7 @@
     <value>ShareX - 螢幕錄製</value>
   </data>
   <data name="btnAbort.Text" xml:space="preserve">
-    <value>停止</value>
+    <value>中止</value>
   </data>
   <data name="btnStart.Text" xml:space="preserve">
     <value>開始</value>


### PR DESCRIPTION
Abort (中止) and Stop (停止) have different meaning, Correct the transaction to distinguish the two.

Due to this transaction problem, there is currently no way to distinguish between abort and stop in screen recoding.

![image](https://user-images.githubusercontent.com/29837738/83950472-9432bf00-a85d-11ea-9960-933b4e9a9e17.png)

Only the Traditional Chinese version has this problem and Simplified Chinese version dose not.
