### PR TITLE
ffmpeg zip archive extraction fix

### DIFF
--- a/ShareX.HelpersLib/FileDownloader.cs
+++ b/ShareX.HelpersLib/FileDownloader.cs
@@ -182,10 +182,11 @@ namespace ShareX.HelpersLib
                             }
 
                             progress.Report(ProgressChanged);
-                            progress.Report(DownloadCompleted);
                         }
                     }
                 }
+
+                progress.Report(DownloadCompleted);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The following exception is raised when the program attemps to extract the ffmpeg archive:

`System.IO.IOException: The process cannot access the file 'C:\Users\ ... \AppData\Local\Temp\ShareX\ffmpeg.zip' because it is being used by another process.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at System.IO.Compression.ZipFile.Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
   at System.IO.Compression.ZipFile.OpenRead(String archiveFileName)
   at ShareX.HelpersLib.ZipManager.Extract(String archivePath, String destination, Boolean retainDirectoryStructure, Func2 filter, Int64 maxUncompressedSize) in C:\dev\src\ShareX\ShareX.HelpersLib\Zip\ZipManager.cs:line 39
   at ShareX.MediaLib.FFmpegGitHubDownloader.ExtractFFmpeg(String archivePath, String extractPath) in C:\dev\src\ShareX\ShareX.MediaLib\FFmpegGitHubDownloader.cs:line 53`

I've tried accross two different machines (latest Win 10 build and Win Server 2019) but it's not a systematic behaviour. I suspect it's a matter of "right timing" too.
Raising the "DownloadCompleted" event after all the resources (the file stream in particular) have been disposed **should** be safe.
