### PR TITLE
Bayer Scale can be changed for gifs if Bayer dither is in use

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
@@ -43,6 +43,7 @@
             this.pbAudioCodecWarning = new System.Windows.Forms.PictureBox();
             this.pbx264PresetWarning = new System.Windows.Forms.PictureBox();
             this.tbOpusBitrate = new System.Windows.Forms.TrackBar();
+            this.nudGIFBayerScale = new System.Windows.Forms.NumericUpDown();
             this.lblCodec = new System.Windows.Forms.Label();
             this.cboVideoCodec = new System.Windows.Forms.ComboBox();
             this.lblx264Preset = new System.Windows.Forms.Label();
@@ -87,12 +88,12 @@
             this.tcFFmpegAudioCodecs = new System.Windows.Forms.TabControl();
             this.tpAAC = new System.Windows.Forms.TabPage();
             this.lblAACQuality = new System.Windows.Forms.Label();
+            this.tpOpus = new System.Windows.Forms.TabPage();
+            this.lblOpusQuality = new System.Windows.Forms.Label();
             this.tpVorbis = new System.Windows.Forms.TabPage();
             this.lblVorbisQuality = new System.Windows.Forms.Label();
             this.tpMP3 = new System.Windows.Forms.TabPage();
             this.lblMP3Quality = new System.Windows.Forms.Label();
-            this.tpOpus = new System.Windows.Forms.TabPage();
-            this.lblOpusQuality = new System.Windows.Forms.Label();
             this.cboVideoSource = new System.Windows.Forms.ComboBox();
             this.lblVideoSource = new System.Windows.Forms.Label();
             this.cboAudioSource = new System.Windows.Forms.ComboBox();
@@ -114,6 +115,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.pbAudioCodecWarning)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pbx264PresetWarning)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.tbOpusBitrate)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudGIFBayerScale)).BeginInit();
             this.gbFFmpegExe.SuspendLayout();
             this.gbCommandLinePreview.SuspendLayout();
             this.gbCommandLineArgs.SuspendLayout();
@@ -130,9 +132,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudQSVBitrate)).BeginInit();
             this.tcFFmpegAudioCodecs.SuspendLayout();
             this.tpAAC.SuspendLayout();
+            this.tpOpus.SuspendLayout();
             this.tpVorbis.SuspendLayout();
             this.tpMP3.SuspendLayout();
-            this.tpOpus.SuspendLayout();
             this.gbSource.SuspendLayout();
             this.gbCodecs.SuspendLayout();
             this.SuspendLayout();
@@ -283,6 +285,23 @@
             this.ttHelpTip.SetToolTip(this.tbOpusBitrate, resources.GetString("tbOpusBitrate.ToolTip"));
             this.tbOpusBitrate.Value = 4;
             this.tbOpusBitrate.ValueChanged += new System.EventHandler(this.tbOpusBirate_ValueChanged);
+            // 
+            // nudGIFBayerScale
+            // 
+            resources.ApplyResources(this.nudGIFBayerScale, "nudGIFBayerScale");
+            this.nudGIFBayerScale.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.nudGIFBayerScale.Name = "nudGIFBayerScale";
+            this.ttHelpTip.SetToolTip(this.nudGIFBayerScale, resources.GetString("nudGIFBayerScale.ToolTip"));
+            this.nudGIFBayerScale.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudGIFBayerScale.ValueChanged += new System.EventHandler(this.nudGIFBayerScale_SelectedIndexChanged);
             // 
             // lblCodec
             // 
@@ -509,6 +528,7 @@
             // tpGIF
             // 
             this.tpGIF.BackColor = System.Drawing.SystemColors.Window;
+            this.tpGIF.Controls.Add(this.nudGIFBayerScale);
             this.tpGIF.Controls.Add(this.cbGIFDither);
             this.tpGIF.Controls.Add(this.lblGIFDither);
             this.tpGIF.Controls.Add(this.cbGIFStatsMode);
@@ -648,6 +668,19 @@
             resources.ApplyResources(this.lblAACQuality, "lblAACQuality");
             this.lblAACQuality.Name = "lblAACQuality";
             // 
+            // tpOpus
+            // 
+            this.tpOpus.Controls.Add(this.tbOpusBitrate);
+            this.tpOpus.Controls.Add(this.lblOpusQuality);
+            resources.ApplyResources(this.tpOpus, "tpOpus");
+            this.tpOpus.Name = "tpOpus";
+            this.tpOpus.UseVisualStyleBackColor = true;
+            // 
+            // lblOpusQuality
+            // 
+            resources.ApplyResources(this.lblOpusQuality, "lblOpusQuality");
+            this.lblOpusQuality.Name = "lblOpusQuality";
+            // 
             // tpVorbis
             // 
             this.tpVorbis.BackColor = System.Drawing.SystemColors.Window;
