### PR TITLE
Add canvas margin from percentage canvas size

### DIFF
--- a/ShareX.ImageEffectsLib/Manipulations/Canvas.cs
+++ b/ShareX.ImageEffectsLib/Manipulations/Canvas.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
@@ -36,6 +37,9 @@ namespace ShareX.ImageEffectsLib
         [DefaultValue(typeof(Padding), "0, 0, 0, 0")]
         public Padding Margin { get; set; }
 
+        [DefaultValue(CanvasMarginMode.AbsoluteSize), Description("How the margin around the canvas will be calculated."), TypeConverter(typeof(EnumDescriptionConverter))]
+        public CanvasMarginMode MarginMode { get; set; }
+
         [DefaultValue(typeof(Color), "Transparent"), Editor(typeof(MyColorEditor), typeof(UITypeEditor)), TypeConverter(typeof(MyColorConverter))]
         public Color Color { get; set; }
 
@@ -44,9 +48,32 @@ namespace ShareX.ImageEffectsLib
             this.ApplyDefaultPropertyValues();
         }
 
+        public enum CanvasMarginMode
+        {
+            AbsoluteSize,
+            PercentageOfCanvas
+        }
+
         public override Bitmap Apply(Bitmap bmp)
         {
-            Bitmap bmpResult = ImageHelpers.AddCanvas(bmp, Margin, Color);
+            Padding canvasMargin;
+
+            if (MarginMode == CanvasMarginMode.PercentageOfCanvas)
+            {
+                // Calculate the amount of padding to add to the sides, based on canvas size.
+                canvasMargin = new Padding();
+                canvasMargin.Top = (int)Math.Round(Margin.Top / 100f * bmp.Height);
+                canvasMargin.Bottom = (int)Math.Round(Margin.Bottom / 100f * bmp.Height);
+                canvasMargin.Left = (int)Math.Round(Margin.Left / 100f * bmp.Width);
+                canvasMargin.Right = (int)Math.Round(Margin.Right / 100f * bmp.Width);
+            }
+            else
+            {
+                // Use the margin as is (absolute size)
+                canvasMargin = Margin;
+            }
+
+            Bitmap bmpResult = ImageHelpers.AddCanvas(bmp, canvasMargin, Color);
 
             if (bmpResult == null)
             {


### PR DESCRIPTION
Currently, adding a border to the canvas requires absolute pixel units.
This PR allows you to add border based off a percentage of the canvas size, allowing you to make borders that scale well to different image sizes, especially for high resolution/dpi displays.

![image](https://user-images.githubusercontent.com/13886925/96892164-48d22380-1481-11eb-9b71-f38b19d6b187.png)
