### PR TITLE
Add shared drive support to Google Drive uploader

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
+++ b/ShareX.UploadersLib/FileUploaders/GoogleDrive.cs
@@ -52,7 +52,8 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 IsPublic = config.GoogleDriveIsPublic,
                 DirectLink = config.GoogleDriveDirectLink,
-                FolderID = config.GoogleDriveUseFolder ? config.GoogleDriveFolderID : null
+                FolderID = config.GoogleDriveUseFolder ? config.GoogleDriveFolderID : null,
+                DriveID = config.GoogleDriveSelectedDrive?.id
             };
         }
 
@@ -75,6 +76,13 @@ namespace ShareX.UploadersLib.FileUploaders
         public bool IsPublic { get; set; }
         public bool DirectLink { get; set; }
         public string FolderID { get; set; }
+        public string DriveID { get; set; }
+
+        public static GoogleDriveSharedDrive MyDrive = new GoogleDriveSharedDrive
+        {
+            id = "", // empty defaults to user drive
+            name = Resources.GoogleDrive_MyDrive_My_drive
+        };
 
         public GoogleDrive(OAuth2Info oauth)
         {
@@ -106,15 +114,22 @@ namespace ShareX.UploadersLib.FileUploaders
             return GoogleAuth.GetAccessToken(code);
         }
 
