### PR TITLE
fixed #5020: Show screen record encoding progress in tray icon

### DIFF
--- a/ShareX/Forms/ScreenRecordForm.cs
+++ b/ShareX/Forms/ScreenRecordForm.cs
@@ -52,6 +52,7 @@ namespace ShareX
         private Rectangle borderRectangle0Based;
         private bool activateWindow;
         private float duration;
+        private static int lastIconStatus = -1;
 
         public ScreenRecordForm(Rectangle regionRectangle, TaskSettings taskSettings, bool activateWindow = true, float duration = 0)
         {
@@ -306,6 +307,38 @@ namespace ShareX
         public void ChangeStateProgress(int progress)
         {
             niTray.Text = $"ShareX - {Resources.ScreenRecordForm_StartRecording_Encoding___} {progress}%";
+
+            if (niTray.Visible && lastIconStatus != progress)
+            {
+                Icon icon;
+
+                if (progress >= 0)
+                {
+                    try
+                    {
+                        icon = TaskHelpers.GetProgressIcon(progress);
+                    }
+                    catch (Exception e)
+                    {
+                        DebugHelper.WriteException(e);
+                        progress = -1;
+                        if (lastIconStatus == progress) return;
+                        icon = Resources.camcorder_pencil.ToIcon();
+                    }
+                }
+                else
+                {
+                    icon = Resources.camcorder_pencil.ToIcon();
+                }
+
+                using (Icon oldIcon = niTray.Icon)
+                {
+                    niTray.Icon = icon;
+                    oldIcon.DisposeHandle();
+                }
+
+                lastIconStatus = progress;
+            }
         }
     }
 }

--- a/ShareX/Forms/ScreenRecordForm.cs
+++ b/ShareX/Forms/ScreenRecordForm.cs
@@ -316,7 +316,7 @@ namespace ShareX
                 {
                     try
                     {
-                        icon = TaskHelpers.GetProgressIcon(progress);
+                        icon = TaskHelpers.GetProgressIcon(progress, Color.FromArgb(140, 0, 36));
                     }
                     catch (Exception e)
                     {

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -644,6 +644,11 @@ namespace ShareX
 
         public static Icon GetProgressIcon(int percentage)
         {
+            return GetProgressIcon(percentage, Color.FromArgb(16, 116, 193));
+        }
+
+        public static Icon GetProgressIcon(int percentage, Color color)
+        {
             percentage = percentage.Clamp(0, 99);
 
             Size size = SystemInformation.SmallIconSize;
@@ -654,7 +659,7 @@ namespace ShareX
 
                 if (y > 0)
                 {
-                    using (Brush brush = new SolidBrush(Color.FromArgb(16, 116, 193)))
+                    using (Brush brush = new SolidBrush(color))
                     {
                         g.FillRectangle(brush, 0, size.Height - 1 - y, size.Width, y);
                     }


### PR DESCRIPTION
Now screen record encoding progress percentage is visible in tray icon. That way user can know status of encoding.

Example screenshot:

![](https://jaex.getsharex.com/2020/10/rrjTsVzpli.png)