### PR TITLE
Added Copy, Save and SaveAs hotkeys in Capture mode

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -579,7 +579,16 @@ namespace ShareX.ScreenCaptureLib
                     CloseWindow(RegionResult.ActiveMonitor);
                     break;
                 case Keys.Control | Keys.C:
-                    CopyAreaInfo();
+                    Result = RegionResult.Region;
+                    OnCopyImageRequested();
+                    break;
+                case Keys.Control | Keys.S:
+                    Result = RegionResult.Region;
+                    OnSaveImageRequested();
+                    break;
+                case Keys.Control | Keys.Shift | Keys.S:
+                    Result = RegionResult.Region;
+                    OnSaveImageAsRequested();
                     break;
             }
 

--- a/ShareX/CaptureHelpers/CaptureRegion.cs
+++ b/ShareX/CaptureHelpers/CaptureRegion.cs
@@ -26,6 +26,7 @@
 using ShareX.HelpersLib;
 using ShareX.ScreenCaptureLib;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace ShareX
@@ -87,6 +88,47 @@ namespace ShareX
 
             using (RegionCaptureForm form = new RegionCaptureForm(mode, taskSettings.CaptureSettingsReference.SurfaceOptions, bmp))
             {
+                form.SaveImageRequested += (output, newFilePath) =>
+                {
+                    using (output)
+                    {
+                        if (string.IsNullOrEmpty(newFilePath))
+                        {
+                            string fileName = TaskHelpers.GetFilename(taskSettings, taskSettings.ImageSettings.ImageFormat.GetDescription(), output);
+                            newFilePath = Path.Combine(taskSettings.GetScreenshotsFolder(), fileName);
+                        }
+
+                        ImageHelpers.SaveImage(output, newFilePath);
+                    }
+
+                    return newFilePath;
+                };
+
+                form.SaveImageAsRequested += (output, newFilePath) =>
+                {
+                    using (output)
+                    {
+                        if (string.IsNullOrEmpty(newFilePath))
+                        {
+                            string fileName = TaskHelpers.GetFilename(taskSettings, taskSettings.ImageSettings.ImageFormat.GetDescription(), output);
+                            newFilePath = Path.Combine(taskSettings.GetScreenshotsFolder(), fileName);
+                        }
+
+                        newFilePath = ImageHelpers.SaveImageFileDialog(output, newFilePath);
+                    }
+
+                    return newFilePath;
+                };
+
+                form.CopyImageRequested += output =>
+                {
+                    Program.MainForm.InvokeSafe(() =>
+                    {
+                        using (output)
+                        { ClipboardHelpers.CopyImage(output); }
+                    });
+                };
+
                 if (cursorData != null && cursorData.IsVisible)
                 {
                     form.AddCursor(cursorData.Handle, CaptureHelpers.ScreenToClient(cursorData.Position));


### PR DESCRIPTION
These changes allows you to use hotkeys while capturing region.
I made it to improve UX. 
User case before changes: Press PrntScrn → Select regions → Press Enter → Press Ctrl+Shift+S to save
After these changes: Press PrntScrn → Select regions → Press Ctrl+S to save
As you can see users can skip one step now and choose action (save or copy) by pressing hotkey.

Actions
Copy: Ctrl+C
Save: Ctrl+S
SaveAs: Ctrl+Shift+S