-        private string GetMetadata(string name, string parentID)
+        private string GetMetadata(string name, string parentID, string driveID = "")
         {
             object metadata;
+
+            // If there's no parent folder, the drive behaves as parent
+            if (string.IsNullOrEmpty(parentID))
+            {
+                parentID = driveID;
+            }
 
             if (!string.IsNullOrEmpty(parentID))
             {
                 metadata = new
                 {
                     name = name,
+                    driveId = driveID,
                     parents = new[]
                     {
                         parentID
@@ -148,7 +163,7 @@ namespace ShareX.UploadersLib.FileUploaders
             string response = SendRequest(HttpMethod.POST, url, json, RequestHelpers.ContentTypeJSON, null, GoogleAuth.GetAuthHeaders());
         }
 
-        public List<GoogleDriveFile> GetFolders(bool trashed = false, bool writer = true)
+        public List<GoogleDriveFile> GetFolders(string driveID = "", bool trashed = false, bool writer = true)
         {
             if (!CheckAuthorization()) return null;
 
@@ -159,7 +174,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 query += " and trashed = false";
             }
 
-            if (writer)
+            if (writer && string.IsNullOrEmpty(driveID))
             {
                 query += " and 'me' in writers";
             }
@@ -167,6 +182,13 @@ namespace ShareX.UploadersLib.FileUploaders
             Dictionary<string, string> args = new Dictionary<string, string>();
             args.Add("q", query);
             args.Add("fields", "nextPageToken,files(id,name,description)");
+            if (!string.IsNullOrEmpty(driveID))
+            {
+                args.Add("driveId", driveID);
+                args.Add("corpora", "drive");
+                args.Add("supportsAllDrives", "true");
+                args.Add("includeItemsFromAllDrives", "true");
+            }
 
             List<GoogleDriveFile> folders = new List<GoogleDriveFile>();
             string pageToken = "";
@@ -194,14 +216,53 @@ namespace ShareX.UploadersLib.FileUploaders
             return folders;
         }
 
+        public List<GoogleDriveSharedDrive> GetDrives()
+        {
+            if (!CheckAuthorization()) return null;
+
+            Dictionary<string, string> args = new Dictionary<string, string>();
+            List<GoogleDriveSharedDrive> drives = new List<GoogleDriveSharedDrive>();
+            string pageToken = "";
+
+            // Make sure we get all the pages of results
+            do
+            {
+                args["pageToken"] = pageToken;
+                string response = SendRequest(HttpMethod.GET, "https://www.googleapis.com/drive/v3/drives", args, GoogleAuth.GetAuthHeaders());
+                pageToken = "";
+
+                if (!string.IsNullOrEmpty(response))
+                {
+                    GoogleDriveSharedDriveList driveList = JsonConvert.DeserializeObject<GoogleDriveSharedDriveList>(response);
+
+                    if (driveList != null)
+                    {
+                        drives.AddRange(driveList.drives);
+                        pageToken = driveList.nextPageToken;
+                    }
+                }
+            }
+            while (!string.IsNullOrEmpty(pageToken));
+
+            return drives;
+        }
+
         public override UploadResult Upload(Stream stream, string fileName)
         {
             if (!CheckAuthorization()) return null;
 
-            string metadata = GetMetadata(fileName, FolderID);
+            string metadata = GetMetadata(fileName, FolderID, DriveID);
 
-            UploadResult result = SendRequestFile("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,webViewLink,webContentLink", stream, fileName,
-                "file", headers: GoogleAuth.GetAuthHeaders(), contentType: "multipart/related", relatedData: metadata);
+            Dictionary<string, string> args = new Dictionary<string, string>();
+            args.Add("uploadType", "multipart");
+            args.Add("fields", "id,webViewLink,webContentLink");
+            if (!string.IsNullOrEmpty(DriveID))
+            {
+                args.Add("supportsAllDrives", "true");
+            }
+
+            UploadResult result = SendRequestFile("https://www.googleapis.com/upload/drive/v3/files", stream, fileName, "file", args,
+                GoogleAuth.GetAuthHeaders(), contentType: "multipart/related", relatedData: metadata);
 
             if (!string.IsNullOrEmpty(result.Response))
             {
@@ -250,6 +311,23 @@ namespace ShareX.UploadersLib.FileUploaders
     public class GoogleDriveFileList
     {
         public List<GoogleDriveFile> files { get; set; }
+        public string nextPageToken { get; set; }
+    }
+
+    public class GoogleDriveSharedDrive
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+
+        public override string ToString()
+        {
+            return name;
+        }
+    }
+
+    public class GoogleDriveSharedDriveList
+    {
+        public List<GoogleDriveSharedDrive> drives { get; set; }
         public string nextPageToken { get; set; }
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -189,6 +189,7 @@ namespace ShareX.UploadersLib
             this.cbOneDriveCreateShareableLink = new System.Windows.Forms.CheckBox();
             this.oAuth2OneDrive = new ShareX.UploadersLib.OAuthControl();
             this.tpGoogleDrive = new System.Windows.Forms.TabPage();
+            this.cbGoogleDriveSharedDrive = new System.Windows.Forms.ComboBox();
             this.cbGoogleDriveDirectLink = new System.Windows.Forms.CheckBox();
             this.cbGoogleDriveUseFolder = new System.Windows.Forms.CheckBox();
             this.txtGoogleDriveFolderID = new System.Windows.Forms.TextBox();
@@ -1727,6 +1728,7 @@ namespace ShareX.UploadersLib
             // tpGoogleDrive
             // 
             this.tpGoogleDrive.BackColor = System.Drawing.SystemColors.Window;
+            this.tpGoogleDrive.Controls.Add(this.cbGoogleDriveSharedDrive);
             this.tpGoogleDrive.Controls.Add(this.cbGoogleDriveDirectLink);
             this.tpGoogleDrive.Controls.Add(this.cbGoogleDriveUseFolder);
             this.tpGoogleDrive.Controls.Add(this.txtGoogleDriveFolderID);
@@ -1737,6 +1739,14 @@ namespace ShareX.UploadersLib
             this.tpGoogleDrive.Controls.Add(this.oauth2GoogleDrive);
             resources.ApplyResources(this.tpGoogleDrive, "tpGoogleDrive");
             this.tpGoogleDrive.Name = "tpGoogleDrive";
+            // 
+            // cbGoogleDriveSharedDrive
+            // 
+            this.cbGoogleDriveSharedDrive.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbGoogleDriveSharedDrive.FormattingEnabled = true;
+            resources.ApplyResources(this.cbGoogleDriveSharedDrive, "cbGoogleDriveSharedDrive");
+            this.cbGoogleDriveSharedDrive.Name = "cbGoogleDriveSharedDrive";
+            this.cbGoogleDriveSharedDrive.SelectedIndexChanged += new System.EventHandler(this.cbGoogleDriveSharedDrive_SelectedIndexChanged);
             // 
             // cbGoogleDriveDirectLink
             // 
@@ -5651,5 +5661,6 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.CheckBox cbGoogleCloudStorageStripExtensionImage;
         private System.Windows.Forms.Label lblB2UrlPreview;
         private HelpersLib.TabToTreeView tttvMain;
+        private System.Windows.Forms.ComboBox cbGoogleDriveSharedDrive;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -386,6 +386,13 @@ namespace ShareX.UploadersLib
 
             #region Google Drive
 
+            cbGoogleDriveSharedDrive.Items.Clear();
+            cbGoogleDriveSharedDrive.Items.Add(GoogleDrive.MyDrive);
+            if (Config.GoogleDriveSelectedDrive?.id != GoogleDrive.MyDrive.id)
+            {
+                cbGoogleDriveSharedDrive.Items.Add(Config.GoogleDriveSelectedDrive);
+            }
+
             if (OAuth2Info.CheckOAuth(Config.GoogleDriveOAuth2Info))
             {
                 oauth2GoogleDrive.Status = OAuthLoginStatus.LoginSuccessful;
@@ -397,6 +404,7 @@ namespace ShareX.UploadersLib
             cbGoogleDriveUseFolder.Checked = Config.GoogleDriveUseFolder;
             txtGoogleDriveFolderID.Enabled = Config.GoogleDriveUseFolder;
             txtGoogleDriveFolderID.Text = Config.GoogleDriveFolderID;
+            GoogleDriveSelectConfigDrive();
 
             #endregion Google Drive
 
@@ -1759,6 +1767,7 @@ namespace ShareX.UploadersLib
         private void btnGoogleDriveRefreshFolders_Click(object sender, EventArgs e)
         {
             GoogleDriveRefreshFolders();
+            GoogleDriveRefreshDrives();
         }
 
         private void lvGoogleDriveFoldersList_SelectedIndexChanged(object sender, EventArgs e)
@@ -1772,6 +1781,12 @@ namespace ShareX.UploadersLib
                     txtGoogleDriveFolderID.Text = folder.id;
                 }
             }
+        }
+
+        private void cbGoogleDriveSharedDrive_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            GoogleDriveSharedDrive selectedDrive = cbGoogleDriveSharedDrive.SelectedItem as GoogleDriveSharedDrive;
+            Config.GoogleDriveSelectedDrive = selectedDrive;
         }
 
         #endregion Google Drive

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -3572,6 +3572,27 @@ when you made the application key.</value>
   <data name="&gt;&gt;tpOneDrive.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGoogleDriveSharedDrive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>352, 16</value>
+  </data>
+  <data name="cbGoogleDriveSharedDrive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 21</value>
+  </data>
+  <data name="cbGoogleDriveSharedDrive.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveSharedDrive.Name" xml:space="preserve">
+    <value>cbGoogleDriveSharedDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveSharedDrive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveSharedDrive.Parent" xml:space="preserve">
+    <value>tpGoogleDrive</value>
+  </data>
+  <data name="&gt;&gt;cbGoogleDriveSharedDrive.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbGoogleDriveDirectLink.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3585,7 +3606,7 @@ when you made the application key.</value>
     <value>93, 17</value>
   </data>
   <data name="cbGoogleDriveDirectLink.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>2</value>
   </data>
   <data name="cbGoogleDriveDirectLink.Text" xml:space="preserve">
     <value>Use direct link</value>
@@ -3600,7 +3621,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;cbGoogleDriveDirectLink.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="cbGoogleDriveUseFolder.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3609,13 +3630,13 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="cbGoogleDriveUseFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>352, 16</value>
+    <value>352, 47</value>
   </data>
   <data name="cbGoogleDriveUseFolder.Size" type="System.Drawing.Size, System.Drawing">
     <value>165, 17</value>
   </data>
   <data name="cbGoogleDriveUseFolder.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>5</value>
   </data>
   <data name="cbGoogleDriveUseFolder.Text" xml:space="preserve">
     <value>Upload files to selected folder</value>
@@ -3630,16 +3651,16 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;cbGoogleDriveUseFolder.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="txtGoogleDriveFolderID.Location" type="System.Drawing.Point, System.Drawing">
     <value>352, 88</value>
   </data>
   <data name="txtGoogleDriveFolderID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 20</value>
+    <value>432, 20</value>
   </data>
   <data name="txtGoogleDriveFolderID.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;txtGoogleDriveFolderID.Name" xml:space="preserve">
     <value>txtGoogleDriveFolderID</value>
@@ -3651,7 +3672,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;txtGoogleDriveFolderID.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="lblGoogleDriveFolderID.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3666,7 +3687,7 @@ when you made the application key.</value>
     <value>53, 13</value>
   </data>
   <data name="lblGoogleDriveFolderID.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="lblGoogleDriveFolderID.Text" xml:space="preserve">
     <value>Folder ID:</value>
@@ -3681,7 +3702,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;lblGoogleDriveFolderID.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="chGoogleDriveTitle.Text" xml:space="preserve">
     <value>Title</value>
@@ -3702,7 +3723,7 @@ when you made the application key.</value>
     <value>432, 352</value>
   </data>
   <data name="lvGoogleDriveFoldersList.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;lvGoogleDriveFoldersList.Name" xml:space="preserve">
     <value>lvGoogleDriveFoldersList</value>
@@ -3714,7 +3735,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;lvGoogleDriveFoldersList.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -3723,13 +3744,13 @@ when you made the application key.</value>
     <value>NoControl</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>352, 40</value>
+    <value>616, 15</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Size" type="System.Drawing.Size, System.Drawing">
     <value>168, 23</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>4</value>
   </data>
   <data name="btnGoogleDriveRefreshFolders.Text" xml:space="preserve">
     <value>Refresh folders list</value>
@@ -3744,7 +3765,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;btnGoogleDriveRefreshFolders.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="cbGoogleDriveIsPublic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3774,7 +3795,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;cbGoogleDriveIsPublic.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="oauth2GoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 16</value>
@@ -3795,7 +3816,7 @@ when you made the application key.</value>
     <value>tpGoogleDrive</value>
   </data>
   <data name="&gt;&gt;oauth2GoogleDrive.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 238</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -323,7 +323,7 @@ namespace ShareX.UploadersLib
 
                 if (OAuth2Info.CheckOAuth(Config.GoogleDriveOAuth2Info))
                 {
-                    List<GoogleDriveFile> folders = new GoogleDrive(Config.GoogleDriveOAuth2Info).GetFolders();
+                    List<GoogleDriveFile> folders = new GoogleDrive(Config.GoogleDriveOAuth2Info).GetFolders(Config.GoogleDriveSelectedDrive.id);
 
                     if (folders != null)
                     {
@@ -341,6 +341,42 @@ namespace ShareX.UploadersLib
             {
                 ex.ShowError();
             }
+        }
+
+        private void GoogleDriveRefreshDrives()
+        {
+            try
+            {
+                if (OAuth2Info.CheckOAuth(Config.GoogleDriveOAuth2Info))
+                {
+                    List<GoogleDriveSharedDrive> drives = new GoogleDrive(Config.GoogleDriveOAuth2Info).GetDrives();
+
+                    if (drives != null)
+                    {
+                        cbGoogleDriveSharedDrive.Items.Clear();
+                        cbGoogleDriveSharedDrive.Items.Add(GoogleDrive.MyDrive);
+
+                        foreach (GoogleDriveSharedDrive drive in drives)
+                        {
+                            cbGoogleDriveSharedDrive.Items.Add(drive);
+                        }
+                        GoogleDriveSelectConfigDrive();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ex.ShowError();
+            }
+        }
+
+        private void GoogleDriveSelectConfigDrive()
+        {
+            string driveID = Config.GoogleDriveSelectedDrive?.id;
+            cbGoogleDriveSharedDrive.SelectedItem = cbGoogleDriveSharedDrive.Items
+                .OfType<GoogleDriveSharedDrive>()
+                .Where(x => x.id == driveID)
+                .FirstOrDefault();
         }
 
         #endregion Google Drive

--- a/ShareX.UploadersLib/Properties/Resources.Designer.cs
+++ b/ShareX.UploadersLib/Properties/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace ShareX.UploadersLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to My drive.
+        /// </summary>
+        internal static string GoogleDrive_MyDrive_My_drive {
+            get {
+                return ResourceManager.GetString("GoogleDrive_MyDrive_My_drive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
         internal static System.Drawing.Icon GooglePhotos {

--- a/ShareX.UploadersLib/Properties/Resources.resx
+++ b/ShareX.UploadersLib/Properties/Resources.resx
@@ -404,4 +404,7 @@ Created folders:</value>
   <data name="navigation_270_button_white" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\navigation-270-button-white.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="GoogleDrive_MyDrive_My_drive" xml:space="preserve">
+    <value>My drive</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -198,6 +198,7 @@ namespace ShareX.UploadersLib
         public bool GoogleDriveDirectLink { get; set; } = false;
         public bool GoogleDriveUseFolder { get; set; } = false;
         public string GoogleDriveFolderID { get; set; } = "";
+        public GoogleDriveSharedDrive GoogleDriveSelectedDrive { get; set; } = GoogleDrive.MyDrive;
 
         #endregion Google Drive
 


### PR DESCRIPTION
Solves issue #4787. Adds a dropdown for selecting from multiple drives:

![image](https://user-images.githubusercontent.com/603444/84210241-1ca89e00-aab0-11ea-9af0-c62989253661.png)

Refresh button is used to manually update list of drives and folders. I avoided doing this "automatically" to not spam requests everytime the settings form is open or changed.

Biggest challenge was not naming this `GoogleDriveDrive`.