@@ -673,19 +706,6 @@
             // 
             resources.ApplyResources(this.lblMP3Quality, "lblMP3Quality");
             this.lblMP3Quality.Name = "lblMP3Quality";
-            // 
-            // tpOpus
-            // 
-            this.tpOpus.Controls.Add(this.tbOpusBitrate);
-            this.tpOpus.Controls.Add(this.lblOpusQuality);
-            resources.ApplyResources(this.tpOpus, "tpOpus");
-            this.tpOpus.Name = "tpOpus";
-            this.tpOpus.UseVisualStyleBackColor = true;
-            // 
-            // lblOpusQuality
-            // 
-            resources.ApplyResources(this.lblOpusQuality, "lblOpusQuality");
-            this.lblOpusQuality.Name = "lblOpusQuality";
             // 
             // cboVideoSource
             // 
@@ -817,6 +837,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.pbAudioCodecWarning)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pbx264PresetWarning)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.tbOpusBitrate)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudGIFBayerScale)).EndInit();
             this.gbFFmpegExe.ResumeLayout(false);
             this.gbFFmpegExe.PerformLayout();
             this.gbCommandLinePreview.ResumeLayout(false);
@@ -844,12 +865,12 @@
             this.tcFFmpegAudioCodecs.ResumeLayout(false);
             this.tpAAC.ResumeLayout(false);
             this.tpAAC.PerformLayout();
+            this.tpOpus.ResumeLayout(false);
+            this.tpOpus.PerformLayout();
             this.tpVorbis.ResumeLayout(false);
             this.tpVorbis.PerformLayout();
             this.tpMP3.ResumeLayout(false);
             this.tpMP3.PerformLayout();
-            this.tpOpus.ResumeLayout(false);
-            this.tpOpus.PerformLayout();
             this.gbSource.ResumeLayout(false);
             this.gbSource.PerformLayout();
             this.gbCodecs.ResumeLayout(false);
@@ -937,5 +958,6 @@
         private System.Windows.Forms.TabPage tpOpus;
         private System.Windows.Forms.TrackBar tbOpusBitrate;
         private System.Windows.Forms.Label lblOpusQuality;
+        private System.Windows.Forms.NumericUpDown nudGIFBayerScale;
     }
 }

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
@@ -108,6 +108,7 @@ namespace ShareX.ScreenCaptureLib
             // GIF
             cbGIFStatsMode.SelectedIndex = (int)Options.FFmpeg.GIFStatsMode;
             cbGIFDither.SelectedIndex = (int)Options.FFmpeg.GIFDither;
+            nudGIFBayerScale.SetValue(Options.FFmpeg.GIFBayerScale);
 
             // AMF
             cbAMFUsage.SelectedIndex = (int)Options.FFmpeg.AMF_usage;
@@ -220,6 +221,7 @@ namespace ShareX.ScreenCaptureLib
                     txtCommandLinePreview.Text = Options.GetFFmpegArgs();
                 }
 
+                nudGIFBayerScale.Visible = (Options.FFmpeg.GIFDither == FFmpegPaletteUseDither.bayer);
                 UpdateFFmpegPathUI();
             }
         }
@@ -445,6 +447,12 @@ namespace ShareX.ScreenCaptureLib
         private void cbGIFDither_SelectedIndexChanged(object sender, EventArgs e)
         {
             Options.FFmpeg.GIFDither = (FFmpegPaletteUseDither)cbGIFDither.SelectedIndex;
+            UpdateUI();
+        }
+
+        private void nudGIFBayerScale_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.GIFBayerScale = (int)nudGIFBayerScale.Value;
             UpdateUI();
         }
 

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
@@ -334,7 +334,7 @@ For real time encoding (e.g. screen recording), the preset must be as fast as po
     <value>tpGIF</value>
   </data>
   <data name="&gt;&gt;cbGIFStatsMode.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="cbGIFDither.Location" type="System.Drawing.Point, System.Drawing">
     <value>144, 36</value>
@@ -358,7 +358,7 @@ For real time encoding (e.g. screen recording), the preset must be as fast as po
     <value>tpGIF</value>
   </data>
   <data name="&gt;&gt;cbGIFDither.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="pbAudioCodecWarning.Location" type="System.Drawing.Point, System.Drawing">
     <value>550, 22</value>
@@ -452,6 +452,30 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>tpOpus</value>
   </data>
   <data name="&gt;&gt;tbOpusBitrate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="nudGIFBayerScale.Location" type="System.Drawing.Point, System.Drawing">
