### PR TITLE
Change url prefix addition in S3 uploader

### DIFF
--- a/ShareX.HelpersLib/Helpers/URLHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/URLHelpers.cs
@@ -420,6 +420,11 @@ namespace ShareX.HelpersLib
         {
             return URLPrefixes.Any(x => url.StartsWith(x, StringComparison.InvariantCultureIgnoreCase));
         }
+        
+        public static string GetPrefix(string url)
+        {
+            return URLPrefixes.Find(x => url.StartsWith(x, StringComparison.InvariantCultureIgnoreCase));
+        }
 
         public static string FixPrefix(string url, string prefix = "http://")
         {

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -125,8 +125,8 @@ namespace ShareX.UploadersLib.FileUploaders
                 isPathStyleRequest = true;
             }
 
-            string endpoint = URLHelpers.RemovePrefixes(Settings.Endpoint);
-            string host = isPathStyleRequest ? endpoint : $"{Settings.Bucket}.{endpoint}";
+            string endpoint = isPathStyleRequest ? Settings.Endpoint : Settings.Bucket + "." + URLHelpers.RemovePrefixes(Settings.Endpoint)
+            string host = URLHelpers.RemovePrefixes(endpoint);
             string algorithm = "AWS4-HMAC-SHA256";
             string credentialDate = DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
             string region = GetRegion();
@@ -205,7 +205,7 @@ namespace ShareX.UploadersLib.FileUploaders
             headers.Remove("Host");
             headers.Remove("Content-Type");
 
-            string url = URLHelpers.CombineURL(host, canonicalURI);
+            string url = URLHelpers.CombineURL(endpoint, canonicalURI);
             url = URLHelpers.FixPrefix(url, "https://");
 
             SendRequest(HttpMethod.PUT, url, stream, contentType, null, headers);

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -125,8 +125,9 @@ namespace ShareX.UploadersLib.FileUploaders
                 isPathStyleRequest = true;
             }
 
-            string endpoint = isPathStyleRequest ? Settings.Endpoint : Settings.Bucket + "." + URLHelpers.RemovePrefixes(Settings.Endpoint);
-            string host = URLHelpers.RemovePrefixes(endpoint);
+            string scheme = URLHelpers.GetPrefix(Settings.Endpoint);
+            string endpoint = URLHelpers.RemovePrefixes(Settings.Endpoint);
+            string host = isPathStyleRequest ? endpoint : $"{Settings.Bucket}.{endpoint}";
             string algorithm = "AWS4-HMAC-SHA256";
             string credentialDate = DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
             string region = GetRegion();
@@ -205,7 +206,7 @@ namespace ShareX.UploadersLib.FileUploaders
             headers.Remove("Host");
             headers.Remove("Content-Type");
 
-            string url = URLHelpers.CombineURL(endpoint, canonicalURI);
+            string url = URLHelpers.CombineURL(scheme + endpoint, canonicalURI);
             url = URLHelpers.FixPrefix(url, "https://");
 
             SendRequest(HttpMethod.PUT, url, stream, contentType, null, headers);

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -125,7 +125,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 isPathStyleRequest = true;
             }
 
-            string endpoint = isPathStyleRequest ? Settings.Endpoint : Settings.Bucket + "." + URLHelpers.RemovePrefixes(Settings.Endpoint)
+            string endpoint = isPathStyleRequest ? Settings.Endpoint : Settings.Bucket + "." + URLHelpers.RemovePrefixes(Settings.Endpoint);
             string host = URLHelpers.RemovePrefixes(endpoint);
             string algorithm = "AWS4-HMAC-SHA256";
             string credentialDate = DateTime.UtcNow.ToString("yyyyMMdd", CultureInfo.InvariantCulture);

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -206,7 +206,7 @@ namespace ShareX.UploadersLib.FileUploaders
             headers.Remove("Content-Type");
 
             string url = URLHelpers.CombineURL(host, canonicalURI);
-            url = URLHelpers.ForcePrefix(url, "https://");
+            url = URLHelpers.FixPrefix(url, "https://");
 
             SendRequest(HttpMethod.PUT, url, stream, contentType, null, headers);
 

--- a/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
+++ b/ShareX.UploadersLib/FileUploaders/AmazonS3.cs
@@ -206,7 +206,7 @@ namespace ShareX.UploadersLib.FileUploaders
             headers.Remove("Host");
             headers.Remove("Content-Type");
 
-            string url = URLHelpers.CombineURL(scheme + endpoint, canonicalURI);
+            string url = URLHelpers.CombineURL(scheme + host, canonicalURI);
             url = URLHelpers.FixPrefix(url, "https://");
 
             SendRequest(HttpMethod.PUT, url, stream, contentType, null, headers);


### PR DESCRIPTION
Hosting a local version of an S3 compatible service like MinIO doesn't require https, but the uploader forces https no matter what. If the user specifies that it should be uploaded with http then it should use http.

Related issue #6228 