### PR TITLE
Update color picker format options to include 0-1 colors

### DIFF
--- a/ShareX.HelpersLib/NameParser/CodeMenuEntryPixelInfo.cs
+++ b/ShareX.HelpersLib/NameParser/CodeMenuEntryPixelInfo.cs
@@ -35,6 +35,9 @@ namespace ShareX.HelpersLib
         public static readonly CodeMenuEntryPixelInfo r = new CodeMenuEntryPixelInfo("r", "Red color (0-255)");
         public static readonly CodeMenuEntryPixelInfo g = new CodeMenuEntryPixelInfo("g", "Green color (0-255)");
         public static readonly CodeMenuEntryPixelInfo b = new CodeMenuEntryPixelInfo("b", "Blue color (0-255)");
+        public static readonly CodeMenuEntryPixelInfo R = new CodeMenuEntryPixelInfo("R", "Red color (0-1.000)");
+        public static readonly CodeMenuEntryPixelInfo G = new CodeMenuEntryPixelInfo("G", "Green color (0-1.000)");
+        public static readonly CodeMenuEntryPixelInfo B = new CodeMenuEntryPixelInfo("B", "Blue color (0-1.000)");
         public static readonly CodeMenuEntryPixelInfo hex = new CodeMenuEntryPixelInfo("hex", "Hex color value (Lowercase)");
         public static readonly CodeMenuEntryPixelInfo HEX = new CodeMenuEntryPixelInfo("HEX", "Hex color value (Uppercase)");
         public static readonly CodeMenuEntryPixelInfo x = new CodeMenuEntryPixelInfo("x", "X position");
