### PR TITLE
Added "Color depth" filter

### DIFF
--- a/ShareX.HelpersLib/Cryptographic/HashCheck.cs
+++ b/ShareX.HelpersLib/Cryptographic/HashCheck.cs
@@ -62,7 +62,7 @@ namespace ShareX.HelpersLib
                     {
                         return HashCheckThread(filePath, hashType, progress, cts.Token);
                     }
-                    catch (OperationCanceledException e)
+                    catch (OperationCanceledException)
                     {
                     }
 

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1378,6 +1378,37 @@ namespace ShareX.HelpersLib
             }
         }
 
+        public static void ColorDepth(Bitmap bmp, int bitsPerChannel = 4)
+        {
+            if (bitsPerChannel < 1 || bitsPerChannel > 8)
+            {
+                return;
+            }
+
+            double colorsPerChannel = Math.Pow(2, bitsPerChannel);
+            double colorInterval = 255 / (colorsPerChannel - 1);
+
+            byte Remap(byte color, double interval)
+            {
+                return (byte) Math.Round((Math.Round(color / interval) * interval));
+            }
+
+            using (UnsafeBitmap unsafeBitmap = new UnsafeBitmap(bmp, true))
+            {
+                for (int y = 0; y < unsafeBitmap.Height; y++)
+                {
+                    for (int x = 0; x < unsafeBitmap.Width; x++)
+                    {
+                        ColorBgra color = unsafeBitmap.GetPixel(x, y);
+                        color.Red = Remap(color.Red, colorInterval);
+                        color.Green = Remap(color.Green, colorInterval);
+                        color.Blue = Remap(color.Blue, colorInterval);
+                        unsafeBitmap.SetPixel(x, y, color);
+                    }
+                }
+            }
+        }
+
         // http://incubator.quasimondo.com/processing/superfast_blur.php
         public static void FastBoxBlur(Bitmap bmp, int radius)
         {

--- a/ShareX.ImageEffectsLib/Filters/ColorDepth.cs
+++ b/ShareX.ImageEffectsLib/Filters/ColorDepth.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using System.Drawing;
+using ShareX.HelpersLib;
+
+namespace ShareX.ImageEffectsLib
+{
+    [Description("Color depth")]
+    internal class ColorDepth : ImageEffect
+    {
+        private int _bitsPerChannel;
+
+        [DefaultValue(4)]
+        public int BitsPerChannel
+        {
+            get => this._bitsPerChannel;
+            set => this._bitsPerChannel = value.Max(1).Min(8);
+        }
+
+        public ColorDepth()
+        {
+            this.ApplyDefaultPropertyValues();
+        }
+
+        public override Bitmap Apply(Bitmap bmp)
+        {
+            ImageHelpers.ColorDepth(bmp, this.BitsPerChannel);
+            return bmp;
+        }
+    }
+}

--- a/ShareX.ImageEffectsLib/Forms/ImageEffectsForm.cs
+++ b/ShareX.ImageEffectsLib/Forms/ImageEffectsForm.cs
@@ -120,9 +120,9 @@ namespace ShareX.ImageEffectsLib
                 typeof(DrawBorder),
                 typeof(DrawCheckerboard),
                 typeof(DrawImage),
+                typeof(DrawParticles),
                 typeof(DrawTextEx),
-                typeof(DrawText),
-                typeof(DrawParticles));
+                typeof(DrawText));
 
             AddEffectToContextMenu(Resources.ImageEffectsForm_AddAllEffectsToTreeView_Manipulations,
                 typeof(AutoCrop),
@@ -140,13 +140,13 @@ namespace ShareX.ImageEffectsLib
                 typeof(Alpha),
                 typeof(BlackWhite),
                 typeof(Brightness),
+                typeof(MatrixColor), // "Color matrix"
                 typeof(Colorize),
                 typeof(Contrast),
                 typeof(Gamma),
                 typeof(Grayscale),
                 typeof(Hue),
                 typeof(Inverse),
-                typeof(MatrixColor),
                 typeof(Polaroid),
                 typeof(Saturation),
                 typeof(SelectiveColor),
@@ -154,10 +154,11 @@ namespace ShareX.ImageEffectsLib
 
             AddEffectToContextMenu(Resources.ImageEffectsForm_AddAllEffectsToTreeView_Filters,
                 typeof(Blur),
+                typeof(ColorDepth),
+                typeof(MatrixConvolution), // "Convolution matrix"
                 typeof(EdgeDetect),
                 typeof(Emboss),
                 typeof(GaussianBlur),
-                typeof(MatrixConvolution),
                 typeof(MeanRemoval),
                 typeof(Outline),
                 typeof(Pixelate),

--- a/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
+++ b/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Drawings\DrawText.cs" />
     <Compile Include="Drawings\DrawTextEx.cs" />
     <Compile Include="Enums.cs" />
+    <Compile Include="Filters\ColorDepth.cs" />
     <Compile Include="Filters\EdgeDetect.cs" />
     <Compile Include="Filters\Emboss.cs" />
     <Compile Include="Filters\GaussianBlur.cs" />

--- a/ShareX.MediaLib/Forms/VideoConverterForm.cs
+++ b/ShareX.MediaLib/Forms/VideoConverterForm.cs
@@ -174,7 +174,7 @@ namespace ShareX.MediaLib
 
         private Task<bool> StartEncodingAsync()
         {
-            return Task.Run(StartEncoding);
+            return Task.Run(() => StartEncoding());
         }
 
         private void Manager_EncodeProgressChanged(float percentage)

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -34,6 +34,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Added "Color depth" filter that remaps RGB pixel color to the nearest color at the specified color depth. For example, #E1CB96 will be remapped to #DDCC99 when "BitsPerChannel" is set to 4.

The attached image includes three sample images, each processed by the filter using the range of allowed bpc values (1-8).

 ![ColorDepth_Sample](https://user-images.githubusercontent.com/6905832/93138096-5383e680-f693-11ea-96db-967415a6ab52.png)