### PR TITLE
Added strength parameter for some image filters

### DIFF
--- a/ShareX.ImageEffectsLib/Filters/MeanRemoval.cs
+++ b/ShareX.ImageEffectsLib/Filters/MeanRemoval.cs
@@ -32,11 +32,32 @@ namespace ShareX.ImageEffectsLib
     [Description("Mean removal")]
     internal class MeanRemoval : ImageEffect
     {
+        private int strength;
+
+        [DefaultValue(5)]
+        public int Strength
+        {
+            get
+            {
+                return strength;
+            }
+            set
+            {
+                int capped = value.Min(10);
+                strength = capped.Max(1);
+            }
+        }
+
+        public MeanRemoval()
+        {
+            this.ApplyDefaultPropertyValues();
+        }
+
         public override Bitmap Apply(Bitmap bmp)
         {
             using (bmp)
             {
-                return ConvolutionMatrixManager.MeanRemoval().Apply(bmp);
+                return ConvolutionMatrixManager.MeanRemoval(30 - (2 * Strength)).Apply(bmp);
             }
         }
     }

--- a/ShareX.ImageEffectsLib/Filters/Sharpen.cs
+++ b/ShareX.ImageEffectsLib/Filters/Sharpen.cs
@@ -24,19 +24,42 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
+using System.ComponentModel;
 using System.Drawing;
 
 namespace ShareX.ImageEffectsLib
 {
+    [Description("Sharpen")]
     internal class Sharpen : ImageEffect
     {
+        private int strength;
+
+        [DefaultValue(5)]
+        public int Strength
+        {
+            get
+            {
+                return strength;
+            }
+            set
+            {
+                int capped = value.Min(10);
+                strength = capped.Max(1);
+            }
+        }
+
+        public Sharpen()
+        {
+            this.ApplyDefaultPropertyValues();
+        }
+
         public override Bitmap Apply(Bitmap bmp)
         {
             //return ImageHelpers.Sharpen(bmp, Strength);
 
             using (bmp)
             {
-                return ConvolutionMatrixManager.Sharpen().Apply(bmp);
+                return ConvolutionMatrixManager.Sharpen(20 - Strength).Apply(bmp);
             }
         }
     }

--- a/ShareX.ImageEffectsLib/Filters/Smooth.cs
+++ b/ShareX.ImageEffectsLib/Filters/Smooth.cs
@@ -24,17 +24,40 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
+using System.ComponentModel;
 using System.Drawing;
 
 namespace ShareX.ImageEffectsLib
 {
+    [Description("Smooth")]
     internal class Smooth : ImageEffect
     {
+        private int strength;
+
+        [DefaultValue(5)]
+        public int Strength
+        {
+            get
+            {
+                return strength;
+            }
+            set
+            {
+                int capped = value.Min(10);
+                strength = capped.Max(1);
+            }
+        }
+
+        public Smooth()
+        {
+            this.ApplyDefaultPropertyValues();
+        }
+
         public override Bitmap Apply(Bitmap bmp)
         {
             using (bmp)
             {
-                return ConvolutionMatrixManager.Smooth().Apply(bmp);
+                return ConvolutionMatrixManager.Smooth(50 - (5 * Strength)).Apply(bmp);
             }
         }
     }


### PR DESCRIPTION
Added a strength parameter for the Sharpen, Smooth, and Mean Removal image filters. 

### Details

The 3 affected filters use image manipulation methods from the ShareX.HelpersLib.ConvolutionMatrixManager class. These methods already accept a "weight" integer as an argument that determines the strength of the effect, so this change just adds a parameter in the GUI that sets the value of that "weight" argument.

The Strength integer is capped between 1 and 10 for all three affected filters, and the default is 5. The strategy used for adding the parameter is identical to how it is for other filters with similar parameters, like the Blur filter's "Radius" setting. The integer value is not directly used as the argument to the image manipulation methods - instead we apply strength as an offset from a constant arbitrary value, which I tuned for each filter so that the user perceives a comfortable relative strength scale from 1-10. 

The weird part about this code change might be the arithmetic and constant arbitrary values used for the weight argument calculation. The relationship of the ConvolutionMatrixManager "weight" to perceived strength of the effect wasn't linear, so I can really only say that I tuned it the best I can. 

### Purpose
I have been using the Scale effect in combination with the Sharpen effect to compress my screen captures while keeping them sharp. However, the Sharpen filter was too strong and makes my screenshots look bad and unusable. I wanted to reduce the strength of the Sharpen filter, but there was no option for that.

### Testing
All 3 filters still function correctly after adding the change. The strength parameter now shows up in each affected image effect inside the Image Effects editor window. 

For my own use case, I set my sharpen filter to 2/10 just to apply a slight sharpen after I scaled down my images. Works great!