### PR TITLE
Use result image for auto crop in Image Editor

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -2001,7 +2001,7 @@ namespace ShareX.ScreenCaptureLib
         private void AutoCropImage()
         {
             Rectangle source = new Rectangle(0, 0, Form.Canvas.Width, Form.Canvas.Height);
-            Rectangle rect = ImageHelpers.FindAutoCropRectangle(Form.Canvas);
+            Rectangle rect = ImageHelpers.FindAutoCropRectangle(Form.GetResultImage());
 
             if (source != rect && rect.X >= 0 && rect.Y >= 0 && rect.Width > 0 && rect.Height > 0)
             {


### PR DESCRIPTION
When using the Auto Crop function in the image editor, it was using the original image as reference for finding the new boundary.
This can give an unwanted result of only cropping back to it's original region.
By instead referencing the ResultImage bitmap, it now includes all shapes and customisations the user has added into the canvas.

For more information, please read issue #4994 