### PR TITLE
Added display path options to folder listing module.

### DIFF
--- a/ShareX.IndexerLib/IndexerHtml.cs
+++ b/ShareX.IndexerLib/IndexerHtml.cs
@@ -54,7 +54,7 @@ namespace ShareX.IndexerLib
             sbHtmlIndex.AppendLine(HtmlHelper.StartTag("body"));
 
             folderPath = Path.GetFullPath(folderPath).TrimEnd('\\');
-            prePathTrim = folderPath.LastIndexOf(@"\");
+            prePathTrim = folderPath.LastIndexOf(@"\") + 1;
 
             FolderInfo folderInfo = GetFolderInfo(folderPath);
             folderInfo.Update();

--- a/ShareX.IndexerLib/IndexerHtml.cs
+++ b/ShareX.IndexerLib/IndexerHtml.cs
@@ -34,6 +34,7 @@ namespace ShareX.IndexerLib
     public class IndexerHtml : Indexer
     {
         protected StringBuilder sbContent = new StringBuilder();
+        protected int prePathTrim = 0;
 
         public IndexerHtml(IndexerSettings indexerSettings) : base(indexerSettings)
         {
@@ -51,6 +52,8 @@ namespace ShareX.IndexerLib
             sbHtmlIndex.AppendLine(GetCssStyle());
             sbHtmlIndex.AppendLine(HtmlHelper.EndTag("head"));
             sbHtmlIndex.AppendLine(HtmlHelper.StartTag("body"));
+
+            prePathTrim = folderPath.LastIndexOf(@"\");
 
             FolderInfo folderInfo = GetFolderInfo(folderPath);
             folderInfo.Update();
@@ -107,7 +110,7 @@ namespace ShareX.IndexerLib
 
                 if (dir.TotalFileCount > 0)
                 {
-                    folderNameRow += dir.TotalFileCount + " file" + (dir.TotalFileCount > 1 ? "s" : "");
+                    folderNameRow += dir.TotalFileCount.ToString("n0") + " file" + (dir.TotalFileCount > 1 ? "s" : "");
                 }
 
                 if (dir.TotalFolderCount > 0)
@@ -117,16 +120,27 @@ namespace ShareX.IndexerLib
                         folderNameRow += ", ";
                     }
 
-                    folderNameRow += dir.TotalFolderCount + " folder" + (dir.TotalFolderCount > 1 ? "s" : "");
+                    folderNameRow += dir.TotalFolderCount.ToString("n0") + " folder" + (dir.TotalFolderCount > 1 ? "s" : "");
                 }
 
                 folderNameRow += ")";
                 folderNameRow = " " + HtmlHelper.Tag("span", folderNameRow, "", "class=\"FolderInfo\"");
             }
 
+            string pathTitle = "";
+
+            if (settings.DisplayPath)
+            {
+                pathTitle = settings.DisplayPathLimited ? dir.FolderPath.Substring(prePathTrim) : dir.FolderPath;
+            }
+            else
+            {
+                pathTitle = dir.FolderName;
+            }
+
             int heading = (level + 1).Clamp(1, 6);
 
-            return HtmlHelper.StartTag("h" + heading) + URLHelpers.HtmlEncode(dir.FolderName) + folderNameRow + HtmlHelper.EndTag("h" + heading);
+            return HtmlHelper.StartTag("h" + heading) + URLHelpers.HtmlEncode(pathTitle) + folderNameRow + HtmlHelper.EndTag("h" + heading);
         }
 
         private string GetFileNameRow(FileInfo fi, int level)

--- a/ShareX.IndexerLib/IndexerHtml.cs
+++ b/ShareX.IndexerLib/IndexerHtml.cs
@@ -53,6 +53,7 @@ namespace ShareX.IndexerLib
             sbHtmlIndex.AppendLine(HtmlHelper.EndTag("head"));
             sbHtmlIndex.AppendLine(HtmlHelper.StartTag("body"));
 
+            folderPath = Path.GetFullPath(folderPath).TrimEnd('\\');
             prePathTrim = folderPath.LastIndexOf(@"\");
 
             FolderInfo folderInfo = GetFolderInfo(folderPath);

--- a/ShareX.IndexerLib/IndexerSettings.cs
+++ b/ShareX.IndexerLib/IndexerSettings.cs
@@ -59,6 +59,12 @@ namespace ShareX.IndexerLib
         [Category("Indexer / HTML"), DefaultValue(false), Description("Use custom Cascading Style Sheet file.")]
         public bool UseCustomCSSFile { get; set; }
 
+        [Category("Indexer / HTML"), DefaultValue(false), Description("Display the path for each subfolder.")]
+        public bool DisplayPath { get; set; }
+
+        [Category("Indexer / HTML"), DefaultValue(false), Description("Limit the display path to the selected root folder. Must have DisplayPath enabled.")]
+        public bool DisplayPathLimited { get; set; }
+
         [Category("Indexer / HTML"), DefaultValue(""), Description("Custom Cascading Style Sheet file path."), Editor(typeof(CssFileNameEditor), typeof(UITypeEditor))]
         public string CustomCSSFilePath { get; set; }
 


### PR DESCRIPTION
Added an additional feaature to the Directory Indexer module. There are now two settings to show the full path of the directories, or the shorter variation of the path starting from the root. Another update is to show number seperators on the folder and file count for clarity.

![Comparison of ShareX directory indexing module changes](https://user-images.githubusercontent.com/1139365/89729317-57856e80-da2c-11ea-8c64-584ce5a94b1c.png)

Notes in the picture:
Marker 1 - original root folder path.
Marker 2 - original sub folder path.
Marker 3 - original file/folder count.
Marker 4 - updated full folder path for root and sub folders.
Marker 5 - updated file/folder count with seperators.
Marker 6 - updated folder path limiting to the selected root folder.