### PR TITLE
Minor fix on ruler measuring

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -1057,8 +1057,8 @@ namespace ShareX.ScreenCaptureLib
             }
             else if (Mode == RegionCaptureMode.Ruler)
             {
-                Point endLocation = new Point(rect.Right - 1, rect.Bottom - 1);
-                string text = $"X: {rect.X} | Y: {rect.Y} | Right: {endLocation.X} | Bottom: {endLocation.Y}\r\n" +
+                Point endLocation = new Point(rect.Right, rect.Bottom);
+                string text = $"X: {rect.X} | Y: {rect.Y} | Right: {endLocation.X - 1} | Bottom: {endLocation.Y - 1}\r\n" +
                     $"Width: {rect.Width} px | Height: {rect.Height} px | Area: {rect.Area()} px | Perimeter: {rect.Perimeter()} px\r\n" +
                     $"Distance: {MathHelpers.Distance(rect.Location, endLocation):0.00} px | Angle: {MathHelpers.LookAtDegree(rect.Location, endLocation):0.00}°";
                 return text;


### PR DESCRIPTION
I have noticed the ruler measuring system was slightly off with doing the calculations using the width and height:
![image](https://user-images.githubusercontent.com/44097323/118266563-b348c080-b4b2-11eb-86ce-c560f2e554a5.png)

For example, if you use the width and height to calculate the angle in a calculator (by doing `arctan(height/width)`) the result is off by 1 decimal. This is because ShareX subtracts 1 from each coordinate on the end vector (line 1060 before changes), which makes sense for presenting the end vector. But then uses the resulting vector to calculate the angle and distance, therefore actually does `arctan(height-1/width-1)`. Naturally, a similar error of 2 pixels happens with the distance (by doing `sqrt(height^2 + width^2)` when ShareX actually does `sqrt((height-1)^2 + (width-1)^2)`).

I have changed it so the end vector remains the same as in `rect` (line 1060) and the subtraction happens only when displaying the end vector (line 1061)