### PR TITLE
Fixed ruler disappearing when the region box is too small.

### DIFF
--- a/ShareX.ScreenCaptureLib/RegionCaptureTasks.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureTasks.cs
@@ -156,6 +156,7 @@ namespace ShareX.ScreenCaptureLib
             RegionCaptureOptions newOptions = GetRegionCaptureOptions(options);
             newOptions.QuickCrop = false;
             newOptions.UseLightResizeNodes = true;
+            newOptions.MinimumSize = 0;
 
             using (RegionCaptureForm form = new RegionCaptureForm(RegionCaptureMode.Ruler, newOptions))
             {


### PR DESCRIPTION
When the ruler tool is opened, the region info window is hidden when the region is too thin, making the ruler useless for straight lines or accurate measurements.

This is a one line fix so the ruler is always displayed.

![Ruler fix](https://user-images.githubusercontent.com/1139365/89733136-4a2bac80-da4b-11ea-8f19-336eb16e194e.png)

Marker 1 - Test area
Marker 2 - Start position
Marker 3 - End position - No Information shown.
Marker 4 & 5 - Increase region size to display limit now shows the ruler information.
Marker 6: - Pull request fix to show the info window at any region size.