@@ -47,9 +50,12 @@ namespace ShareX.HelpersLib
 
         public static string Parse(string input, Color color, Point position)
         {
-            return input.Replace(r.ToPrefixString(), color.R.ToString(), StringComparison.InvariantCultureIgnoreCase).
-                Replace(g.ToPrefixString(), color.G.ToString(), StringComparison.InvariantCultureIgnoreCase).
-                Replace(b.ToPrefixString(), color.B.ToString(), StringComparison.InvariantCultureIgnoreCase).
+            return input.Replace(r.ToPrefixString(), color.R.ToString(), StringComparison.InvariantCulture).
+                Replace(g.ToPrefixString(), color.G.ToString(), StringComparison.InvariantCulture).
+                Replace(b.ToPrefixString(), color.B.ToString(), StringComparison.InvariantCulture).
+                Replace(R.ToPrefixString(), Math.Round(color.R / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(G.ToPrefixString(), Math.Round(color.G / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(B.ToPrefixString(), Math.Round(color.B / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(HEX.ToPrefixString(), ColorHelpers.ColorToHex(color), StringComparison.InvariantCulture).
                 Replace(hex.ToPrefixString(), ColorHelpers.ColorToHex(color).ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(x.ToPrefixString(), position.X.ToString(), StringComparison.InvariantCultureIgnoreCase).

--- a/ShareX.HelpersLib/NameParser/CodeMenuEntryPixelInfo.cs
+++ b/ShareX.HelpersLib/NameParser/CodeMenuEntryPixelInfo.cs
@@ -24,20 +24,31 @@
 #endregion License Information (GPL v3)
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
 
 namespace ShareX.HelpersLib
 {
     public class CodeMenuEntryPixelInfo : CodeMenuEntry
     {
-        protected override string Prefix { get; } = "$";
+        // We need access to the prefix later on
+        private static readonly string _prefix = "$";
+        protected override string Prefix { get; } = _prefix;
 
-        public static readonly CodeMenuEntryPixelInfo r = new CodeMenuEntryPixelInfo("r", "Red color (0-255)");
-        public static readonly CodeMenuEntryPixelInfo g = new CodeMenuEntryPixelInfo("g", "Green color (0-255)");
-        public static readonly CodeMenuEntryPixelInfo b = new CodeMenuEntryPixelInfo("b", "Blue color (0-255)");
-        public static readonly CodeMenuEntryPixelInfo R = new CodeMenuEntryPixelInfo("R", "Red color (0-1.000)");
-        public static readonly CodeMenuEntryPixelInfo G = new CodeMenuEntryPixelInfo("G", "Green color (0-1.000)");
-        public static readonly CodeMenuEntryPixelInfo B = new CodeMenuEntryPixelInfo("B", "Blue color (0-1.000)");
+
+        // This shouldn't show up in the list of options, but will continue to work for backwards compatibility's sake.
+        //public static readonly CodeMenuEntryPixelInfo r = new CodeMenuEntryPixelInfo("r", "Red color (0-255)");
+        //public static readonly CodeMenuEntryPixelInfo g = new CodeMenuEntryPixelInfo("g", "Green color (0-255)");
+        //public static readonly CodeMenuEntryPixelInfo b = new CodeMenuEntryPixelInfo("b", "Blue color (0-255)");
+
+        public static readonly CodeMenuEntryPixelInfo r255 = new CodeMenuEntryPixelInfo("r255", "Red color (0-255)");
+        public static readonly CodeMenuEntryPixelInfo g255 = new CodeMenuEntryPixelInfo("g255", "Green color (0-255)");
+        public static readonly CodeMenuEntryPixelInfo b255 = new CodeMenuEntryPixelInfo("b255", "Blue color (0-255)");
+        public static readonly CodeMenuEntryPixelInfo r1 = new CodeMenuEntryPixelInfo("r1", "Red color (0-1). Specify decimal precison with {n}, defaults to 3.");
+        public static readonly CodeMenuEntryPixelInfo g1 = new CodeMenuEntryPixelInfo("g1", "Green color (0-1). Specify decimal precison with {n}, defaults to 3.");
+        public static readonly CodeMenuEntryPixelInfo b1 = new CodeMenuEntryPixelInfo("b1", "Blue color (0-1). Specify decimal precison with {n}, defaults to 3.");
         public static readonly CodeMenuEntryPixelInfo hex = new CodeMenuEntryPixelInfo("hex", "Hex color value (Lowercase)");
         public static readonly CodeMenuEntryPixelInfo HEX = new CodeMenuEntryPixelInfo("HEX", "Hex color value (Uppercase)");
         public static readonly CodeMenuEntryPixelInfo x = new CodeMenuEntryPixelInfo("x", "X position");
@@ -50,17 +61,82 @@ namespace ShareX.HelpersLib
 
         public static string Parse(string input, Color color, Point position)
         {
-            return input.Replace(r.ToPrefixString(), color.R.ToString(), StringComparison.InvariantCulture).
-                Replace(g.ToPrefixString(), color.G.ToString(), StringComparison.InvariantCulture).
-                Replace(b.ToPrefixString(), color.B.ToString(), StringComparison.InvariantCulture).
-                Replace(R.ToPrefixString(), Math.Round(color.R / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
-                Replace(G.ToPrefixString(), Math.Round(color.G / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
-                Replace(B.ToPrefixString(), Math.Round(color.B / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
+            input = input.Replace(r255.ToPrefixString(), color.R.ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(g255.ToPrefixString(), color.G.ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(b255.ToPrefixString(), color.B.ToString(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(HEX.ToPrefixString(), ColorHelpers.ColorToHex(color), StringComparison.InvariantCulture).
                 Replace(hex.ToPrefixString(), ColorHelpers.ColorToHex(color).ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(x.ToPrefixString(), position.X.ToString(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(y.ToPrefixString(), position.Y.ToString(), StringComparison.InvariantCultureIgnoreCase).
                 Replace(n.ToPrefixString(), Environment.NewLine, StringComparison.InvariantCultureIgnoreCase);
+            
+            // Special cases for r1{n} that includes variable length rounding.
+            // Turns out the rounding must be between 0 and 15 inclusive. I will force all numbers to that range.
+            foreach (Tuple<string, int> entry in ListEntryWithValue(input, r1.ToPrefixString()))
+            {
+                input = input.Replace(entry.Item1, Math.Round(color.B / 255.0, Math.Min(Math.Max(entry.Item2, 0), 15), MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            foreach (Tuple<string, int> entry in ListEntryWithValue(input, g1.ToPrefixString()))
+            {
+                input = input.Replace(entry.Item1, Math.Round(color.B / 255.0, Math.Min(Math.Max(entry.Item2, 0), 15), MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            foreach (Tuple<string, int> entry in ListEntryWithValue(input, b1.ToPrefixString()))
+            {
+                input = input.Replace(entry.Item1, Math.Round(color.B / 255.0, Math.Min(Math.Max(entry.Item2, 0), 15), MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase);
+            }
+
+            // Case for r1 that does not include variable lenthg rounding, defaults to 3 didgets
+            input = input.Replace(r1.ToPrefixString(), Math.Round(color.B / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(g1.ToPrefixString(), Math.Round(color.B / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(b1.ToPrefixString(), Math.Round(color.B / 255.0, 3, MidpointRounding.AwayFromZero).ToString(), StringComparison.InvariantCultureIgnoreCase);
+
+            // This is here for backwards compatibility. These do not show up in the list, so they have to be done slightly differently,
+            // and have to be done last so they don't munch the `$r` from other entries.
+            input = input.Replace(_prefix + "r", color.R.ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(_prefix + "g", color.G.ToString(), StringComparison.InvariantCultureIgnoreCase).
+                Replace(_prefix + "b", color.B.ToString(), StringComparison.InvariantCultureIgnoreCase);
+
+            return input;
+        }
+
+        private static IEnumerable<Tuple<string, string[]>> ListEntryWithArguments(string text, string entry, int elements)
+        {
+            foreach (Tuple<string, string> o in text.ForEachBetween(entry + "{", "}"))
+            {
+                string[] s = o.Item2.Split(',');
+                if (elements > s.Length)
+                {
+                    Array.Resize(ref s, elements);
+                }
+                yield return new Tuple<string, string[]>(o.Item1, s);
+            }
+        }
+
+        private static IEnumerable<Tuple<string, int[]>> ListEntryWithValues(string text, string entry, int elements)
+        {
+            foreach (Tuple<string, string[]> o in ListEntryWithArguments(text, entry, elements))
+            {
+                int[] a = new int[o.Item2.Length];
+                for (int i = o.Item2.Length - 1; i >= 0; --i)
+                {
+                    int n = 0;
+                    if (int.TryParse(o.Item2[i], out n))
+                    {
+                        a[i] = n;
+                    }
+                }
+                yield return new Tuple<string, int[]>(o.Item1, a);
+            }
+        }
+
+        private static IEnumerable<Tuple<string, int>> ListEntryWithValue(string text, string entry)
+        {
+            foreach (Tuple<string, int[]> o in ListEntryWithValues(text, entry, 1))
+            {
+                yield return new Tuple<string, int>(o.Item1, o.Item2[0]);
+            }
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22972550/94211455-5bf3d280-fe86-11ea-9e48-9318b6bf60fc.png)
Basically what the title says, you can now use capital letters `$R`, `$G`, and `$B` to get a color string with colors represented from 0-1. This format of colors is used with a number of things, most notably Unity, and this will save me and hopefully others from having to convert normal colors to 0-1 range every so often, which I say is a win.    
I have it set to round to 3 decimal places, but that's totally arbitrary and any precision will basically work, although some level of rounding seems sensible otherwise you get unnecessarily long outputs. If you think it should be more/less precise, just LMK and I'll do whatever. Also, I think the use of `1.000` in the description strings gets the point across pretty well, but that can also be stated more clearly if need be. 
 
I looked around for a bit and couldn't find a contributor guide so I tried to just modify as little as possible and keep styling consistent. Not really sure what I'm supposed to be PRing into, I'm assuming master since most other recent commits are straight to master? I've tested this myself and it works fine, both capital and lowercase format characters work as intended, but feel free to verify yourself. Thanks for all the hard work on the best screenshot tool for windows! 
<sub><sub><sub>Also bankers rounding is a dumb default thanks Microsoft</sub></sub></sub>