### PR TITLE
Allow quick tasks to use a specific image effect preset

### DIFF
--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -186,6 +186,9 @@ namespace ShareX
         [Category("Application"), DefaultValue(false), Description("In main window when task is completed automatically select it.")]
         public bool AutoSelectLastCompletedTask { get; set; }
 
+        [Category("Application"), DefaultValue(false), Description("Allow Quick Tasks to use specific image effect presets.")]
+        public bool AllowQuickTaskImageEffectPresets { get; set; }
+
         [Category("Hotkey"), DefaultValue(false), Description("Disables hotkeys.")]
         public bool DisableHotkeys { get; set; }
 

--- a/ShareX/CaptureHelpers/CaptureBase.cs
+++ b/ShareX/CaptureHelpers/CaptureBase.cs
@@ -112,6 +112,7 @@ namespace ShareX
                     taskSettings.AfterCaptureJob = taskSettings.AfterCaptureJob.Remove(AfterCaptureTasks.AddImageEffects);
                 }
 
+                taskSettings.ImageSettingsReference.DefaultImageEffectPresetOverride = null;
                 UploadManager.RunImageTask(imageInfo, taskSettings);
             }
         }

--- a/ShareX/Forms/QuickTaskInfoEditForm.cs
+++ b/ShareX/Forms/QuickTaskInfoEditForm.cs
@@ -65,6 +65,47 @@ namespace ShareX
                     ToolStripMenuItem tsmi = new ToolStripMenuItem(enums[i]);
                     tsmi.Image = TaskHelpers.FindMenuIcon<T>(i + 1);
 
+                    if (enums[i] == "Add image effects" && Program.Settings.AllowQuickTaskImageEffectPresets)
+                    {
+                        var presets = TaskSettings.GetDefaultTaskSettings().ImageSettings.ImageEffectPresets;
+
+                        for (int presetIndex = 0; presetIndex < presets.Count; presetIndex++)
+                        {
+                            ToolStripMenuItem tsmiPreset = new ToolStripMenuItem
+                            {
+                                Text = presets[presetIndex].Name,
+                                Tag = presetIndex
+                            };
+
+                            if (TaskInfo.DefaultImageEffectPresetOverride == presetIndex)
+                                tsmiPreset.Checked = true;
+
+                            tsmiPreset.Click += (sender, e) =>
+                            {
+                                tsmiPreset.Checked = !tsmiPreset.Checked;
+
+                                if (tsmiPreset.Checked)
+                                {
+                                    TaskInfo.DefaultImageEffectPresetOverride = (int)tsmiPreset.Tag;
+
+                                    foreach (ToolStripMenuItem tp in tsmi.DropDownItems)
+                                    {
+                                        if (tp != tsmiPreset)
+                                            tp.Checked = false;
+                                    }
+
+                                    if (!tsmi.Checked)
+                                        tsmi.PerformClick();
+                                }
+                                else
+                                    TaskInfo.DefaultImageEffectPresetOverride = null;
+                            };
+
+                            tsmi.DropDownItems.Add(tsmiPreset);
+                            UpdateUploaderMenuNames();
+                        }
+                    }
+
                     int index = i;
 
                     tsmi.Click += (sender, e) =>

--- a/ShareX/QuickTaskInfo.cs
+++ b/ShareX/QuickTaskInfo.cs
@@ -34,6 +34,7 @@ namespace ShareX
         public string Name { get; set; }
         public AfterCaptureTasks AfterCaptureTasks { get; set; }
         public AfterUploadTasks AfterUploadTasks { get; set; }
+        public int? DefaultImageEffectPresetOverride { get; set; }
 
         public bool IsValid
         {

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -592,6 +592,16 @@ namespace ShareX
                     }
                 }
 
+                if (Program.Settings.AllowQuickTaskImageEffectPresets && taskSettingsImage.DefaultImageEffectPresetOverride.HasValue)
+                {
+                    var defaultTaskSettingsImage = TaskSettings.GetDefaultTaskSettings().ImageSettings;
+
+                    if (defaultTaskSettingsImage.ImageEffectPresets.IsValidIndex(taskSettingsImage.DefaultImageEffectPresetOverride.Value))
+                    {
+                        return defaultTaskSettingsImage.ImageEffectPresets[taskSettingsImage.DefaultImageEffectPresetOverride.Value].ApplyEffects(bmp);
+                    }
+                }
+
                 if (taskSettingsImage.ImageEffectPresets.IsValidIndex(taskSettingsImage.SelectedImageEffectPreset))
                 {
                     using (bmp)

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -300,6 +300,7 @@ namespace ShareX
 
         public List<ImageEffectPreset> ImageEffectPresets = new List<ImageEffectPreset>() { ImageEffectPreset.GetDefaultPreset() };
         public int SelectedImageEffectPreset = 0;
+        public int? DefaultImageEffectPresetOverride;
 
         public bool ShowImageEffectsWindowAfterCapture = false;
         public bool ImageEffectOnlyRegionCapture = false;

--- a/ShareX/UploadManager.cs
+++ b/ShareX/UploadManager.cs
@@ -407,6 +407,10 @@ namespace ShareX
                         {
                             taskSettings.AfterCaptureJob = taskInfo.AfterCaptureTasks;
                             taskSettings.AfterUploadJob = taskInfo.AfterUploadTasks;
+
+                            if (Program.Settings.AllowQuickTaskImageEffectPresets && taskInfo.DefaultImageEffectPresetOverride.HasValue)
+                                taskSettings.ImageSettingsReference.DefaultImageEffectPresetOverride = taskInfo.DefaultImageEffectPresetOverride.Value;
+
                             RunImageTask(imageInfo, taskSettings, true);
                         }
                     };


### PR DESCRIPTION
As a ShareX user my workflow revolves around the use of a single hotkey (PrintScr) and a default image effect (add a shadow). However, there are occasions where I'd like a different combination of effects to be applied (eg shadow + resize, or resize but no shadow, etc). 

While this could be achieved using multiple hotkeys, I find having a single hotkey a lot simpler to remember, and thus quick tasks come to the rescue!

This change allows (if the application settings is enabled) the user to select from a list of default task image effect presets when configuring a quick task. 

Here are my three default task image effect presets:
![image](https://user-images.githubusercontent.com/55967602/87863710-0c8ab500-c9b2-11ea-99f0-9358acf0a87c.png)

And here they appear in a sub-menu (under 'Add image effects') when configuring a quick task:
![image](https://user-images.githubusercontent.com/55967602/87863721-37750900-c9b2-11ea-9675-524ba4909df8.png)

When the hotkey is pressed and the hotkey workflow pops the quick task menu, the user can effectively choose which of the image effect presets should be applied:
![image](https://user-images.githubusercontent.com/55967602/87863733-858a0c80-c9b2-11ea-9bf4-7b1caa573f7b.png)

It seems at least one other ShareX user is looking for similar functionality - https://www.reddit.com/r/sharex/comments/ghujxg/can_you_assign_different_image_effects_to/

Note: I'm just a hobbyist developer, so apologies in advance if my changes are a bit amateurish!