### PR TITLE
Fixed URL encoding for Plik

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/Plik.cs
+++ b/ShareX.UploadersLib/FileUploaders/Plik.cs
@@ -112,7 +112,6 @@ namespace ShareX.UploadersLib.FileUploaders
             UploadResult result = new UploadResult(fileDataReq.Response);
             UploadMetadataResponse fileData = JsonConvert.DeserializeObject<UploadMetadataResponse>(fileDataReq.Response);
             UploadMetadataResponseFile actFile = metaData.files.First().Value;
-            result.URL = $"{Settings.URL}/file/{metaData.id}/{actFile.id}/{actFile.fileName}";
             result.URL = Uri.EscapeUriString($"{Settings.URL}/file/{metaData.id}/{actFile.id}/{actFile.fileName}");
             return result;
         }

--- a/ShareX.UploadersLib/FileUploaders/Plik.cs
+++ b/ShareX.UploadersLib/FileUploaders/Plik.cs
@@ -113,6 +113,7 @@ namespace ShareX.UploadersLib.FileUploaders
             UploadMetadataResponse fileData = JsonConvert.DeserializeObject<UploadMetadataResponse>(fileDataReq.Response);
             UploadMetadataResponseFile actFile = metaData.files.First().Value;
             result.URL = $"{Settings.URL}/file/{metaData.id}/{actFile.id}/{actFile.fileName}";
+            result.URL = Uri.EscapeUriString($"{Settings.URL}/file/{metaData.id}/{actFile.id}/{actFile.fileName}");
             return result;
         }
 

--- a/ShareX.UploadersLib/FileUploaders/Plik.cs
+++ b/ShareX.UploadersLib/FileUploaders/Plik.cs
@@ -112,7 +112,7 @@ namespace ShareX.UploadersLib.FileUploaders
             UploadResult result = new UploadResult(fileDataReq.Response);
             UploadMetadataResponse fileData = JsonConvert.DeserializeObject<UploadMetadataResponse>(fileDataReq.Response);
             UploadMetadataResponseFile actFile = metaData.files.First().Value;
-            result.URL = Uri.EscapeUriString($"{Settings.URL}/file/{metaData.id}/{actFile.id}/{actFile.fileName}");
+            result.URL = $"{Settings.URL}/file/{metaData.id}/{actFile.id}/{URLHelpers.URLEncode(actFile.fileName)}";
             return result;
         }
 


### PR DESCRIPTION
This adds encoding to the result URL so that it can be pasted in chats and so on without having to replace space with %20 and so on.