+    <value>254, 36</value>
+  </data>
+  <data name="nudGIFBayerScale.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="nudGIFBayerScale.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="nudGIFBayerScale.ToolTip" xml:space="preserve">
+    <value>Controls the Bayer Scale index, a higher scale will display more banding. Default is 2.</value>
+  </data>
+  <data name="&gt;&gt;nudGIFBayerScale.Name" xml:space="preserve">
+    <value>nudGIFBayerScale</value>
+  </data>
+  <data name="&gt;&gt;nudGIFBayerScale.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudGIFBayerScale.Parent" xml:space="preserve">
+    <value>tpGIF</value>
+  </data>
+  <data name="&gt;&gt;nudGIFBayerScale.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="lblCodec.AutoSize" type="System.Boolean, mscorlib">
@@ -1121,7 +1145,7 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>tpGIF</value>
   </data>
   <data name="&gt;&gt;lblGIFDither.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblGIFStatsMode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1148,7 +1172,7 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>tpGIF</value>
   </data>
   <data name="&gt;&gt;lblGIFStatsMode.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tpGIF.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -1561,114 +1585,6 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
   <data name="&gt;&gt;tpAAC.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="lblVorbisQuality.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblVorbisQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="lblVorbisQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
-  </data>
-  <data name="lblVorbisQuality.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lblVorbisQuality.Text" xml:space="preserve">
-    <value>Quality:</value>
-  </data>
-  <data name="&gt;&gt;lblVorbisQuality.Name" xml:space="preserve">
-    <value>lblVorbisQuality</value>
-  </data>
-  <data name="&gt;&gt;lblVorbisQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVorbisQuality.Parent" xml:space="preserve">
-    <value>tpVorbis</value>
-  </data>
-  <data name="&gt;&gt;lblVorbisQuality.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpVorbis.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpVorbis.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpVorbis.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 70</value>
-  </data>
-  <data name="tpVorbis.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpVorbis.Text" xml:space="preserve">
-    <value>Vorbis</value>
-  </data>
-  <data name="&gt;&gt;tpVorbis.Name" xml:space="preserve">
-    <value>tpVorbis</value>
-  </data>
-  <data name="&gt;&gt;tpVorbis.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpVorbis.Parent" xml:space="preserve">
-    <value>tcFFmpegAudioCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpVorbis.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblMP3Quality.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblMP3Quality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 16</value>
-  </data>
-  <data name="lblMP3Quality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
-  </data>
-  <data name="lblMP3Quality.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="lblMP3Quality.Text" xml:space="preserve">
-    <value>Quality:</value>
-  </data>
-  <data name="&gt;&gt;lblMP3Quality.Name" xml:space="preserve">
-    <value>lblMP3Quality</value>
-  </data>
-  <data name="&gt;&gt;lblMP3Quality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMP3Quality.Parent" xml:space="preserve">
-    <value>tpMP3</value>
-  </data>
-  <data name="&gt;&gt;lblMP3Quality.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tpMP3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpMP3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpMP3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 70</value>
-  </data>
-  <data name="tpMP3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tpMP3.Text" xml:space="preserve">
-    <value>MP3</value>
-  </data>
-  <data name="&gt;&gt;tpMP3.Name" xml:space="preserve">
-    <value>tpMP3</value>
-  </data>
-  <data name="&gt;&gt;tpMP3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpMP3.Parent" xml:space="preserve">
-    <value>tcFFmpegAudioCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpMP3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lblOpusQuality.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1724,6 +1640,114 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>tcFFmpegAudioCodecs</value>
   </data>
   <data name="&gt;&gt;tpOpus.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblVorbisQuality.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblVorbisQuality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="lblVorbisQuality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 13</value>
