### PR TITLE
Ensure proper saving of settings on file shares

### DIFF
--- a/ShareX.HelpersLib/Settings/SettingsBase.cs
+++ b/ShareX.HelpersLib/Settings/SettingsBase.cs
@@ -157,7 +157,7 @@ namespace ShareX.HelpersLib
                                 FileHelpers.CreateDirectory(BackupFolder);
                             }
 
-                            File.Replace(tempFilePath, filePath, backupFilePath);
+                            File.Replace(tempFilePath, filePath, backupFilePath, true);
                         }
                         else
                         {


### PR DESCRIPTION
On Windows file shares (DFS) with restricted WRITE_DAC permission, the method File.Replace results in a System.UnauthorizedAccessException, even when the user has full permissions to interact with the file and folder. This configuration can commonly be found in business environments.

By setting the flag ignoreMetadataErrors to true, errors related to attributes and ACL are ignored. This results in the settings being saved correctly. Normal errors during file operation are not suppressed with this change, they should fail as usual. Attributes and permissions should not be affected either as long as the permission to set them is present. 

Reference: https://stackoverflow.com/questions/59062659/file-replace-doesnt-work-on-shared-driver

Example of the error:

```
2022-07-12 08:54:13.531 - ShareX starting.
2022-07-12 08:54:13.534 - Version: 14.0.1
2022-07-12 08:54:13.534 - Build: Release
2022-07-12 08:54:13.534 - Command line: "C:\Program Files\ShareX\ShareX.exe" 
2022-07-12 08:54:13.534 - Personal path: \\[redacted]\[redacted]\makuhlmann\ShareX
2022-07-12 08:54:13.535 - Operating system: Windows 10 Enterprise (64-bit)
2022-07-12 08:54:13.535 - Running as elevated process: False
2022-07-12 08:54:13.562 - Flags: DisableUpdateCheck
2022-07-12 08:54:13.585 - ApplicationConfig load started: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:13.970 - ApplicationConfig load finished: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:13.979 - Language changed to: Deutsch (Deutschland)
2022-07-12 08:54:13.980 - MainForm init started.
2022-07-12 08:54:13.982 - UploadersConfig load started: \\[redacted]\[redacted]\makuhlmann\ShareX\UploadersConfig.json
2022-07-12 08:54:14.089 - UploadersConfig load finished: \\[redacted]\[redacted]\makuhlmann\ShareX\UploadersConfig.json
2022-07-12 08:54:14.102 - HotkeysConfig load started: \\[redacted]\[redacted]\makuhlmann\ShareX\HotkeysConfig.json
2022-07-12 08:54:14.237 - HotkeysConfig load finished: \\[redacted]\[redacted]\makuhlmann\ShareX\HotkeysConfig.json
2022-07-12 08:54:14.373 - MainForm init finished.
2022-07-12 08:54:14.503 - Startup time: 1009 ms
2022-07-12 08:54:14.524 - Hotkey registered: Hotkey: Ctrl + Print Screen, Description: Bereich aufnehmen, Job: RectangleRegion
2022-07-12 08:54:14.525 - Hotkey registered: Hotkey: Print Screen, Description: Gesamten Bildschirm aufnehmen, Job: PrintScreen
2022-07-12 08:54:14.525 - Hotkey registered: Hotkey: Alt + Print Screen, Description: Aktives Fenster aufnehmen, Job: ActiveWindow
2022-07-12 08:54:14.525 - Hotkey registered: Hotkey: Shift + Print Screen, Description: Bildschirmaufzeichnung, Job: ScreenRecorder
2022-07-12 08:54:14.525 - Hotkey registered: Hotkey: Ctrl + Shift + Print Screen, Description: Bildschirmaufzeichnung (GIF), Job: ScreenRecorderGIF
2022-07-12 08:54:14.526 - HotkeyManager started.
2022-07-12 08:54:14.527 - WatchFolderManager started.
2022-07-12 08:54:17.595 - ApplicationConfig save started: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:17.818 - Exception:
System.UnauthorizedAccessException: Der Zugriff auf den Pfad wurde verweigert.
   bei System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   bei System.IO.File.InternalReplace(String sourceFileName, String destinationFileName, String destinationBackupFileName, Boolean ignoreMetadataErrors)
   bei ShareX.HelpersLib.SettingsBase`1.SaveInternal(String filePath)
2022-07-12 08:54:17.856 - ApplicationConfig save failed: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:18.490 - ApplicationConfig save started: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:18.490 - UploadersConfig save started: \\[redacted]\[redacted]\makuhlmann\ShareX\UploadersConfig.json
2022-07-12 08:54:18.491 - HotkeysConfig save started: \\[redacted]\[redacted]\makuhlmann\ShareX\HotkeysConfig.json
2022-07-12 08:54:18.618 - Exception:
System.UnauthorizedAccessException: Der Zugriff auf den Pfad wurde verweigert.
   bei System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   bei System.IO.File.InternalReplace(String sourceFileName, String destinationFileName, String destinationBackupFileName, Boolean ignoreMetadataErrors)
   bei ShareX.HelpersLib.SettingsBase`1.SaveInternal(String filePath)
2022-07-12 08:54:18.618 - UploadersConfig save failed: \\[redacted]\[redacted]\makuhlmann\ShareX\UploadersConfig.json
2022-07-12 08:54:18.692 - Exception:
System.UnauthorizedAccessException: Der Zugriff auf den Pfad wurde verweigert.
   bei System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   bei System.IO.File.InternalReplace(String sourceFileName, String destinationFileName, String destinationBackupFileName, Boolean ignoreMetadataErrors)
   bei ShareX.HelpersLib.SettingsBase`1.SaveInternal(String filePath)
2022-07-12 08:54:18.695 - ApplicationConfig save failed: \\[redacted]\[redacted]\makuhlmann\ShareX\ApplicationConfig.json
2022-07-12 08:54:18.707 - Exception:
System.UnauthorizedAccessException: Der Zugriff auf den Pfad wurde verweigert.
   bei System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   bei System.IO.File.InternalReplace(String sourceFileName, String destinationFileName, String destinationBackupFileName, Boolean ignoreMetadataErrors)
   bei ShareX.HelpersLib.SettingsBase`1.SaveInternal(String filePath)
2022-07-12 08:54:18.707 - HotkeysConfig save failed: \\[redacted]\[redacted]\makuhlmann\ShareX\HotkeysConfig.json
```