### PR TITLE
Add Pin to Top button to Inspect Window tool

### DIFF
--- a/ShareX/Forms/InspectWindowForm.Designer.cs
+++ b/ShareX/Forms/InspectWindowForm.Designer.cs
@@ -35,6 +35,7 @@ namespace ShareX
             this.btnInspectWindow = new System.Windows.Forms.Button();
             this.btnInspectControl = new System.Windows.Forms.Button();
             this.btnRefresh = new System.Windows.Forms.Button();
+            this.btnPinToTop = new System.Windows.Forms.Button();
             this.pInfo.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -74,10 +75,18 @@ namespace ShareX
             this.btnRefresh.UseVisualStyleBackColor = true;
             this.btnRefresh.Click += new System.EventHandler(this.btnRefresh_Click);
             // 
+            // btnPinToTop
+            // 
+            resources.ApplyResources(this.btnPinToTop, "btnPinToTop");
+            this.btnPinToTop.Name = "btnPinToTop";
+            this.btnPinToTop.UseVisualStyleBackColor = true;
+            this.btnPinToTop.Click += new System.EventHandler(this.btnPinToTop_Click);
+            // 
             // InspectWindowForm
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnPinToTop);
             this.Controls.Add(this.btnRefresh);
             this.Controls.Add(this.btnInspectControl);
             this.Controls.Add(this.btnInspectWindow);
@@ -95,5 +104,6 @@ namespace ShareX
         private System.Windows.Forms.Button btnInspectWindow;
         private System.Windows.Forms.Button btnInspectControl;
         private System.Windows.Forms.Button btnRefresh;
+        private System.Windows.Forms.Button btnPinToTop;
     }
 }

--- a/ShareX/Forms/InspectWindowForm.cs
+++ b/ShareX/Forms/InspectWindowForm.cs
@@ -124,5 +124,17 @@ namespace ShareX
         {
             UpdateWindowInfo();
         }
+
+        private void btnPinToTop_Click(object sender, EventArgs e)
+        {
+            if (SelectedWindow == null) return;
+            // Determine current Pinned status to toggle pin
+            IntPtr style = NativeMethods.GetWindowLong(SelectedWindow.Handle, NativeConstants.GWL_EXSTYLE);
+            SpecialWindowHandles flag = (style.ToInt32() & (int)WindowStyles.WS_EX_TOPMOST) != 0 ?
+                SpecialWindowHandles.HWND_NOTOPMOST : SpecialWindowHandles.HWND_TOPMOST;
+
+            NativeMethods.SetWindowPos(SelectedWindow.Handle, (IntPtr)flag,
+                0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE);
+        }
     }
 }

--- a/ShareX/Forms/InspectWindowForm.resx
+++ b/ShareX/Forms/InspectWindowForm.resx
@@ -135,6 +135,9 @@
   <data name="rtbInfo.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
+  <data name="rtbInfo.Text" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;rtbInfo.Name" xml:space="preserve">
     <value>rtbInfo</value>
   </data>
@@ -172,7 +175,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pInfo.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="btnInspectWindow.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 8</value>
@@ -196,7 +199,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnInspectWindow.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnInspectControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>160, 8</value>
@@ -220,7 +223,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnInspectControl.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="btnRefresh.Location" type="System.Drawing.Point, System.Drawing">
     <value>312, 8</value>
@@ -244,6 +247,30 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRefresh.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnPinToTop.Location" type="System.Drawing.Point, System.Drawing">
+    <value>460, 8</value>
+  </data>
+  <data name="btnPinToTop.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 23</value>
+  </data>
+  <data name="btnPinToTop.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnPinToTop.Text" xml:space="preserve">
+    <value>Pin to Top</value>
+  </data>
+  <data name="&gt;&gt;btnPinToTop.Name" xml:space="preserve">
+    <value>btnPinToTop</value>
+  </data>
+  <data name="&gt;&gt;btnPinToTop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnPinToTop.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnPinToTop.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/ShareX/Forms/InspectWindowForm.resx
+++ b/ShareX/Forms/InspectWindowForm.resx
@@ -250,16 +250,16 @@
     <value>1</value>
   </data>
   <data name="btnPinToTop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>460, 8</value>
+    <value>464, 8</value>
   </data>
   <data name="btnPinToTop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 23</value>
+    <value>144, 24</value>
   </data>
   <data name="btnPinToTop.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="btnPinToTop.Text" xml:space="preserve">
-    <value>Pin to Top</value>
+    <value>Pin to top</value>
   </data>
   <data name="&gt;&gt;btnPinToTop.Name" xml:space="preserve">
     <value>btnPinToTop</value>


### PR DESCRIPTION
This adds a "Pin to Top" button to the "Inspect Window" tool.
When pressed, the button will set the currently inspecting window as
"HWND_TOPMOST" (or "HWND_NOTOPMOST" if it was already TOPMOST)

![image](https://user-images.githubusercontent.com/29953391/156786381-903413cf-9660-46a6-a49d-d3751b09ff4f.png)

This has the effect of the window always staying in front of other windows, which is just a useful utility tool
which i thought would best fit into Inspect Window.

This is my first pull request to ShareX and i wasn't able to find commit guidelines anywhere, so please review this pull
and LMK if i i'm doing something wrong ^^