### PR TITLE
fixed #4669: Swap move/resize hotkeys in region capture so arrow keys moves shapes instead of resize

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -758,18 +758,20 @@ namespace ShareX.ScreenCaptureLib
                 {
                     Cursor.Position = Cursor.Position.Add(x, y);
                 }
+                else if (e.Control)
+                {
+                    shape.OnResizing();
+                    shape.Resize(x, y, true);
+                }
+                else if (e.Alt)
+                {
+                    shape.OnResizing();
+                    shape.Resize(x, y, false);
+                }
                 else
                 {
-                    if (e.Control)
-                    {
-                        shape.OnMoving();
-                        shape.Move(x, y);
-                    }
-                    else
-                    {
-                        shape.OnResizing();
-                        shape.Resize(x, y, !e.Alt);
-                    }
+                    shape.OnMoving();
+                    shape.Move(x, y);
                 }
             }
         }


### PR DESCRIPTION
Swap resize key with move key in region capture so arrow keys moves shapes instead of resize.

Keybinds after change:

<kbd>Arrow keys</kbd> = Move cursor / Move current shape
<kbd>Ctrl + Arrow keys</kbd> = Resize current shape from bottom right corner
<kbd>Alt + Arrow keys</kbd> = Resize current shape from top left corner
<kbd>Shift + Arrow keys</kbd> = Resize or move faster