### PR TITLE
Change "中止" to "取消"

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/ScreenRecordForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/ScreenRecordForm.zh-CN.resx
@@ -121,7 +121,7 @@
     <value>ShareX - 屏幕录制</value>
   </data>
   <data name="btnAbort.Text" xml:space="preserve">
-    <value>中止</value>
+    <value>取消</value>
   </data>
   <data name="btnStart.Text" xml:space="preserve">
     <value>开始</value>

--- a/ShareX/Forms/TaskSettingsForm.zh-CN.resx
+++ b/ShareX/Forms/TaskSettingsForm.zh-CN.resx
@@ -511,7 +511,7 @@
     <value>使用无损编码录制，并应用用户编码选项</value>
   </data>
   <data name="cbScreenRecordConfirmAbort.Text" xml:space="preserve">
-    <value>中止时确认</value>
+    <value>取消时确认</value>
   </data>
   <data name="cbCaptureOCRAutoCopy.Text" xml:space="preserve">
     <value>自动复制结果至剪贴板</value>


### PR DESCRIPTION
The meaning of "中止" in Chinese is very similar to stopping (“停止”), but what is expressed here is actually the meaning of "canceling" (“取消”), so it is better to change "中止" to "取消".