### PR TITLE
Switched ctrl+c and ctrl+shift+c behaviors, updated resource files as well

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -654,7 +654,7 @@ namespace ShareX.ScreenCaptureLib
                 case Keys.Oemtilde:
                     CloseWindow(RegionResult.ActiveMonitor);
                     break;
-                case Keys.Control | Keys.C:
+                case Keys.Control | Keys.Shift | Keys.C:
                     CopyAreaInfo();
                     break;
                 case Keys.Control | Keys.Alt | Keys.D0:

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1780,7 +1780,7 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy image to clipboard (Ctrl + Shift + C).
+        ///   Looks up a localized string similar to Copy image to clipboard (Ctrl + C).
         /// </summary>
         internal static string ShapeManager_CreateToolbar_CopyImageToClipboard {
             get {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
@@ -254,7 +254,7 @@
     <value>ادامه دادن وظیفه (کلید space یا راست کلیک)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>کپی کردن تصویر به کلیپ بورد (CTRL + SHIFT + C)</value>
+    <value>کپی کردن تصویر به کلیپ بورد (CTRL + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>بریدن عکس ...</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
@@ -256,7 +256,7 @@
     <value>Lanjutkan tugas (Spasi atau klik kanan)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Salin gambar ke papan klip (Ctrl + Shift + C)</value>
+    <value>Salin gambar ke papan klip (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
     <value>Radius sudut:</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
@@ -295,7 +295,7 @@
     <value>Força de ampliação:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiar imagem para a área de transferência (Ctrl + Shift + C)</value>
+    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Imprimir imagem ... (Ctrl + P)</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
@@ -211,7 +211,7 @@
     <value>Capturar</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiar imagem para a área de transferência (Ctrl + Shift + C)</value>
+    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Imprimir imagem... (Ctrl + P)</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -329,7 +329,7 @@
     <value>..\Resources\layout-split.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copy image to clipboard (Ctrl + Shift + C)</value>
+    <value>Copy image to clipboard (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Print image... (Ctrl + P)</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
@@ -316,7 +316,7 @@
     <value>Son bölgeyi yakala</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Resimi panoya kopyala (Ctrl + Shift + C)</value>
+    <value>Resimi panoya kopyala (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>Resimi kırp...</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
@@ -214,7 +214,7 @@
     <value>Tiếp tục tác vụ (Phím cách hoặc chuột phải)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Chép ảnh vào vùng nhớ tạm (Ctrl + Shift + C)</value>
+    <value>Chép ảnh vào vùng nhớ tạm (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
     <value>Bán kính góc:</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
@@ -301,7 +301,7 @@
     <value>繼續任務 (空白鍵或滑鼠右鍵)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>將圖片複製到剪貼簿 (Ctrl + Shift + C)</value>
+    <value>將圖片複製到剪貼簿 (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>裁切圖片...</value>

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -729,7 +729,7 @@ namespace ShareX.ScreenCaptureLib
                         case Keys.Control | Keys.Shift | Keys.S:
                             Form.OnSaveImageAsRequested();
                             break;
-                        case Keys.Control | Keys.Shift | Keys.C:
+                        case Keys.Control | Keys.C:
                             Form.OnCopyImageRequested();
                             break;
                         case Keys.Control | Keys.U:


### PR DESCRIPTION
While using the image editor, I found it much more convenient to have Ctrl + C be the keybind that copies the current state of the image. A friend of mine as well as I sometimes edit a singular photo multiple times (ex. drawing circles around features within an image we want to highlight, but one at a time) and we would like to avoid having to press an extra key to do default copy behavior. 

This should only affect the image editor, and new uses will be able to avoid having info data overwrite their clipboards in region select mode because of muscle memory. 