### PR TITLE
Allow drawing arrows in reverse

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -190,6 +190,13 @@ namespace ShareX.HelpersLib
         NearestNeighbor
     }
 
+    public enum ArrowHeadDirection
+    {
+        Start,
+        End,
+        Both
+    }
+
     public enum FFmpegArchitecture
     {
         win64,

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1192,11 +1192,11 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Arrows on both ends.
+        ///   Looks up a localized string similar to Arrow points to:.
         /// </summary>
-        internal static string ShapeManager_ArrowsOnBothEnds {
+        internal static string ShapeManager_ArrowHeadDirection {
             get {
-                return ResourceManager.GetString("ShapeManager_ArrowsOnBothEnds", resourceCulture);
+                return ResourceManager.GetString("ShapeManager_ArrowHeadDirection", resourceCulture);
             }
         }
         

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -277,9 +277,6 @@
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>Rotate 90° counter clockwise</value>
   </data>
-  <data name="ShapeManager_ArrowsOnBothEnds" xml:space="preserve">
-    <value>Arrows on both ends</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>Interpolation mode:</value>
   </data>
@@ -715,5 +712,8 @@ X: {4} Y: {5}</value>
   </data>
   <data name="keyboard-enter" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\keyboard-enter.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Arrow points to:</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
@@ -52,7 +52,7 @@ namespace ShareX.ScreenCaptureLib
         public int LineCenterPointCount { get; set; } = 1;
 
         // Arrow drawing
-        public bool ArrowHeadsBothSide { get; set; } = false;
+        public ArrowHeadDirection ArrowHeadDirection { get; set; } = ArrowHeadDirection.End;
 
         // Text (Outline) drawing
         public TextDrawingOptions TextOutlineOptions { get; set; } = new TextDrawingOptions()

--- a/ShareX.ScreenCaptureLib/Shapes/Drawing/ArrowDrawingShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Drawing/ArrowDrawingShape.cs
@@ -33,18 +33,18 @@ namespace ShareX.ScreenCaptureLib
     {
         public override ShapeType ShapeType { get; } = ShapeType.DrawingArrow;
 
-        public bool ArrowHeadsBothSide { get; set; }
+        public ArrowHeadDirection ArrowHeadDirection { get; set; }
 
         public override void OnConfigLoad()
         {
             base.OnConfigLoad();
-            ArrowHeadsBothSide = AnnotationOptions.ArrowHeadsBothSide;
+            ArrowHeadDirection = AnnotationOptions.ArrowHeadDirection;
         }
 
         public override void OnConfigSave()
         {
             base.OnConfigSave();
-            AnnotationOptions.ArrowHeadsBothSide = ArrowHeadsBothSide;
+            AnnotationOptions.ArrowHeadDirection = ArrowHeadDirection;
         }
 
         protected override Pen CreatePen(Color borderColor, int borderSize)
@@ -62,11 +62,18 @@ namespace ShareX.ScreenCaptureLib
                 };
 
                 Pen pen = new Pen(borderColor, borderSize);
-                pen.CustomEndCap = lineCap;
 
-                if (ArrowHeadsBothSide && MathHelpers.Distance(Points[0], Points[Points.Length - 1]) > arrowHeight * borderSize * 2)
+                if (ArrowHeadDirection == ArrowHeadDirection.Both && MathHelpers.Distance(Points[0], Points[Points.Length - 1]) > arrowHeight * borderSize * 2)
+                {
+                    pen.CustomEndCap = pen.CustomStartCap = lineCap;
+                }
+                else if (ArrowHeadDirection == ArrowHeadDirection.Start)
                 {
                     pen.CustomStartCap = lineCap;
+                }
+                else
+                {
+                    pen.CustomEndCap = lineCap;
                 }
 
                 pen.LineJoin = LineJoin.Round;

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -48,12 +48,12 @@ namespace ShareX.ScreenCaptureLib
         private ToolStripEx tsMain;
         private ToolStripButton tsbSaveImage, tsbBorderColor, tsbFillColor, tsbHighlightColor;
         private ToolStripDropDownButton tsddbShapeOptions;
-        private ToolStripMenuItem tsmiArrowHeadsBothSide, tsmiShadow, tsmiShadowColor, tsmiStepUseLetters, tsmiUndo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
+        private ToolStripMenuItem tsmiShadow, tsmiShadowColor, tsmiStepUseLetters, tsmiUndo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
             tsmiMoveTop, tsmiMoveUp, tsmiMoveDown, tsmiMoveBottom, tsmiRegionCapture, tsmiQuickCrop, tsmiShowMagnifier;
         private ToolStripLabeledNumericUpDown tslnudBorderSize, tslnudCornerRadius, tslnudCenterPoints, tslnudBlurRadius, tslnudPixelateSize, tslnudStepFontSize,
             tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength;
         private ToolStripLabel tslDragLeft, tslDragRight;
-        private ToolStripLabeledComboBox tscbImageInterpolationMode, tscbCursorTypes;
+        private ToolStripLabeledComboBox tsmiArrowHeadDirection, tscbImageInterpolationMode, tscbCursorTypes;
 
         internal void CreateToolbar()
         {
@@ -566,14 +566,16 @@ namespace ShareX.ScreenCaptureLib
             };
             tsddbShapeOptions.DropDownItems.Add(tslnudCenterPoints);
 
-            tsmiArrowHeadsBothSide = new ToolStripMenuItem(Resources.ShapeManager_ArrowsOnBothEnds);
-            tsmiArrowHeadsBothSide.CheckOnClick = true;
-            tsmiArrowHeadsBothSide.Click += (sender, e) =>
+            tsmiArrowHeadDirection = new ToolStripLabeledComboBox(null);
+            tsmiArrowHeadDirection.Content.AddRange(Helpers.GetLocalizedEnumDescriptions<ArrowHeadDirection>());
+            tsmiArrowHeadDirection.Content.SelectedIndexChanged += (sender, e) =>
             {
-                AnnotationOptions.ArrowHeadsBothSide = tsmiArrowHeadsBothSide.Checked;
+                AnnotationOptions.ArrowHeadDirection = (ArrowHeadDirection)tsmiArrowHeadDirection.Content.SelectedIndex;
+                tsmiArrowHeadDirection.Invalidate();
                 UpdateCurrentShape();
             };
-            tsddbShapeOptions.DropDownItems.Add(tsmiArrowHeadsBothSide);
+            tsddbShapeOptions.DropDownItems.Add(tsmiArrowHeadDirection);
+
 
             tslnudStepFontSize = new ToolStripLabeledNumericUpDown(Resources.ShapeManager_CreateToolbar_FontSize);
             tslnudStepFontSize.Content.Minimum = 10;
@@ -1411,7 +1413,7 @@ namespace ShareX.ScreenCaptureLib
 
             tslnudCenterPoints.Content.Value = AnnotationOptions.LineCenterPointCount;
 
-            tsmiArrowHeadsBothSide.Checked = AnnotationOptions.ArrowHeadsBothSide;
+            tsmiArrowHeadDirection.Content.SelectedIndex = (int)AnnotationOptions.ArrowHeadDirection;
 
             switch (shapeType)
             {
@@ -1494,7 +1496,7 @@ namespace ShareX.ScreenCaptureLib
             }
 
             tslnudCenterPoints.Visible = shapeType == ShapeType.DrawingLine || shapeType == ShapeType.DrawingArrow;
-            tsmiArrowHeadsBothSide.Visible = shapeType == ShapeType.DrawingArrow;
+            tsmiArrowHeadDirection.Visible = shapeType == ShapeType.DrawingArrow;
             tscbImageInterpolationMode.Visible = shapeType == ShapeType.DrawingImage || shapeType == ShapeType.DrawingImageScreen || shapeType == ShapeType.DrawingMagnify;
             tslnudStartingStepValue.Visible = shapeType == ShapeType.DrawingStep;
             tslnudStepFontSize.Visible = tsmiStepUseLetters.Visible = shapeType == ShapeType.DrawingStep;


### PR DESCRIPTION
Adds a shape option for drawing arrows pointing to their origin
Closes #5103

![image](https://user-images.githubusercontent.com/12771982/95148574-650e6900-07cf-11eb-9cf9-aa8b7c9a396f.png)
![image](https://user-images.githubusercontent.com/12771982/95148593-6e97d100-07cf-11eb-8039-6b6d6bc8a6a7.png)
