### PR TITLE
Make resize nodes more stable

### DIFF
--- a/ShareX.ScreenCaptureLib/RegionHelpers/ResizeNode.cs
+++ b/ShareX.ScreenCaptureLib/RegionHelpers/ResizeNode.cs
@@ -100,7 +100,7 @@ namespace ShareX.ScreenCaptureLib
             switch (Shape)
             {
                 case NodeShape.Square:
-                    g.DrawRectangle(Pens.White, rect.Offset(-1).Round());
+                    g.DrawRectangle(Pens.White, rect.Round().Offset(-1));
                     g.DrawRectangle(Pens.Black, rect.Round());
                     break;
                 default:
@@ -109,7 +109,7 @@ namespace ShareX.ScreenCaptureLib
                     g.DrawEllipse(Pens.Black, rect);
                     break;
                 case NodeShape.Diamond:
-                    g.DrawDiamond(Pens.White, rect.Offset(-1).Round());
+                    g.DrawDiamond(Pens.White, rect.Round().Offset(-1));
                     g.DrawDiamond(Pens.Black, rect.Round());
                     break;
                 case NodeShape.CustomNode when CustomNodeImage != null:


### PR DESCRIPTION
When resizing an element I could observe resize nodes glitching out a bit
### Before (sometimes during resize)
![image](https://user-images.githubusercontent.com/6942070/182005864-ea695e30-6c60-482a-bea6-ddddb7fbb23b.png)
![AszKwjwjn8](https://user-images.githubusercontent.com/6942070/182006021-8fbb28c9-fdb1-4f8c-ab16-2bd39eda6f32.gif)

### After (always stable)
![image](https://user-images.githubusercontent.com/6942070/182005909-6601e11c-4f8e-465e-b012-61d242846478.png)


