### PR TITLE
fixed #5068: Automatically register failed hotkeys

### DIFF
--- a/ShareX/Forms/HotkeySettingsForm.cs
+++ b/ShareX/Forms/HotkeySettingsForm.cs
@@ -111,10 +111,21 @@ namespace ShareX
             }
         }
 
+        private void RegisterFailedHotkeys()
+        {
+            foreach (HotkeySettings hotkeySettings in manager.Hotkeys.Where(x => x.HotkeyInfo.Status == HotkeyStatus.Failed))
+            {
+                manager.RegisterHotkey(hotkeySettings);
+            }
+
+            UpdateHotkeyStatus();
+        }
+
         private void control_HotkeyChanged(object sender, EventArgs e)
         {
             HotkeySelectionControl control = (HotkeySelectionControl)sender;
             manager.RegisterHotkey(control.Setting);
+            RegisterFailedHotkeys();
         }
 
         private HotkeySelectionControl AddHotkeySelectionControl(HotkeySettings hotkeySetting)


### PR DESCRIPTION
If two hotkeys sharing same keybinds then changing one hotkey will register other failed hotkey automatically.

Example:

![](https://jaex.getsharex.com/2020/10/ykyFSxh4Bf.gif)