+  </data>
+  <data name="lblVorbisQuality.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblVorbisQuality.Text" xml:space="preserve">
+    <value>Quality:</value>
+  </data>
+  <data name="&gt;&gt;lblVorbisQuality.Name" xml:space="preserve">
+    <value>lblVorbisQuality</value>
+  </data>
+  <data name="&gt;&gt;lblVorbisQuality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVorbisQuality.Parent" xml:space="preserve">
+    <value>tpVorbis</value>
+  </data>
+  <data name="&gt;&gt;lblVorbisQuality.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpVorbis.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpVorbis.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpVorbis.Size" type="System.Drawing.Size, System.Drawing">
+    <value>304, 70</value>
+  </data>
+  <data name="tpVorbis.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpVorbis.Text" xml:space="preserve">
+    <value>Vorbis</value>
+  </data>
+  <data name="&gt;&gt;tpVorbis.Name" xml:space="preserve">
+    <value>tpVorbis</value>
+  </data>
+  <data name="&gt;&gt;tpVorbis.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpVorbis.Parent" xml:space="preserve">
+    <value>tcFFmpegAudioCodecs</value>
+  </data>
+  <data name="&gt;&gt;tpVorbis.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblMP3Quality.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblMP3Quality.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="lblMP3Quality.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 13</value>
+  </data>
+  <data name="lblMP3Quality.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblMP3Quality.Text" xml:space="preserve">
+    <value>Quality:</value>
+  </data>
+  <data name="&gt;&gt;lblMP3Quality.Name" xml:space="preserve">
+    <value>lblMP3Quality</value>
+  </data>
+  <data name="&gt;&gt;lblMP3Quality.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMP3Quality.Parent" xml:space="preserve">
+    <value>tpMP3</value>
+  </data>
+  <data name="&gt;&gt;lblMP3Quality.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tpMP3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpMP3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpMP3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>304, 70</value>
+  </data>
+  <data name="tpMP3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpMP3.Text" xml:space="preserve">
+    <value>MP3</value>
+  </data>
+  <data name="&gt;&gt;tpMP3.Name" xml:space="preserve">
+    <value>tpMP3</value>
+  </data>
+  <data name="&gt;&gt;tpMP3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpMP3.Parent" xml:space="preserve">
+    <value>tcFFmpegAudioCodecs</value>
+  </data>
+  <data name="&gt;&gt;tpMP3.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="tcFFmpegAudioCodecs.Location" type="System.Drawing.Point, System.Drawing">
@@ -2051,7 +2075,7 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
     <value>eiFFmpeg</value>
   </data>
   <data name="&gt;&gt;eiFFmpeg.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=13.0.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.ExportImportControl, ShareX.HelpersLib, Version=13.2.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;eiFFmpeg.Parent" xml:space="preserve">
     <value>$this</value>
@@ -2059,12 +2083,12 @@ Otherwise it can't keep up with recording and a lot of frame drops will happen.<
   <data name="&gt;&gt;eiFFmpeg.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="$this.TrayHeight" type="System.Int32, mscorlib">
     <value>60</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/FFmpegOptions.cs
@@ -51,6 +51,7 @@ namespace ShareX.ScreenCaptureLib
         public int NVENC_bitrate { get; set; } = 3000; // kbit/s
         public FFmpegPaletteGenStatsMode GIFStatsMode { get; set; } = FFmpegPaletteGenStatsMode.full;
         public FFmpegPaletteUseDither GIFDither { get; set; } = FFmpegPaletteUseDither.sierra2_4a;
+        public int GIFBayerScale { get; set; } = 2;
         public FFmpegAMFUsage AMF_usage { get; set; } = FFmpegAMFUsage.transcoding;
         public FFmpegAMFQuality AMF_quality { get; set; } = FFmpegAMFQuality.speed;
         public FFmpegQSVPreset QSV_preset { get; set; } = FFmpegQSVPreset.fast;

--- a/ShareX.ScreenCaptureLib/Screencast/ScreenRecorder.cs
+++ b/ShareX.ScreenCaptureLib/Screencast/ScreenRecorder.cs
@@ -265,7 +265,9 @@ namespace ShareX.ScreenCaptureLib
                 // https://ffmpeg.org/ffmpeg-filters.html#palettegen-1
                 // https://ffmpeg.org/ffmpeg-filters.html#paletteuse
                 return ffmpeg.Run($"-i \"{input}\" -lavfi \"palettegen=stats_mode={Options.FFmpeg.GIFStatsMode}[palette]," +
-                    $"[0:v][palette]paletteuse=dither={Options.FFmpeg.GIFDither}\" -y \"{output}\"");
+                    $"[0:v][palette]paletteuse=dither={Options.FFmpeg.GIFDither}" +
+                    $"{(Options.FFmpeg.GIFDither == FFmpegPaletteUseDither.bayer ? ":bayer_scale=" + Options.FFmpeg.GIFBayerScale : String.Empty)}\"" +
+                    $" -y \"{output}\"");
             }
             finally
             {


### PR DESCRIPTION
Adds a combobox allowing users to alter bayer_scale that is used when encoding a gif file with the bayer dithering mode.
The UI for it isn't that great, as in the label doesn't exist, however the Screen Recording menu is pretty packed as is, I have only put an indication of it's function within the tooltip regrettably.

![image](https://user-images.githubusercontent.com/12771982/92112205-ca69e580-ee30-11ea-86bd-ea2053315b65.png)

There's a little bit of the bayer_scale in action on [this article](http://blog.pkh.me/p/21-high-quality-gif-with-ffmpeg.html#usage), otherwise it is covered in the [ffmpeg filters documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)