### PR TITLE
Fix for toolstrip overflow in image editor

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -56,6 +56,9 @@ namespace ShareX.ScreenCaptureLib
         public string ImageFilePath { get; set; }
         public bool IsFullscreen { get; private set; }
 
+        public const int MinWidth = 800;
+        public const int MinHeight = 550;
+
         public RegionCaptureMode Mode { get; private set; }
         public bool IsEditorMode => Mode == RegionCaptureMode.Editor || Mode == RegionCaptureMode.TaskEditor;
         public bool IsAnnotationMode => Mode == RegionCaptureMode.Annotation || IsEditorMode;
@@ -180,7 +183,7 @@ namespace ShareX.ScreenCaptureLib
             else
             {
                 FormBorderStyle = FormBorderStyle.Sizable;
-                MinimumSize = new Size(800, 550);
+                MinimumSize = new Size(MinWidth, MinHeight);
 
                 if (Options.ImageEditorStartMode == ImageEditorStartMode.PreviousState)
                 {

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -1067,6 +1067,12 @@ namespace ShareX.ScreenCaptureLib
 
             menuForm.Show(Form);
 
+            //Prevent toolstrip overflow
+            if (Form.MinimumSize.Width < tsMain.DisplayRectangle.Size.Width)
+            {
+                Form.MinimumSize = new Size(tsMain.DisplayRectangle.Size.Width, RegionCaptureForm.MinHeight);
+            }
+
             UpdateMenu();
 
             CurrentShapeChanged += shape => UpdateMenu();


### PR DESCRIPTION
Minor bug I noticed when using region capture for small regions. Toolstrip in editor window overflows beyond displayed size of editor window. Not sure if this is mentioned by any issues.

This is how it looks without the fix
![behaviourwithoutfix](https://i.imgur.com/NPMQHjN.png)

This is how it looks with the fix
![behaviourwithfix](https://i.imgur.com/8tbXWG9.png)
