### PR TITLE
Fix FPS limit not applying preference

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -106,7 +106,7 @@ namespace ShareX.ScreenCaptureLib
             timerStart = new Stopwatch();
             FPSManager = new FPSManager()
             {
-                FPSLimit = 100
+                FPSLimit = Options.FPSLimit
             };
             FPSManager.FPSUpdated += FpsManager_FPSChanged;
             regionAnimation = new RectangleAnimation()


### PR DESCRIPTION
FPS limit would save, but not take effect on new capture until bumped