### PR TITLE
Handle invalid output paths in video converter

### DIFF
--- a/ShareX.MediaLib/VideoConverterOptions.cs
+++ b/ShareX.MediaLib/VideoConverterOptions.cs
@@ -39,7 +39,7 @@ namespace ShareX.MediaLib
         {
             get
             {
-                if (string.IsNullOrEmpty(OutputFolderPath) || string.IsNullOrEmpty(OutputFileName))
+                if (!IsValidOutputPath(OutputFolderPath, OutputFileName))
                 {
                     return "";
                 }
@@ -149,6 +149,26 @@ namespace ShareX.MediaLib
                     return "webp";
                 case ConverterVideoCodecs.apng:
                     return "apng";
+            }
+        }
+
+        private bool IsValidOutputPath(string folderPath, string fileName)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(folderPath) || string.IsNullOrEmpty(fileName))
+                {
+                    return false;
+                }
+
+                // Path.Combine will throw if we have invalid characters
+                Path.Combine(folderPath, fileName);
+
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
     }


### PR DESCRIPTION
This is a fix for issue https://github.com/ShareX/ShareX/issues/5816. 

The video converter blows up when the Output path has illegal characters in it. I couldn't see any methods in the Path namespace that check for valid combined paths so I figured move out the validation logic and use the exceptions it gives out.

The result is the output folder path doesn't throw an exception and nothing happens when the convert button is hit. Not great but currently there is no other handling around this

Keen to hear some thoughts