### PR TITLE
fixed #4132: Remember color picker color palette mode selection

### DIFF
--- a/ShareX.HelpersLib/ColorPickerOptions.cs
+++ b/ShareX.HelpersLib/ColorPickerOptions.cs
@@ -1,0 +1,32 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2021 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+namespace ShareX.HelpersLib
+{
+    public class ColorPickerOptions
+    {
+        public bool RecentColorsSelected { get; set; } = true;
+    }
+}

--- a/ShareX.HelpersLib/Controls/ColorButton.cs
+++ b/ShareX.HelpersLib/Controls/ColorButton.cs
@@ -66,6 +66,8 @@ namespace ShareX.HelpersLib
         [DefaultValue(false)]
         public bool ManualButtonClick { get; set; }
 
+        public ColorPickerOptions ColorPickerOptions { get; set; }
+
         private bool isMouseHover;
 
         protected void OnColorChanged(Color color)
@@ -85,7 +87,7 @@ namespace ShareX.HelpersLib
 
         public void ShowColorDialog()
         {
-            if (ColorPickerForm.PickColor(Color, out Color newColor, FindForm()))
+            if (ColorPickerForm.PickColor(Color, out Color newColor, FindForm(), null, ColorPickerOptions))
             {
                 Color = newColor;
             }

--- a/ShareX.HelpersLib/Forms/ColorPickerForm.cs
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.cs
@@ -37,18 +37,34 @@ namespace ShareX.HelpersLib
         public MyColor NewColor { get; private set; }
         public MyColor OldColor { get; private set; }
         public bool IsScreenColorPickerMode { get; private set; }
+        public ColorPickerOptions Options { get; private set; }
 
         private bool oldColorExist;
         private bool controlChangingColor;
         private ControlHider clipboardStatusHider;
 
-        public ColorPickerForm(Color currentColor, bool isScreenColorPickerMode = false, bool checkClipboard = true)
+        public ColorPickerForm(Color currentColor, bool isScreenColorPickerMode = false, bool checkClipboard = true, ColorPickerOptions options = null)
         {
             InitializeComponent();
             ShareXResources.ApplyTheme(this);
             clipboardStatusHider = new ControlHider(btnClipboardStatus, 2000);
 
             IsScreenColorPickerMode = isScreenColorPickerMode;
+            Options = options;
+
+            if (Options == null)
+            {
+                Options = new ColorPickerOptions();
+            }
+
+            if (Options.RecentColorsSelected)
+            {
+                rbRecentColors.Checked = true;
+            }
+            else
+            {
+                rbStandardColors.Checked = true;
+            }
 
             PrepareColorPalette();
             SetCurrentColor(currentColor, !IsScreenColorPickerMode);
@@ -90,9 +106,9 @@ namespace ShareX.HelpersLib
             return false;
         }
 
-        public static bool PickColor(Color currentColor, out Color newColor, Form owner = null, Func<PointInfo> openScreenColorPicker = null)
+        public static bool PickColor(Color currentColor, out Color newColor, Form owner = null, Func<PointInfo> openScreenColorPicker = null, ColorPickerOptions options = null)
         {
-            using (ColorPickerForm dialog = new ColorPickerForm(currentColor))
+            using (ColorPickerForm dialog = new ColorPickerForm(currentColor, options: options))
             {
                 if (openScreenColorPicker != null)
                 {
@@ -116,7 +132,7 @@ namespace ShareX.HelpersLib
 
             Color[] colors;
 
-            if (rbRecentColors.Checked)
+            if (Options.RecentColorsSelected)
             {
                 colors = HelpersOptions.RecentColors.ToArray();
             }
@@ -296,6 +312,8 @@ namespace ShareX.HelpersLib
 
         private void rbRecentColors_CheckedChanged(object sender, EventArgs e)
         {
+            Options.RecentColorsSelected = rbRecentColors.Checked;
+
             PrepareColorPalette();
         }
 

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -104,6 +104,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ColorPickerOptions.cs" />
     <Compile Include="ControlHider.cs" />
     <Compile Include="Controls\ObjectListView.cs">
       <SubType>Component</SubType>

--- a/ShareX.ScreenCaptureLib/Forms/NewImageForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/NewImageForm.cs
@@ -47,6 +47,7 @@ namespace ShareX.ScreenCaptureLib
             nudWidth.Value = Options.EditorNewImageSize.Width;
             nudHeight.Value = Options.EditorNewImageSize.Height;
             cbTransparent.Checked = Options.EditorNewImageTransparent;
+            btnChangeColor.ColorPickerOptions = options.ColorPickerOptions;
             btnChangeColor.Color = options.EditorNewImageBackgroundColor;
         }
 

--- a/ShareX.ScreenCaptureLib/Forms/TextDrawingInputBox.cs
+++ b/ShareX.ScreenCaptureLib/Forms/TextDrawingInputBox.cs
@@ -37,16 +37,18 @@ namespace ShareX.ScreenCaptureLib
     {
         public string InputText { get; private set; }
         public TextDrawingOptions Options { get; private set; }
+        public ColorPickerOptions ColorPickerOptions { get; private set; }
 
         private int processKeyCount;
 
-        public TextDrawingInputBox(string text, TextDrawingOptions options, bool supportGradient)
+        public TextDrawingInputBox(string text, TextDrawingOptions options, bool supportGradient, ColorPickerOptions colorPickerOptions)
         {
             InitializeComponent();
             ShareXResources.ApplyTheme(this);
 
             InputText = text;
             Options = options;
+            ColorPickerOptions = colorPickerOptions;
 
             if (InputText != null)
             {
@@ -67,6 +69,8 @@ namespace ShareX.ScreenCaptureLib
             }
 
             nudTextSize.SetValue(Options.Size);
+
+            btnTextColor.ColorPickerOptions = ColorPickerOptions;
             btnTextColor.Color = Options.Color;
 
             btnGradient.Visible = supportGradient;
@@ -163,7 +167,7 @@ namespace ShareX.ScreenCaptureLib
 
         private void tsmiSecondColor_Click(object sender, EventArgs e)
         {
-            ColorPickerForm.PickColor(Options.Color2, out Color newColor, this);
+            ColorPickerForm.PickColor(Options.Color2, out Color newColor, this, null, ColorPickerOptions);
             Options.Color2 = newColor;
             if (tsmiSecondColor.Image != null) tsmiSecondColor.Image.Dispose();
             tsmiSecondColor.Image = ImageHelpers.CreateColorPickerIcon(Options.Color2, new Rectangle(0, 0, 16, 16));

--- a/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
@@ -100,6 +100,9 @@ namespace ShareX.ScreenCaptureLib
         public List<ImageEffectPreset> ImageEffectPresets = new List<ImageEffectPreset>();
         public int SelectedImageEffectPreset = 0;
 
+        // Color picker
+        public ColorPickerOptions ColorPickerOptions = new ColorPickerOptions();
+
         // Screen color picker
         public string ScreenColorPickerInfoText = "";
     }

--- a/ShareX.ScreenCaptureLib/RegionCaptureTasks.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureTasks.cs
@@ -146,7 +146,7 @@ namespace ShareX.ScreenCaptureLib
         public static void ShowScreenColorPickerDialog(RegionCaptureOptions options)
         {
             Color color = Color.Red;
-            ColorPickerForm colorPickerForm = new ColorPickerForm(color, true);
+            ColorPickerForm colorPickerForm = new ColorPickerForm(color, true, true, options.ColorPickerOptions);
             colorPickerForm.EnableScreenColorPickerButton(() => GetPointInfo(options));
             colorPickerForm.Show();
         }

--- a/ShareX.ScreenCaptureLib/Shapes/Drawing/TextDrawingShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Drawing/TextDrawingShape.cs
@@ -131,7 +131,7 @@ namespace ShareX.ScreenCaptureLib
 
             Manager.Form.Pause();
 
-            using (TextDrawingInputBox inputBox = new TextDrawingInputBox(Text, TextOptions, SupportGradient))
+            using (TextDrawingInputBox inputBox = new TextDrawingInputBox(Text, TextOptions, SupportGradient, Manager.Options.ColorPickerOptions))
             {
                 result = inputBox.ShowDialog(Manager.Form) == DialogResult.OK;
                 Text = inputBox.InputText;

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -2098,7 +2098,7 @@ namespace ShareX.ScreenCaptureLib
                 openScreenColorPicker = () => RegionCaptureTasks.GetPointInfo(Options);
             }
 
-            return ColorPickerForm.PickColor(currentColor, out newColor, Form, openScreenColorPicker);
+            return ColorPickerForm.PickColor(currentColor, out newColor, Form, openScreenColorPicker, Options.ColorPickerOptions);
         }
 
         private void OnCurrentShapeChanged(BaseShape shape)

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -690,7 +690,7 @@ namespace ShareX
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
             taskSettings.CaptureSettings.SurfaceOptions.ScreenColorPickerInfoText = taskSettings.ToolsSettings.ScreenColorPickerInfoText;
 
-            RegionCaptureTasks.ShowScreenColorPickerDialog(taskSettings.CaptureSettings.SurfaceOptions);
+            RegionCaptureTasks.ShowScreenColorPickerDialog(taskSettings.CaptureSettingsReference.SurfaceOptions);
         }
 
         public static void OpenScreenColorPicker(TaskSettings taskSettings = null)


### PR DESCRIPTION
Color palette selection will be saved now:

![](https://jaex.getsharex.com/2021/10/ShareX_vI3t2wmMFX.png)

That way user don't have to select "Standard colors" each time color picker is opened.