### PR TITLE
fixed #4219: Added registry check to allow system admins to disable update check

### DIFF
--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -1007,7 +1007,7 @@ namespace ShareX
 
         private void ConfigureAutoUpdate()
         {
-            Program.UpdateManager.AutoUpdateEnabled = Program.Settings.AutoCheckUpdate && !Program.PortableApps;
+            Program.UpdateManager.AutoUpdateEnabled = !Program.SystemDisableUpdateCheck && Program.Settings.AutoCheckUpdate && !Program.PortableApps;
             Program.UpdateManager.CheckPreReleaseUpdates = Program.Settings.CheckPreReleaseUpdates;
             Program.UpdateManager.ConfigureAutoUpdate();
         }

--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -121,6 +121,7 @@ namespace ShareX
         public static bool PuushMode { get; private set; }
 
         public static bool SystemDisableUpload { get; private set; }
+        public static bool SystemDisableUpdateCheck { get; private set; }
 
         internal static ApplicationConfig Settings { get; set; }
         internal static TaskSettings DefaultTaskSettings { get; set; }
@@ -626,6 +627,7 @@ namespace ShareX
         private static void CheckSystemFlags()
         {
             SystemDisableUpload = CheckSystemFlag("DisableUpload");
+            SystemDisableUpdateCheck = CheckSystemFlag("DisableUpdateCheck");
         }
 
         private static bool CheckSystemFlag(string name)
@@ -721,6 +723,7 @@ namespace ShareX
             if (SteamFirstTimeConfig) flags.Add(nameof(SteamFirstTimeConfig));
             if (IgnoreHotkeyWarning) flags.Add(nameof(IgnoreHotkeyWarning));
             if (SystemDisableUpload) flags.Add(nameof(SystemDisableUpload));
+            if (SystemDisableUpdateCheck) flags.Add(nameof(SystemDisableUpdateCheck));
             if (PuushMode) flags.Add(nameof(PuushMode));
 
             string output = string.Join(", ", flags);

--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -118,8 +118,9 @@ namespace ShareX
         public static bool IsAdmin { get; private set; }
         public static bool SteamFirstTimeConfig { get; private set; }
         public static bool IgnoreHotkeyWarning { get; private set; }
-        public static bool SystemDisableUpload { get; private set; }
         public static bool PuushMode { get; private set; }
+
+        public static bool SystemDisableUpload { get; private set; }
 
         internal static ApplicationConfig Settings { get; set; }
         internal static TaskSettings DefaultTaskSettings { get; set; }
@@ -359,7 +360,7 @@ namespace ShareX
             IgnoreHotkeyWarning = CLI.IsCommandExist("NoHotkeys");
 
             CreateParentFolders();
-            CheckSystemDisableUpload();
+            CheckSystemFlags();
             RegisterExtensions();
             CheckPuushMode();
             DebugWriteFlags();
@@ -622,26 +623,32 @@ namespace ShareX
             return false;
         }
 
-        private static void CheckSystemDisableUpload()
+        private static void CheckSystemFlags()
+        {
+            SystemDisableUpload = CheckSystemFlag("DisableUpload");
+        }
+
+        private static bool CheckSystemFlag(string name)
         {
             try
             {
-                string path = @"SOFTWARE\ShareX";
-                string name = "DisableUpload";
+                const string path = @"SOFTWARE\ShareX";
 
-                if (RegistryHelpers.CheckRegistry(path, name, null, RegistryHive.CurrentUser))
+                if (RegistryHelpers.CheckRegistry(path, name, null, RegistryHive.LocalMachine))
                 {
-                    SystemDisableUpload = RegistryHelpers.CheckRegistry(path, name, "true", RegistryHive.CurrentUser);
+                    return RegistryHelpers.CheckRegistry(path, name, "true", RegistryHive.LocalMachine);
                 }
                 else
                 {
-                    SystemDisableUpload = RegistryHelpers.CheckRegistry(path, name, "true", RegistryHive.LocalMachine);
+                    return RegistryHelpers.CheckRegistry(path, name, "true", RegistryHive.CurrentUser);
                 }
             }
             catch (Exception e)
             {
                 DebugHelper.WriteException(e);
             }
+
+            return false;
         }
 
         private static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)


### PR DESCRIPTION
ShareX first checks `HKEY_LOCAL_MACHINE\SOFTWARE\ShareX` and if it not exists then checks `HKEY_CURRENT_USER\SOFTWARE\ShareX` registry key, so HKLM have priority over HKCU. If `DisableUpdateCheck` string with `true` value is found then ShareX disables auto update checking.