### PR TITLE
Widen Video Converter Form to fit translated lines

### DIFF
--- a/ShareX.MediaLib/Forms/VideoConverterForm.resx
+++ b/ShareX.MediaLib/Forms/VideoConverterForm.resx
@@ -147,10 +147,10 @@
     <value>16</value>
   </data>
   <data name="txtInputFilePath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 12</value>
+    <value>162, 12</value>
   </data>
   <data name="txtInputFilePath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>340, 20</value>
   </data>
   <data name="txtInputFilePath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -168,7 +168,7 @@
     <value>15</value>
   </data>
   <data name="btnInputFilePathBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>408, 11</value>
+    <value>510, 11</value>
   </data>
   <data name="btnInputFilePathBrowse.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 23</value>
@@ -193,10 +193,10 @@
     <value>14</value>
   </data>
   <data name="txtOutputFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 36</value>
+    <value>162, 36</value>
   </data>
   <data name="txtOutputFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>340, 20</value>
   </data>
   <data name="txtOutputFolder.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -241,7 +241,7 @@
     <value>11</value>
   </data>
   <data name="btnOutputFolderBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>408, 35</value>
+    <value>510, 35</value>
   </data>
   <data name="btnOutputFolderBrowse.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 23</value>
@@ -293,10 +293,10 @@
     <value>6</value>
   </data>
   <data name="txtOutputFileName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 60</value>
+    <value>162, 60</value>
   </data>
   <data name="txtOutputFileName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>340, 20</value>
   </data>
   <data name="txtOutputFileName.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -425,7 +425,7 @@
     <value>True</value>
   </data>
   <data name="txtArguments.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 80</value>
+    <value>526, 80</value>
   </data>
   <data name="txtArguments.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -449,7 +449,7 @@
     <value>112, 123</value>
   </data>
   <data name="tbVideoQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 22</value>
+    <value>398, 22</value>
   </data>
   <data name="tbVideoQuality.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -470,7 +470,7 @@
     <value>True</value>
   </data>
   <data name="lblVideoQualityValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>413, 126</value>
+    <value>515, 126</value>
   </data>
   <data name="lblVideoQualityValue.Size" type="System.Drawing.Size, System.Drawing">
     <value>13, 13</value>
@@ -495,16 +495,16 @@
     <value>0</value>
   </data>
   <data name="lblVideoQualityHigher.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 146</value>
+    <value>323, 146</value>
   </data>
   <data name="lblVideoQualityHigher.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 22</value>
+    <value>182, 22</value>
   </data>
   <data name="lblVideoQualityHigher.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
   <data name="lblVideoQualityHigher.Text" xml:space="preserve">
-    <value>-&gt;</value>
+    <value>Xxxxxxxxxxxxxxxxxxxxxxxxxxxx -&gt;   99</value>
     <comment>@Invariant</comment>
   </data>
   <data name="lblVideoQualityHigher.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -526,13 +526,13 @@
     <value>117, 146</value>
   </data>
   <data name="lblVideoQualityLower.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 22</value>
+    <value>192, 22</value>
   </data>
   <data name="lblVideoQualityLower.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
   <data name="lblVideoQualityLower.Text" xml:space="preserve">
-    <value>&lt;-</value>
+    <value>99   &lt;- Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</value>
     <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblVideoQualityLower.Name" xml:space="preserve">
@@ -636,7 +636,7 @@
     <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>456, 278</value>
+    <value>558, 278</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>


### PR DESCRIPTION
- widen the form by 102 pixels
- widen and move some elements accordingly
- change the default text for lower/higher video quality to represent real world line lengths in the form designer

Before (Romanian):
![image](https://user-images.githubusercontent.com/6942070/180895251-e6c4bd20-63e8-4efa-a04b-0daba0b81565.png)
After (Romanian):
![image](https://user-images.githubusercontent.com/6942070/180895329-53fb61e3-7e6f-47c2-8718-10de9733379f.png)

Before (English):
![image](https://user-images.githubusercontent.com/6942070/180895448-ee84136f-b860-461b-a8e0-d2b270857d94.png)
After (English):
![image](https://user-images.githubusercontent.com/6942070/180895508-2fbfdb04-992c-40c4-99c8-cd68f9bc5cc2.png)

Designer:
![image](https://user-images.githubusercontent.com/6942070/180895654-111ceba5-893e-4c0c-a424-a4a90f62bdfe.png)
