### PR TITLE
Add Vultur (s3 compatible) Block Storage

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -106,6 +106,7 @@ namespace ShareX.UploadersLib.FileUploaders
             new AmazonS3Endpoint("DigitalOcean (New York)", "nyc3.digitaloceanspaces.com", "nyc3"),
             new AmazonS3Endpoint("DigitalOcean (San Francisco)", "sfo2.digitaloceanspaces.com", "sfo2"),
             new AmazonS3Endpoint("DigitalOcean (Singapore)", "sgp1.digitaloceanspaces.com", "sgp1"),
+            new AmazonS3Endpoint("Vultr (New Jersey)", "ewr1.vultrobjects.com", "us-east-1"),
             new AmazonS3Endpoint("Wasabi", "s3.wasabisys.com")
         };
 


### PR DESCRIPTION
Not sure why the diff picked up every line changing, but the main change is the inclusion of S3 type storage from Vultr, similar to Digital Ocean. Their endpoint and AWS S3 Region are included in this