### PR TITLE
Fix panning regression (panning at limit accumulates invisible changes)

### DIFF
--- a/ShareX.ScreenCaptureLib/RegionHelpers/ImageEditorScrollbar.cs
+++ b/ShareX.ScreenCaptureLib/RegionHelpers/ImageEditorScrollbar.cs
@@ -198,16 +198,10 @@ namespace ShareX.ScreenCaptureLib
 
             float centerOffsetNew = ((trackLengthInternal / 2.0f) - mousePositionLocal) / trackLengthInternal * inImageSize;
 
-            if (Orientation == Orientation.Horizontal)
-            {
-                form.CanvasCenterOffset = new Vector2(centerOffsetNew, form.CanvasCenterOffset.Y);
-            }
-            else
-            {
-                form.CanvasCenterOffset = new Vector2(form.CanvasCenterOffset.X, centerOffsetNew);
-            }
-
-            form.AutomaticPan();
+            Vector2 canvasCenterOffset = Orientation == Orientation.Horizontal
+                ? new Vector2(centerOffsetNew, form.CanvasCenterOffset.Y)
+                : new Vector2(form.CanvasCenterOffset.X, centerOffsetNew);
+            form.PanToOffset(canvasCenterOffset);
         }
     }
 }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1029,7 +1029,6 @@ namespace ShareX.ScreenCaptureLib
         private void StartPanning()
         {
             IsPanning = true;
-            Form.PanningStrech = new Point(0, 0);
             Options.ShowEditorPanTip = false;
         }
 


### PR DESCRIPTION
This is a fix for [the issue Jaex reported](https://github.com/ShareX/ShareX/pull/6108#issuecomment-1046174097) after the floating point merge.

Minor refactor.  The only routine that updates CanvasCenterOffset now is PanToOffset (replacing AutomaticPan), and this only updates the offset if a pan actually occurred (i.e. the pan wasn't constrained because we're at the pan limit).