### PR TITLE
Fix storing invalid/deleted pushbullet devices

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Pushbullet.cs
+++ b/ShareX.UploadersLib/FileUploaders/Pushbullet.cs
@@ -181,7 +181,7 @@ namespace ShareX.UploadersLib.FileUploaders
             PushbulletResponseDevices devicesResponse = JsonConvert.DeserializeObject<PushbulletResponseDevices>(response);
 
             if (devicesResponse != null && devicesResponse.devices != null)
-                return devicesResponse.devices.Select(x => new PushbulletDevice { Key = x.iden, Name = x.nickname }).ToList();
+                return devicesResponse.devices.Where(x => !String.IsNullOrEmpty(x.nickname)).Select(x1 => new PushbulletDevice { Key = x1.iden, Name = x1.nickname }).ToList();
 
             return new List<PushbulletDevice>();
         }

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -799,7 +799,8 @@ namespace ShareX.UploadersLib
 
                 Config.PushbulletSettings.DeviceList.ForEach(pbDevice =>
                 {
-                    cboPushbulletDevices.Items.Add(pbDevice.Name ?? Resources.UploadersConfigForm_LoadSettings_Invalid_device_name);
+                    if (!String.IsNullOrEmpty(pbDevice.Name))
+                        cboPushbulletDevices.Items.Add(pbDevice.Name);// ?? Resources.UploadersConfigForm_LoadSettings_Invalid_device_name);
                 });
 
                 cboPushbulletDevices.SelectedIndex = 0;

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -800,7 +800,7 @@ namespace ShareX.UploadersLib
                 Config.PushbulletSettings.DeviceList.ForEach(pbDevice =>
                 {
                     if (!String.IsNullOrEmpty(pbDevice.Name))
-                        cboPushbulletDevices.Items.Add(pbDevice.Name);// ?? Resources.UploadersConfigForm_LoadSettings_Invalid_device_name);
+                        cboPushbulletDevices.Items.Add(pbDevice.Name);
                 });
 
                 cboPushbulletDevices.SelectedIndex = 0;


### PR DESCRIPTION
This fixes Pushbullet from getting and storing empty devices when pulling from the user's account. Sorry, this was an oversight on my part when the feature was implemented.