### PR TITLE
Add Cut Out tool

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -213,7 +213,7 @@ namespace ShareX.HelpersLib
         RomanNumeralsLowercase
     }
 
-    public enum CutOutEffectType // Localized (probably)
+    public enum CutOutEffectType // TODO: localize
     {
         None,
         ZigZag,

--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -218,7 +218,6 @@ namespace ShareX.HelpersLib
         None,
         ZigZag,
         TornEdge,
-        Wave,
-        Gradient
+        Wave
     }
 }

--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -212,4 +212,13 @@ namespace ShareX.HelpersLib
         RomanNumeralsUppercase,
         RomanNumeralsLowercase
     }
+
+    public enum CutOutEffectType // Localized (probably)
+    {
+        None,
+        ZigZag,
+        TornEdge,
+        Wave,
+        Gradient
+    }
 }

--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -213,7 +213,7 @@ namespace ShareX.HelpersLib
         RomanNumeralsLowercase
     }
 
-    public enum CutOutEffectType // TODO: localize
+    public enum CutOutEffectType // Localized
     {
         None,
         ZigZag,

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -231,10 +231,10 @@ namespace ShareX.HelpersLib
                     return bmp;
 
                 case CutOutEffectType.ZigZag:
-                    return bmp;
+                    return TornEdges(bmp, effectSize, effectSize, effectEdge, false, false);
 
                 case CutOutEffectType.TornEdge:
-                    return TornEdges(bmp, effectSize, effectSize * 2, effectEdge, false);
+                    return TornEdges(bmp, effectSize, effectSize * 2, effectEdge, false, true);
 
                 case CutOutEffectType.Wave:
                     return WavyEdges(bmp, effectSize, effectSize * 5, effectEdge);
@@ -1749,7 +1749,7 @@ namespace ShareX.HelpersLib
             return bmp;
         }
 
-        public static Bitmap TornEdges(Bitmap bmp, int tornDepth, int tornRange, AnchorStyles sides, bool curvedEdges)
+        public static Bitmap TornEdges(Bitmap bmp, int tornDepth, int tornRange, AnchorStyles sides, bool curvedEdges, bool random)
         {
             if (tornDepth < 1 || tornRange < 1 || sides == AnchorStyles.None)
             {
@@ -1768,53 +1768,57 @@ namespace ShareX.HelpersLib
 
             if (sides.HasFlag(AnchorStyles.Top) && horizontalTornCount > 1)
             {
-                for (int x = 0; x < horizontalTornCount - 1; x++)
+                for (int x = 0; x < bmp.Width; x += tornRange)
                 {
-                    points.Add(new Point(tornRange * x, RandomFast.Next(0, tornDepth)));
+                    int y = random ? RandomFast.Next(0, tornDepth) : ((x / tornRange) & 1) * tornDepth;
+                    points.Add(new Point(x, y));
                 }
             }
             else
             {
                 points.Add(new Point(0, 0));
-                points.Add(new Point(bmp.Width - 1, 0));
+                points.Add(new Point(bmp.Width, 0));
             }
 
             if (sides.HasFlag(AnchorStyles.Right) && verticalTornCount > 1)
             {
-                for (int y = 0; y < verticalTornCount - 1; y++)
+                for (int y = 0; y < bmp.Height; y += tornRange)
                 {
-                    points.Add(new Point(bmp.Width - 1 - RandomFast.Next(0, tornDepth), tornRange * y));
+                    int x = random ? RandomFast.Next(0, tornDepth) : ((y / tornRange) & 1) * tornDepth;
+                    points.Add(new Point(bmp.Width - tornDepth + x, y));
                 }
             }
             else
             {
-                points.Add(new Point(bmp.Width - 1, 0));
-                points.Add(new Point(bmp.Width - 1, bmp.Height - 1));
+                points.Add(new Point(bmp.Width, 0));
+                points.Add(new Point(bmp.Width, bmp.Height));
             }
 
             if (sides.HasFlag(AnchorStyles.Bottom) && horizontalTornCount > 1)
             {
-                for (int x = 0; x < horizontalTornCount - 1; x++)
+                for (int x = bmp.Width; x >= 0; x = (x / tornRange - 1) * tornRange)
                 {
-                    points.Add(new Point(bmp.Width - 1 - (tornRange * x), bmp.Height - 1 - RandomFast.Next(0, tornDepth)));
+                    int y = random ? RandomFast.Next(0, tornDepth) : ((x / tornRange) & 1) * tornDepth;
+                    points.Add(new Point(x, bmp.Height - tornDepth + y));
                 }
             }
             else
             {
-                points.Add(new Point(bmp.Width - 1, bmp.Height - 1));
-                points.Add(new Point(0, bmp.Height - 1));
+                points.Add(new Point(bmp.Width, bmp.Height));
+                points.Add(new Point(0, bmp.Height));
             }
 
             if (sides.HasFlag(AnchorStyles.Left) && verticalTornCount > 1)
             {
-                for (int y = 0; y < verticalTornCount - 1; y++)
+                for (int y = bmp.Height; y >= 0; y = (y / tornRange - 1) * tornRange)
                 {
-                    points.Add(new Point(RandomFast.Next(0, tornDepth), bmp.Height - 1 - (tornRange * y)));
+                    int x = random ? RandomFast.Next(0, tornDepth) : ((y / tornRange) & 1) * tornDepth;
+                    points.Add(new Point(x, y));
                 }
             }
             else
             {
-                points.Add(new Point(0, bmp.Height - 1));
+                points.Add(new Point(0, bmp.Height));
                 points.Add(new Point(0, 0));
             }
 

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -223,7 +223,7 @@ namespace ShareX.HelpersLib
             return null;
         }
 
-        public static Bitmap TrimBitmapInteriorHorizontal(Bitmap bmp, int x, int width)
+        public static Bitmap CutOutBitmapMiddleHorizontal(Bitmap bmp, int x, int width)
         {
             if (bmp != null && width > 0)
             {
@@ -255,7 +255,7 @@ namespace ShareX.HelpersLib
             return null;
         }
 
-        public static Bitmap TrimBitmapInteriorVertical(Bitmap bmp, int y, int height)
+        public static Bitmap CutOutBitmapMiddleVertical(Bitmap bmp, int y, int height)
         {
             if (bmp != null && height > 0)
             {

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1683,6 +1683,7 @@ namespace ShareX.HelpersLib
                 using (TextureBrush brush = new TextureBrush(bmpIn))
                 {
                     g.SetHighQuality();
+                    g.PixelOffsetMode = PixelOffsetMode.Half;
                     g.FillPolygon(brush, path);
                 }
                 return bmpResult;
@@ -1829,6 +1830,7 @@ namespace ShareX.HelpersLib
             using (TextureBrush brush = new TextureBrush(bmp))
             {
                 g.SetHighQuality();
+                g.PixelOffsetMode = PixelOffsetMode.Half;
 
                 Point[] fillPoints = points.Distinct().ToArray();
 

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1673,6 +1673,8 @@ namespace ShareX.HelpersLib
             int horizontalWaveCount = Math.Max(2, (bmp.Width / waveRange + 1) / 2 * 2) - 1;
             int verticalWaveCount = Math.Max(2, (bmp.Height / waveRange + 1) / 2 * 2) - 1;
 
+            int step = Math.Min(Math.Max(1, waveRange / waveDepth), 10);
+
             Bitmap updateResult(Bitmap bmpIn, Point[] path)
             {
                 Bitmap bmpResult = bmpIn.CreateEmptyBitmap();
@@ -1688,55 +1690,56 @@ namespace ShareX.HelpersLib
 
             int waveFunction(int t, int max, int depth) => (int)((1 - Math.Cos(t * Math.PI / max)) * depth / 2);
 
-            if (sides.HasFlag(AnchorStyles.Top) && horizontalWaveCount > 1)
+            if (sides.HasFlag(AnchorStyles.Top))
             {
                 waveRange = bmp.Width / horizontalWaveCount;
                 points.Clear();
-                for (int x = 0; x < bmp.Width; x += waveDepth)
+                for (int x = 0; x < bmp.Width; x += step)
                 {
                     points.Add(new Point(x, waveFunction(x, waveRange, waveDepth)));
                 }
-                points.Add(new Point(bmp.Width - 1, waveFunction(bmp.Width - 1, waveRange, waveDepth)));
-                points.Add(new Point(bmp.Width - 1, bmp.Height - 1));
-                points.Add(new Point(0, bmp.Height - 1));
+                points.Add(new Point(bmp.Width, waveFunction(bmp.Width, waveRange, waveDepth)));
+                points.Add(new Point(bmp.Width, bmp.Height));
+                points.Add(new Point(0, bmp.Height));
                 bmp = updateResult(bmp, points.ToArray());
             }
 
-            if (sides.HasFlag(AnchorStyles.Right) && verticalWaveCount > 1)
+            if (sides.HasFlag(AnchorStyles.Right))
             {
                 waveRange = bmp.Height / verticalWaveCount;
                 points.Clear();
                 points.Add(new Point(0, 0));
-                for (int y = 0; y < bmp.Height; y += waveDepth)
+                for (int y = 0; y < bmp.Height; y += step)
                 {
-                    points.Add(new Point(bmp.Width - 1 - waveDepth + waveFunction(y, waveRange, waveDepth), y));
+                    points.Add(new Point(bmp.Width - waveDepth + waveFunction(y, waveRange, waveDepth), y));
                 }
-                points.Add(new Point(bmp.Width - 1 - waveDepth + waveFunction(bmp.Height - 1, waveRange, waveDepth), bmp.Height - 1));
-                points.Add(new Point(0, bmp.Height - 1));
+                points.Add(new Point(bmp.Width - waveDepth + waveFunction(bmp.Height, waveRange, waveDepth), bmp.Height));
+                points.Add(new Point(0, bmp.Height));
                 bmp = updateResult(bmp, points.ToArray());
             }
 
-            if (sides.HasFlag(AnchorStyles.Bottom) && horizontalWaveCount > 1)
+            if (sides.HasFlag(AnchorStyles.Bottom))
             {
                 waveRange = bmp.Width / horizontalWaveCount;
                 points.Clear();
                 points.Add(new Point(0, 0));
-                points.Add(new Point(bmp.Width - 1, 0));
-                for (int x = bmp.Width - 1; x >= 0; x -= waveDepth)
+                points.Add(new Point(bmp.Width, 0));
+                for (int x = bmp.Width; x >= 0; x -= step)
                 {
-                    points.Add(new Point(x, bmp.Height - 1 - waveDepth + waveFunction(x, waveRange, waveDepth)));
+                    points.Add(new Point(x, bmp.Height - waveDepth + waveFunction(x, waveRange, waveDepth)));
                 }
-                points.Add(new Point(0, bmp.Height - 1 - waveDepth + waveFunction(0, waveRange, waveDepth)));
+                points.Add(new Point(0, bmp.Height - waveDepth + waveFunction(0, waveRange, waveDepth)));
                 bmp = updateResult(bmp, points.ToArray());
             }
 
-            if (sides.HasFlag(AnchorStyles.Left) && verticalWaveCount > 1)
+            if (sides.HasFlag(AnchorStyles.Left))
             {
                 waveRange = bmp.Height / verticalWaveCount;
+                points.Clear();
                 points.Add(new Point(0, 0));
-                points.Add(new Point(bmp.Width - 1, 0));
-                points.Add(new Point(bmp.Width - 1, bmp.Height - 1));
-                for (int y = bmp.Height - 1; y >= 0; y -= waveDepth)
+                points.Add(new Point(bmp.Width, 0));
+                points.Add(new Point(bmp.Width, bmp.Height));
+                for (int y = bmp.Height; y >= 0; y -= step)
                 {
                     points.Add(new Point(waveFunction(y, waveRange, waveDepth), y));
                 }

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -223,7 +223,7 @@ namespace ShareX.HelpersLib
             return null;
         }
 
-        public static Bitmap CutOutBitmapMiddleHorizontal(Bitmap bmp, int x, int width)
+        public static Bitmap CutOutBitmapMiddleHorizontal(Bitmap bmp, int x, int width, CutOutEffectType effectType, int effectSize)
         {
             if (bmp != null && width > 0)
             {
@@ -231,11 +231,39 @@ namespace ShareX.HelpersLib
                 if (x > 0)
                 {
                     leftPart = CropBitmap(bmp, new Rectangle(0, 0, Math.Min(x, bmp.Width), bmp.Height));
+                    switch (effectType)
+                    {
+                        case CutOutEffectType.None:
+                            break;
+                        case CutOutEffectType.ZigZag:
+                            break;
+                        case CutOutEffectType.TornEdge:
+                            leftPart = TornEdges(leftPart, effectSize, effectSize * 2, AnchorStyles.Right, false);
+                            break;
+                        case CutOutEffectType.Wave:
+                            break;
+                        case CutOutEffectType.Gradient:
+                            break;
+                    }
                 }
                 if (x + width < bmp.Width)
                 {
                     int x2 = Math.Max(x + width, 0);
                     rightPart = CropBitmap(bmp, new Rectangle(x2, 0, bmp.Width - x2, bmp.Height));
+                    switch (effectType)
+                    {
+                        case CutOutEffectType.None:
+                            break;
+                        case CutOutEffectType.ZigZag:
+                            break;
+                        case CutOutEffectType.TornEdge:
+                            rightPart = TornEdges(rightPart, effectSize, effectSize * 2, AnchorStyles.Left, false);
+                            break;
+                        case CutOutEffectType.Wave:
+                            break;
+                        case CutOutEffectType.Gradient:
+                            break;
+                    }
                 }
 
                 if (leftPart != null && rightPart != null)
@@ -255,7 +283,7 @@ namespace ShareX.HelpersLib
             return null;
         }
 
-        public static Bitmap CutOutBitmapMiddleVertical(Bitmap bmp, int y, int height)
+        public static Bitmap CutOutBitmapMiddleVertical(Bitmap bmp, int y, int height, CutOutEffectType effectType, int effectSize)
         {
             if (bmp != null && height > 0)
             {
@@ -263,11 +291,39 @@ namespace ShareX.HelpersLib
                 if (y > 0)
                 {
                     topPart = CropBitmap(bmp, new Rectangle(0, 0, bmp.Width, Math.Min(y, bmp.Height)));
+                    switch (effectType)
+                    {
+                        case CutOutEffectType.None:
+                            break;
+                        case CutOutEffectType.ZigZag:
+                            break;
+                        case CutOutEffectType.TornEdge:
+                            topPart = TornEdges(topPart, effectSize, effectSize * 2, AnchorStyles.Bottom, false);
+                            break;
+                        case CutOutEffectType.Wave:
+                            break;
+                        case CutOutEffectType.Gradient:
+                            break;
+                    }
                 }
                 if (y + height < bmp.Height)
                 {
                     int y2 = Math.Max(y + height, 0);
                     bottomPart = CropBitmap(bmp, new Rectangle(0, y2, bmp.Width, bmp.Height - y2));
+                    switch (effectType)
+                    {
+                        case CutOutEffectType.None:
+                            break;
+                        case CutOutEffectType.ZigZag:
+                            break;
+                        case CutOutEffectType.TornEdge:
+                            bottomPart = TornEdges(bottomPart, effectSize, effectSize * 2, AnchorStyles.Top, false);
+                            break;
+                        case CutOutEffectType.Wave:
+                            break;
+                        case CutOutEffectType.Gradient:
+                            break;
+                    }
                 }
 
                 if (topPart != null && bottomPart != null)

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -238,9 +238,6 @@ namespace ShareX.HelpersLib
 
                 case CutOutEffectType.Wave:
                     return WavyEdges(bmp, effectSize, effectSize * 5, effectEdge);
-
-                case CutOutEffectType.Gradient:
-                    return bmp;
             }
 
             throw new NotImplementedException(); // should not be reachable

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -223,6 +223,70 @@ namespace ShareX.HelpersLib
             return null;
         }
 
+        public static Bitmap TrimBitmapInteriorHorizontal(Bitmap bmp, int x, int width)
+        {
+            if (bmp != null && width > 0)
+            {
+                Bitmap leftPart = null, rightPart = null;
+                if (x > 0)
+                {
+                    leftPart = CropBitmap(bmp, new Rectangle(0, 0, Math.Min(x, bmp.Width), bmp.Height));
+                }
+                if (x + width < bmp.Width)
+                {
+                    int x2 = Math.Max(x + width, 0);
+                    rightPart = CropBitmap(bmp, new Rectangle(x2, 0, bmp.Width - x2, bmp.Height));
+                }
+
+                if (leftPart != null && rightPart != null)
+                {
+                    return CombineImages(new List<Bitmap> { leftPart, rightPart }, Orientation.Horizontal);
+                }
+                else if (leftPart != null)
+                {
+                    return leftPart;
+                }
+                else if (rightPart != null)
+                {
+                    return rightPart;
+                }
+            }
+
+            return null;
+        }
+
+        public static Bitmap TrimBitmapInteriorVertical(Bitmap bmp, int y, int height)
+        {
+            if (bmp != null && height > 0)
+            {
+                Bitmap topPart = null, bottomPart = null;
+                if (y > 0)
+                {
+                    topPart = CropBitmap(bmp, new Rectangle(0, 0, bmp.Width, Math.Min(y, bmp.Height)));
+                }
+                if (y + height < bmp.Height)
+                {
+                    int y2 = Math.Max(y + height, 0);
+                    bottomPart = CropBitmap(bmp, new Rectangle(0, y2, bmp.Width, bmp.Height - y2));
+                }
+
+                if (topPart != null && bottomPart != null)
+                {
+                    return CombineImages(new List<Bitmap> { topPart, bottomPart }, Orientation.Vertical);
+                }
+                else if (topPart != null)
+                {
+                    return topPart;
+                }
+                else if (bottomPart != null)
+                {
+                    return bottomPart;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>Automatically crop image to remove transparent outside area.</summary>
         public static Bitmap AutoCropTransparent(Bitmap bmp)
         {

--- a/ShareX.HelpersLib/Properties/Resources.Designer.cs
+++ b/ShareX.HelpersLib/Properties/Resources.Designer.cs
@@ -686,6 +686,42 @@ namespace ShareX.HelpersLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No effect.
+        /// </summary>
+        internal static string CutOutEffectType_None {
+            get {
+                return ResourceManager.GetString("CutOutEffectType_None", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Torn edges.
+        /// </summary>
+        internal static string CutOutEffectType_TornEdge {
+            get {
+                return ResourceManager.GetString("CutOutEffectType_TornEdge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Wave.
+        /// </summary>
+        internal static string CutOutEffectType_Wave {
+            get {
+                return ResourceManager.GetString("CutOutEffectType_Wave", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sawtooth.
+        /// </summary>
+        internal static string CutOutEffectType_ZigZag {
+            get {
+                return ResourceManager.GetString("CutOutEffectType_ZigZag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Browse for a folder....
         /// </summary>
         internal static string DirectoryNameEditor_EditValue_Browse_for_a_folder___ {
@@ -3649,6 +3685,15 @@ namespace ShareX.HelpersLib.Properties {
         internal static string ShapeType_ToolCrop {
             get {
                 return ResourceManager.GetString("ShapeType_ToolCrop", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cut out.
+        /// </summary>
+        internal static string ShapeType_ToolCutOut {
+            get {
+                return ResourceManager.GetString("ShapeType_ToolCutOut", resourceCulture);
             }
         }
         

--- a/ShareX.HelpersLib/Properties/Resources.resx
+++ b/ShareX.HelpersLib/Properties/Resources.resx
@@ -1429,7 +1429,6 @@ Would you like to download and install it?</value>
   </data>
   <data name="HotkeyType_OCR" xml:space="preserve">
     <value>OCR</value>
-    
   </data>
   <data name="HotkeyType_OCR_Category" xml:space="preserve">
     <value>Tools</value>
@@ -1454,5 +1453,20 @@ Would you like to download and install it?</value>
   </data>
   <data name="HotkeyType_PinToScreen_Category" xml:space="preserve">
     <value>Tools</value>
+  </data>
+  <data name="CutOutEffectType_None" xml:space="preserve">
+    <value>No effect</value>
+  </data>
+  <data name="CutOutEffectType_TornEdge" xml:space="preserve">
+    <value>Torn edges</value>
+  </data>
+  <data name="CutOutEffectType_Wave" xml:space="preserve">
+    <value>Wave</value>
+  </data>
+  <data name="CutOutEffectType_ZigZag" xml:space="preserve">
+    <value>Sawtooth</value>
+  </data>
+  <data name="ShapeType_ToolCutOut" xml:space="preserve">
+    <value>Cut out</value>
   </data>
 </root>

--- a/ShareX.ImageEffectsLib/Filters/TornEdge.cs
+++ b/ShareX.ImageEffectsLib/Filters/TornEdge.cs
@@ -52,7 +52,7 @@ namespace ShareX.ImageEffectsLib
 
         public override Bitmap Apply(Bitmap bmp)
         {
-            return ImageHelpers.TornEdges(bmp, Depth, Range, Sides, CurvedEdges);
+            return ImageHelpers.TornEdges(bmp, Depth, Range, Sides, CurvedEdges, true);
         }
     }
 }

--- a/ShareX.ImageEffectsLib/Filters/WaveEdge.cs
+++ b/ShareX.ImageEffectsLib/Filters/WaveEdge.cs
@@ -1,0 +1,54 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2022 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using ShareX.HelpersLib;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ShareX.ImageEffectsLib
+{
+    [Description("Wave edge")]
+    internal class WaveEdge : ImageEffect
+    {
+        public int Depth { get; set; }
+
+        [DefaultValue(10)]
+        public int Range { get; set; }
+
+        [DefaultValue(AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right)]
+        public AnchorStyles Sides { get; set; }
+
+        public WaveEdge()
+        {
+            this.ApplyDefaultPropertyValues();
+        }
+
+        public override Bitmap Apply(Bitmap bmp)
+        {
+            return ImageHelpers.WavyEdges(bmp, Depth, Range, Sides);
+        }
+    }
+}

--- a/ShareX.ImageEffectsLib/Forms/ImageEffectsForm.cs
+++ b/ShareX.ImageEffectsLib/Forms/ImageEffectsForm.cs
@@ -202,7 +202,8 @@ namespace ShareX.ImageEffectsLib
                 typeof(Sharpen),
                 typeof(Slice),
                 typeof(Smooth),
-                typeof(TornEdge));
+                typeof(TornEdge),
+                typeof(WaveEdge));
         }
 
         private void AddEffectToContextMenu(string groupName, params Type[] imageEffects)

--- a/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
+++ b/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Adjustments\Hue.cs" />
     <Compile Include="Adjustments\Inverse.cs" />
     <Compile Include="Adjustments\Saturation.cs" />
+    <Compile Include="Filters\WaveEdge.cs" />
     <Compile Include="ImageEffectPackager.cs" />
     <Compile Include="Forms\ImageEffectPackagerForm.cs">
       <SubType>Form</SubType>

--- a/ShareX.ScreenCaptureLib/Enums.cs
+++ b/ShareX.ScreenCaptureLib/Enums.cs
@@ -292,7 +292,7 @@ namespace ShareX.ScreenCaptureLib
         EffectPixelate,
         EffectHighlight,
         ToolCrop,
-        ToolTrimInterior
+        ToolCutOut
     }
 
     public enum ScrollingCaptureScrollMethod // Localized

--- a/ShareX.ScreenCaptureLib/Enums.cs
+++ b/ShareX.ScreenCaptureLib/Enums.cs
@@ -291,7 +291,8 @@ namespace ShareX.ScreenCaptureLib
         EffectBlur,
         EffectPixelate,
         EffectHighlight,
-        ToolCrop
+        ToolCrop,
+        ToolTrimInterior
     }
 
     public enum ScrollingCaptureScrollMethod // Localized

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -285,6 +285,24 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cut cut effect size.
+        /// </summary>
+        internal static string CutOutEffectSize {
+            get {
+                return ResourceManager.GetString("CutOutEffectSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cut out effect.
+        /// </summary>
+        internal static string CutOutEffectType {
+            get {
+                return ResourceManager.GetString("CutOutEffectType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap disk_black {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -805,4 +805,10 @@ X: {4} Y: {5}</value>
     <value>CRF:</value>
     <comment>@Invariant</comment>
   </data>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Cut cut effect size</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>Cut out effect</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
@@ -106,5 +106,9 @@ namespace ShareX.ScreenCaptureLib
 
         // Highlight effect
         public Color HighlightColor { get; set; } = Color.Yellow;
+
+        // Cut Out tool
+        public CutOutEffectType CutOutEffectType { get; set; } = CutOutEffectType.None;
+        public int CutOutEffectSize { get; set; } = 5;
     }
 }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1625,12 +1625,110 @@ namespace ShareX.ScreenCaptureLib
 
         public void CollapseAllHorizontal(float x, float width)
         {
-            // todo
+            float x2 = x + width;
+            if (width <= 0) return;
+
+            List<BaseShape> toDelete = new List<BaseShape>();
+
+            foreach (BaseShape shape in Shapes)
+            {
+                RectangleF sr = shape.Rectangle;
+                if (sr.Left < x)
+                {
+                    if (sr.Right <= x)
+                    {
+                        // case 1: entirely before the cut, no action needed
+                    }
+                    else if (sr.Right < x2)
+                    {
+                        // case 2: end reaches into the cut, shorten shape to end at x
+                        shape.Rectangle = new RectangleF(sr.X, sr.Y, x - sr.X, sr.Height);
+                    }
+                    else
+                    {
+                        // case 3: end reaches over the cut, shorten shape by width, keeping left
+                        shape.Rectangle = new RectangleF(sr.X, sr.Y, sr.Width - width, sr.Height);
+                    }
+                }
+                else if (sr.Left < x2)
+                {
+                    if (sr.Right <= x2)
+                    {
+                        // case 4: entirely inside the cut, delete the shape
+                        toDelete.Add(shape);
+                    }
+                    else
+                    {
+                        // case 5: beginning reaches into the cut, shorten shape by difference between shape left and x2
+                        shape.Rectangle = new RectangleF(x, sr.Y, sr.Right - x2, sr.Height);
+                    }
+                }
+                else
+                {
+                    // case 6: entirely after the cut, offset shape by width
+                    shape.Rectangle = new RectangleF(sr.X - width, sr.Y, sr.Width, sr.Height);
+                }
+            }
+
+            foreach (BaseShape shape in toDelete)
+            {
+                shape.Dispose();
+                Shapes.Remove(shape);
+            }
         }
 
         public void CollapseAllVertical(float y, float height)
         {
-            // todo
+            float y2 = y + height;
+            if (height <= 0) return;
+
+            List<BaseShape> toDelete = new List<BaseShape>();
+
+            foreach (BaseShape shape in Shapes)
+            {
+                RectangleF sr = shape.Rectangle;
+                if (sr.Top < y)
+                {
+                    if (sr.Bottom <= y)
+                    {
+                        // case 1: entirely before the cut, no action needed
+                    }
+                    else if (sr.Bottom < y2)
+                    {
+                        // case 2: end reaches into the cut, shorten shape to end at x
+                        shape.Rectangle = new RectangleF(sr.X, sr.Y, sr.Width, y - sr.Y);
+                    }
+                    else
+                    {
+                        // case 3: end reaches over the cut, shorten shape by width, keeping left
+                        shape.Rectangle = new RectangleF(sr.X, sr.Y, sr.Width, sr.Height - height);
+                    }
+                }
+                else if (sr.Top < y2)
+                {
+                    if (sr.Bottom <= y2)
+                    {
+                        // case 4: entirely inside the cut, delete the shape
+                        toDelete.Add(shape);
+                    }
+                    else
+                    {
+                        // case 5: beginning reaches into the cut, shorten shape by difference between shape left and x2
+                        shape.Rectangle = new RectangleF(sr.X, y, sr.Width, sr.Bottom - y2);
+                    }
+                }
+                else
+                {
+                    // case 6: entirely after the cut, offset shape by width
+                    shape.Rectangle = new RectangleF(sr.X, sr.Y - height, sr.Width, sr.Height);
+                }
+            }
+
+            foreach (BaseShape shape in toDelete)
+            {
+                shape.Dispose();
+                Shapes.Remove(shape);
+            }
         }
 
         public void RemoveOutsideShapes()
@@ -1824,11 +1922,11 @@ namespace ShareX.ScreenCaptureLib
         {
             bool isHorizontal = rect.Width > rect.Height;
 
-            rect = CaptureHelpers.ScreenToClient(rect.Round());
+            RectangleF adjustedRect = CaptureHelpers.ScreenToClient(rect.Round());
             PointF offset = CaptureHelpers.ScreenToClient(Form.CanvasRectangle.Location.Round());
-            rect.X -= offset.X;
-            rect.Y -= offset.Y;
-            Rectangle cropRect = Rectangle.Intersect(new Rectangle(0, 0, Form.Canvas.Width, Form.Canvas.Height), rect.Round());
+            adjustedRect.X -= offset.X;
+            adjustedRect.Y -= offset.Y;
+            Rectangle cropRect = Rectangle.Intersect(new Rectangle(0, 0, Form.Canvas.Width, Form.Canvas.Height), adjustedRect.Round());
 
             if (isHorizontal && cropRect.Width > 0)
             {

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1195,6 +1195,9 @@ namespace ShareX.ScreenCaptureLib
                 case ShapeType.ToolCrop:
                     shape = new CropTool();
                     break;
+                case ShapeType.ToolTrimInterior:
+                    shape = new TrimInteriorTool();
+                    break;
             }
 
             shape.Manager = this;
@@ -1620,6 +1623,16 @@ namespace ShareX.ScreenCaptureLib
             MoveAll(offset.X, offset.Y);
         }
 
+        public void CollapseAllHorizontal(float x, float width)
+        {
+            // todo
+        }
+
+        public void CollapseAllVertical(float y, float height)
+        {
+            // todo
+        }
+
         public void RemoveOutsideShapes()
         {
             foreach (BaseShape shape in Shapes.ToArray())
@@ -1805,6 +1818,28 @@ namespace ShareX.ScreenCaptureLib
             }
 
             return null;
+        }
+
+        public void TrimInterior(RectangleF rect)
+        {
+            bool isHorizontal = rect.Width > rect.Height;
+
+            rect = CaptureHelpers.ScreenToClient(rect.Round());
+            PointF offset = CaptureHelpers.ScreenToClient(Form.CanvasRectangle.Location.Round());
+            rect.X -= offset.X;
+            rect.Y -= offset.Y;
+            Rectangle cropRect = Rectangle.Intersect(new Rectangle(0, 0, Form.Canvas.Width, Form.Canvas.Height), rect.Round());
+
+            if (isHorizontal && cropRect.Width > 0)
+            {
+                CollapseAllHorizontal(rect.X, rect.Width);
+                UpdateCanvas(ImageHelpers.TrimBitmapInteriorHorizontal(Form.Canvas, cropRect.X, cropRect.Width));
+            }
+            else if (!isHorizontal && cropRect.Height > 0)
+            {
+                CollapseAllVertical(rect.Y, rect.Height);
+                UpdateCanvas(ImageHelpers.TrimBitmapInteriorVertical(Form.Canvas, cropRect.Y, cropRect.Height));
+            }
         }
 
         public Color GetColor(Bitmap bmp, Point pos)

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1195,8 +1195,8 @@ namespace ShareX.ScreenCaptureLib
                 case ShapeType.ToolCrop:
                     shape = new CropTool();
                     break;
-                case ShapeType.ToolTrimInterior:
-                    shape = new TrimInteriorTool();
+                case ShapeType.ToolCutOut:
+                    shape = new CutOutTool();
                     break;
             }
 
@@ -1820,7 +1820,7 @@ namespace ShareX.ScreenCaptureLib
             return null;
         }
 
-        public void TrimInterior(RectangleF rect)
+        public void CutOut(RectangleF rect)
         {
             bool isHorizontal = rect.Width > rect.Height;
 
@@ -1833,12 +1833,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.TrimBitmapInteriorHorizontal(Form.Canvas, cropRect.X, cropRect.Width));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleHorizontal(Form.Canvas, cropRect.X, cropRect.Width));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.TrimBitmapInteriorVertical(Form.Canvas, cropRect.Y, cropRect.Height));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleVertical(Form.Canvas, cropRect.Y, cropRect.Height));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1672,8 +1672,7 @@ namespace ShareX.ScreenCaptureLib
 
             foreach (BaseShape shape in toDelete)
             {
-                shape.Dispose();
-                Shapes.Remove(shape);
+                DeleteShape(shape);
             }
         }
 
@@ -1726,8 +1725,7 @@ namespace ShareX.ScreenCaptureLib
 
             foreach (BaseShape shape in toDelete)
             {
-                shape.Dispose();
-                Shapes.Remove(shape);
+                DeleteShape(shape);
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1929,12 +1929,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.Wave, 10));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.ZigZag, 5));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.Wave, 10));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.ZigZag, 5));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1929,12 +1929,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.ZigZag, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, AnnotationOptions.CutOutEffectType, AnnotationOptions.CutOutEffectSize));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.ZigZag, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, AnnotationOptions.CutOutEffectType, AnnotationOptions.CutOutEffectSize));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1931,12 +1931,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleHorizontal(Form.Canvas, cropRect.X, cropRect.Width));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleHorizontal(Form.Canvas, cropRect.X, cropRect.Width, CutOutEffectType.TornEdge, 5));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleVertical(Form.Canvas, cropRect.Y, cropRect.Height));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleVertical(Form.Canvas, cropRect.Y, cropRect.Height, CutOutEffectType.TornEdge, 5));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1929,12 +1929,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleHorizontal(Form.Canvas, cropRect.X, cropRect.Width, CutOutEffectType.TornEdge, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.TornEdge, 5));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddleVertical(Form.Canvas, cropRect.Y, cropRect.Height, CutOutEffectType.TornEdge, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.TornEdge, 5));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManager.cs
@@ -1929,12 +1929,12 @@ namespace ShareX.ScreenCaptureLib
             if (isHorizontal && cropRect.Width > 0)
             {
                 CollapseAllHorizontal(rect.X, rect.Width);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.TornEdge, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Horizontal, cropRect.X, cropRect.Width, CutOutEffectType.Wave, 10));
             }
             else if (!isHorizontal && cropRect.Height > 0)
             {
                 CollapseAllVertical(rect.Y, rect.Height);
-                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.TornEdge, 5));
+                UpdateCanvas(ImageHelpers.CutOutBitmapMiddle(Form.Canvas, Orientation.Vertical, cropRect.Y, cropRect.Height, CutOutEffectType.Wave, 10));
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -51,9 +51,9 @@ namespace ShareX.ScreenCaptureLib
         private ToolStripMenuItem tsmiShadow, tsmiShadowColor, tsmiUndo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
             tsmiMoveTop, tsmiMoveUp, tsmiMoveDown, tsmiMoveBottom, tsmiRegionCapture, tsmiQuickCrop, tsmiShowMagnifier;
         private ToolStripLabeledNumericUpDown tslnudBorderSize, tslnudCornerRadius, tslnudCenterPoints, tslnudBlurRadius, tslnudPixelateSize, tslnudStepFontSize,
-            tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength;
+            tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength, tslnudCutOutEffectSize;
         private ToolStripLabel tslDragLeft, tslDragRight;
-        private ToolStripLabeledComboBox tscbBorderStyle, tscbArrowHeadDirection, tscbImageInterpolationMode, tscbCursorTypes, tscbStepType;
+        private ToolStripLabeledComboBox tscbBorderStyle, tscbArrowHeadDirection, tscbImageInterpolationMode, tscbCursorTypes, tscbStepType, tscbCutOutEffectType;
 
         internal void CreateToolbar()
         {
@@ -641,6 +641,26 @@ namespace ShareX.ScreenCaptureLib
                 Form.Resume();
             };
             tsddbShapeOptions.DropDownItems.Add(tsmiShadowColor);
+
+            tscbCutOutEffectType = new ToolStripLabeledComboBox(Resources.CutOutEffectType);
+            tscbCutOutEffectType.Content.AddRange(Helpers.GetLocalizedEnumDescriptions<CutOutEffectType>());
+            tscbCutOutEffectType.Content.SelectedIndexChanged += (sender, e) =>
+            {
+                AnnotationOptions.CutOutEffectType = (CutOutEffectType)tscbCutOutEffectType.Content.SelectedIndex;
+                tscbCutOutEffectType.Invalidate();
+                UpdateCurrentShape();
+            };
+            tsddbShapeOptions.DropDownItems.Add(tscbCutOutEffectType);
+
+            tslnudCutOutEffectSize = new ToolStripLabeledNumericUpDown(Resources.CutOutEffectSize);
+            tslnudCutOutEffectSize.Content.Minimum = 3;
+            tslnudCutOutEffectSize.Content.Maximum = 100;
+            tslnudCutOutEffectSize.Content.ValueChanged = (sender, e) =>
+            {
+                AnnotationOptions.CutOutEffectSize = (int)tslnudCutOutEffectSize.Content.Value;
+                UpdateCurrentShape();
+            };
+            tsddbShapeOptions.DropDownItems.Add(tslnudCutOutEffectSize);
 
             // In dropdown menu if only last item is visible then menu opens at 0, 0 position on first open, so need to add dummy item to solve this weird bug...
             tsddbShapeOptions.DropDownItems.Add(new ToolStripSeparator() { Visible = false });
@@ -1456,6 +1476,10 @@ namespace ShareX.ScreenCaptureLib
 
             tscbArrowHeadDirection.Content.SelectedIndex = (int)AnnotationOptions.ArrowHeadDirection;
 
+            tscbCutOutEffectType.Content.SelectedIndex = (int)AnnotationOptions.CutOutEffectType;
+
+            tslnudCutOutEffectSize.Content.Value = AnnotationOptions.CutOutEffectSize;
+
             switch (shapeType)
             {
                 default:
@@ -1477,6 +1501,7 @@ namespace ShareX.ScreenCaptureLib
                 case ShapeType.DrawingCursor:
                 case ShapeType.EffectBlur:
                 case ShapeType.EffectPixelate:
+                case ShapeType.ToolCutOut:
                     tsddbShapeOptions.Visible = true;
                     break;
             }
@@ -1561,6 +1586,8 @@ namespace ShareX.ScreenCaptureLib
             tslnudBlurRadius.Visible = shapeType == ShapeType.EffectBlur;
             tslnudPixelateSize.Visible = shapeType == ShapeType.EffectPixelate;
             tsbHighlightColor.Visible = shapeType == ShapeType.EffectHighlight;
+            tscbCutOutEffectType.Visible = shapeType == ShapeType.ToolCutOut;
+            tslnudCutOutEffectSize.Visible = shapeType == ShapeType.ToolCutOut;
 
             if (tsmiRegionCapture != null)
             {

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -44,7 +44,7 @@ namespace ShareX.ScreenCaptureLib
         private Size buttonSize = new Size(80, 40);
         private int buttonOffset = 15;
 
-        private Brush EffectBrush = new SolidBrush(Color.FromArgb(128, Color.Gray));
+        private Brush selectionHighlightBrush = new SolidBrush(Color.FromArgb(128, Color.Gray));
 
         public override void OnUpdate()
         {
@@ -109,11 +109,11 @@ namespace ShareX.ScreenCaptureLib
         {
             if (IsHorizontalTrim)
             {
-                g.FillRectangle(EffectBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
+                g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
             }
             else if (IsVerticalTrim)
             {
-                g.FillRectangle(EffectBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
+                g.FillRectangle(selectionHighlightBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
             }
         }
 
@@ -168,6 +168,8 @@ namespace ShareX.ScreenCaptureLib
         public override void Dispose()
         {
             base.Dispose();
+
+            selectionHighlightBrush.Dispose();
 
             if ((confirmButton != null && confirmButton.IsCursorHover) || (cancelButton != null && cancelButton.IsCursorHover))
             {

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -24,6 +24,7 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -122,11 +123,11 @@ namespace ShareX.ScreenCaptureLib
             {
                 if (IsHorizontalTrim)
                 {
-                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
+                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, Math.Max(g.ClipBounds.Y, Manager.Form.CanvasRectangle.Y), Rectangle.Width, Math.Min(g.ClipBounds.Height, Manager.Form.CanvasRectangle.Height)));
                 }
                 else if (IsVerticalTrim)
                 {
-                    g.FillRectangle(selectionHighlightBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
+                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Math.Max(g.ClipBounds.X, Manager.Form.CanvasRectangle.X), Rectangle.Y, Math.Min(g.ClipBounds.Width, Manager.Form.CanvasRectangle.Width), Rectangle.Height));
                 }
             }
         }

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -24,7 +24,6 @@
 #endregion License Information (GPL v3)
 
 using ShareX.HelpersLib;
-using System;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -39,7 +38,8 @@ namespace ShareX.ScreenCaptureLib
         public bool IsHorizontalTrim => Rectangle.Width >= Options.MinimumSize && Rectangle.Width > Rectangle.Height;
         public bool IsVerticalTrim => Rectangle.Height >= Options.MinimumSize && Rectangle.Height >= Rectangle.Width;
 
-        public override bool IsValidShape {
+        public override bool IsValidShape
+        {
             get
             {
                 if (!IsHorizontalTrim && !IsVerticalTrim) return false;

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -29,9 +29,9 @@ using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    public class TrimInteriorTool : BaseTool
+    public class CutOutTool : BaseTool
     {
-        public override ShapeType ShapeType { get; } = ShapeType.ToolTrimInterior;
+        public override ShapeType ShapeType { get; } = ShapeType.ToolCutOut;
 
         public override bool LimitRectangleToInsideCanvas { get; } = true;
 
@@ -112,7 +112,7 @@ namespace ShareX.ScreenCaptureLib
 
         private void ConfirmButton_MousePressed(object sender, MouseEventArgs e)
         {
-            Manager.TrimInterior(Rectangle);
+            Manager.CutOut(Rectangle);
             Remove();
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -44,8 +44,6 @@ namespace ShareX.ScreenCaptureLib
         private Size buttonSize = new Size(80, 40);
         private int buttonOffset = 15;
 
-        private Brush selectionHighlightBrush = new SolidBrush(Color.FromArgb(128, Color.Gray));
-
         public override void OnUpdate()
         {
             base.OnUpdate();
@@ -107,13 +105,17 @@ namespace ShareX.ScreenCaptureLib
 
         public override void OnDraw(Graphics g)
         {
-            if (IsHorizontalTrim)
+            using (Image selectionHighlightPattern = ImageHelpers.CreateCheckerPattern(8, 8, Color.FromArgb(128, Color.White), Color.FromArgb(128, Color.Gray)))
+            using (Brush selectionHighlightBrush = new TextureBrush(selectionHighlightPattern, System.Drawing.Drawing2D.WrapMode.Tile))
             {
-                g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
-            }
-            else if (IsVerticalTrim)
-            {
-                g.FillRectangle(selectionHighlightBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
+                if (IsHorizontalTrim)
+                {
+                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
+                }
+                else if (IsVerticalTrim)
+                {
+                    g.FillRectangle(selectionHighlightBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
+                }
             }
         }
 
@@ -168,8 +170,6 @@ namespace ShareX.ScreenCaptureLib
         public override void Dispose()
         {
             base.Dispose();
-
-            selectionHighlightBrush.Dispose();
 
             if ((confirmButton != null && confirmButton.IsCursorHover) || (cancelButton != null && cancelButton.IsCursorHover))
             {

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -49,6 +49,22 @@ namespace ShareX.ScreenCaptureLib
             }
         }
 
+        public RectangleF CutOutRectangle
+        {
+            get
+            {
+                if (IsHorizontalTrim)
+                {
+                    return new RectangleF(Rectangle.X, Manager.Form.CanvasRectangle.Y, Rectangle.Width, Manager.Form.CanvasRectangle.Height);
+                }
+                if (IsVerticalTrim)
+                {
+                    return new RectangleF(Manager.Form.CanvasRectangle.X, Rectangle.Y, Manager.Form.CanvasRectangle.Width, Rectangle.Height);
+                }
+                return RectangleF.Empty;
+            }
+        }
+
         private ImageEditorButton confirmButton, cancelButton;
         private Size buttonSize = new Size(80, 40);
         private int buttonOffset = 15;
@@ -121,14 +137,7 @@ namespace ShareX.ScreenCaptureLib
             using (Image selectionHighlightPattern = ImageHelpers.CreateCheckerPattern(8, 8, Color.FromArgb(128, Color.White), Color.FromArgb(128, Color.Gray)))
             using (Brush selectionHighlightBrush = new TextureBrush(selectionHighlightPattern, System.Drawing.Drawing2D.WrapMode.Tile))
             {
-                if (IsHorizontalTrim)
-                {
-                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Rectangle.X, Math.Max(g.ClipBounds.Y, Manager.Form.CanvasRectangle.Y), Rectangle.Width, Math.Min(g.ClipBounds.Height, Manager.Form.CanvasRectangle.Height)));
-                }
-                else if (IsVerticalTrim)
-                {
-                    g.FillRectangle(selectionHighlightBrush, new RectangleF(Math.Max(g.ClipBounds.X, Manager.Form.CanvasRectangle.X), Rectangle.Y, Math.Min(g.ClipBounds.Width, Manager.Form.CanvasRectangle.Width), Rectangle.Height));
-                }
+                g.FillRectangle(selectionHighlightBrush, CutOutRectangle);
             }
         }
 

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -38,11 +38,23 @@ namespace ShareX.ScreenCaptureLib
         public bool IsHorizontalTrim => Rectangle.Width >= Options.MinimumSize && Rectangle.Width > Rectangle.Height;
         public bool IsVerticalTrim => Rectangle.Height >= Options.MinimumSize && Rectangle.Height >= Rectangle.Width;
 
-        public override bool IsValidShape => IsHorizontalTrim || IsVerticalTrim;
+        public override bool IsValidShape {
+            get
+            {
+                if (!IsHorizontalTrim && !IsVerticalTrim) return false;
+                if (IsHorizontalTrim && Rectangle.Left <= Manager.Form.CanvasRectangle.Left && Rectangle.Right >= Manager.Form.CanvasRectangle.Right) return false;
+                if (IsVerticalTrim && Rectangle.Top <= Manager.Form.CanvasRectangle.Top && Rectangle.Bottom >= Manager.Form.CanvasRectangle.Bottom) return false;
+                return true;
+            }
+        }
 
         private ImageEditorButton confirmButton, cancelButton;
         private Size buttonSize = new Size(80, 40);
         private int buttonOffset = 15;
+
+        public override void ShowNodes()
+        {
+        }
 
         public override void OnUpdate()
         {

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -134,7 +134,7 @@ namespace ShareX.ScreenCaptureLib
 
         public override void OnDraw(Graphics g)
         {
-            using (Image selectionHighlightPattern = ImageHelpers.CreateCheckerPattern(8, 8, Color.FromArgb(128, Color.White), Color.FromArgb(128, Color.Gray)))
+            using (Image selectionHighlightPattern = ImageHelpers.CreateCheckerPattern(1, 1, Color.FromArgb(128, Color.LightGray), Color.FromArgb(128, Color.Gray)))
             using (Brush selectionHighlightBrush = new TextureBrush(selectionHighlightPattern, System.Drawing.Drawing2D.WrapMode.Tile))
             {
                 g.FillRectangle(selectionHighlightBrush, CutOutRectangle);

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/CutOutTool.cs
@@ -52,21 +52,55 @@ namespace ShareX.ScreenCaptureLib
 
             if (confirmButton != null && cancelButton != null)
             {
-                if (Rectangle.Bottom + buttonOffset + buttonSize.Height > Manager.Form.ClientArea.Bottom &&
-                    Rectangle.Width > (buttonSize.Width * 2) + (buttonOffset * 3) &&
-                    Rectangle.Height > buttonSize.Height + (buttonOffset * 2))
+                if (IsVerticalTrim)
                 {
-                    confirmButton.Rectangle = new RectangleF(Rectangle.Right - (buttonOffset * 2) - (buttonSize.Width * 2),
-                        Rectangle.Bottom - buttonOffset - buttonSize.Height, buttonSize.Width, buttonSize.Height);
-                    cancelButton.Rectangle = new RectangleF(Rectangle.Right - buttonOffset - buttonSize.Width,
-                        Rectangle.Bottom - buttonOffset - buttonSize.Height, buttonSize.Width, buttonSize.Height);
+                    float spaceBelow = Manager.Form.ClientArea.Bottom - Rectangle.Bottom;
+                    bool positionBelow = spaceBelow >= buttonSize.Height + 2 * buttonOffset;
+                    float buttonsTop = positionBelow ? Rectangle.Bottom + buttonOffset : Rectangle.Top - buttonOffset - buttonSize.Height;
+                    float buttonsLeft = Rectangle.Left + Rectangle.Width / 2 - (2 * buttonSize.Width + buttonOffset) / 2;
+                    float buttonsRight = buttonsLeft + 2 * buttonSize.Width + buttonOffset;
+                    bool overflowsLeft = buttonsLeft < Manager.Form.ClientArea.Left + buttonOffset;
+                    bool overflowsRight = buttonsRight >= Manager.Form.ClientArea.Right - buttonOffset;
+                    if (overflowsLeft && overflowsRight)
+                    {
+                        // can't fix
+                    }
+                    else if (overflowsLeft)
+                    {
+                        buttonsLeft = Manager.Form.ClientArea.Left + buttonOffset;
+                    }
+                    else if (overflowsRight)
+                    {
+                        buttonsRight = Manager.Form.ClientArea.Right - buttonOffset;
+                        buttonsLeft = buttonsRight - 2 * buttonSize.Width - buttonOffset;
+                    }
+                    confirmButton.Rectangle = new RectangleF(buttonsLeft, buttonsTop, buttonSize.Width, buttonSize.Height);
+                    cancelButton.Rectangle = confirmButton.Rectangle.LocationOffset(buttonSize.Width + buttonOffset, 0);
                 }
                 else
                 {
-                    confirmButton.Rectangle = new RectangleF(Rectangle.Right - (buttonSize.Width * 2) - buttonOffset,
-                        Rectangle.Bottom + buttonOffset, buttonSize.Width, buttonSize.Height);
-                    cancelButton.Rectangle = new RectangleF(Rectangle.Right - buttonSize.Width,
-                        Rectangle.Bottom + buttonOffset, buttonSize.Width, buttonSize.Height);
+                    float spaceRight = Manager.Form.ClientArea.Right - Rectangle.Right;
+                    bool positionRight = spaceRight >= buttonSize.Width + 2 * buttonOffset;
+                    float buttonsLeft = positionRight ? Rectangle.Right + buttonOffset : Rectangle.Left - buttonOffset - buttonSize.Width;
+                    float buttonsTop = Rectangle.Top + Rectangle.Height / 2 - (2 * buttonSize.Height + buttonOffset) / 2;
+                    float buttonsBottom = buttonsTop + 2 * buttonSize.Height + buttonOffset;
+                    bool overflowsTop = buttonsTop < Manager.Form.ClientArea.Top + buttonOffset;
+                    bool overflowsBottom = buttonsBottom >= Manager.Form.ClientArea.Bottom - buttonOffset;
+                    if (overflowsTop && overflowsBottom)
+                    {
+                        // can't fix
+                    }
+                    else if (overflowsTop)
+                    {
+                        buttonsTop = Manager.Form.ClientArea.Top + buttonOffset;
+                    }
+                    else if (overflowsBottom)
+                    {
+                        buttonsBottom = Manager.Form.ClientArea.Bottom - buttonOffset;
+                        buttonsTop = buttonsBottom - 2 * buttonSize.Height - buttonOffset;
+                    }
+                    confirmButton.Rectangle = new RectangleF(buttonsLeft, buttonsTop, buttonSize.Width, buttonSize.Height);
+                    cancelButton.Rectangle = confirmButton.Rectangle.LocationOffset(0, buttonSize.Height + buttonOffset);
                 }
             }
         }

--- a/ShareX.ScreenCaptureLib/Shapes/Tool/TrimInteriorTool.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Tool/TrimInteriorTool.cs
@@ -1,0 +1,154 @@
+﻿#region License Information (GPL v3)
+
+/*
+    ShareX - A program that allows you to take screenshots and share any file type
+    Copyright (c) 2007-2022 ShareX Team
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    Optionally you can also view the license at <http://www.gnu.org/licenses/>.
+*/
+
+#endregion License Information (GPL v3)
+
+using ShareX.HelpersLib;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ShareX.ScreenCaptureLib
+{
+    public class TrimInteriorTool : BaseTool
+    {
+        public override ShapeType ShapeType { get; } = ShapeType.ToolTrimInterior;
+
+        public override bool LimitRectangleToInsideCanvas { get; } = true;
+
+        public bool IsHorizontalTrim => Rectangle.Width >= Options.MinimumSize && Rectangle.Width > Rectangle.Height;
+        public bool IsVerticalTrim => Rectangle.Height >= Options.MinimumSize && Rectangle.Height >= Rectangle.Width;
+
+        public override bool IsValidShape => IsHorizontalTrim || IsVerticalTrim;
+
+        private ImageEditorButton confirmButton, cancelButton;
+        private Size buttonSize = new Size(80, 40);
+        private int buttonOffset = 15;
+
+        private Brush EffectBrush = new SolidBrush(Color.FromArgb(128, Color.Gray));
+
+        public override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            if (confirmButton != null && cancelButton != null)
+            {
+                if (Rectangle.Bottom + buttonOffset + buttonSize.Height > Manager.Form.ClientArea.Bottom &&
+                    Rectangle.Width > (buttonSize.Width * 2) + (buttonOffset * 3) &&
+                    Rectangle.Height > buttonSize.Height + (buttonOffset * 2))
+                {
+                    confirmButton.Rectangle = new RectangleF(Rectangle.Right - (buttonOffset * 2) - (buttonSize.Width * 2),
+                        Rectangle.Bottom - buttonOffset - buttonSize.Height, buttonSize.Width, buttonSize.Height);
+                    cancelButton.Rectangle = new RectangleF(Rectangle.Right - buttonOffset - buttonSize.Width,
+                        Rectangle.Bottom - buttonOffset - buttonSize.Height, buttonSize.Width, buttonSize.Height);
+                }
+                else
+                {
+                    confirmButton.Rectangle = new RectangleF(Rectangle.Right - (buttonSize.Width * 2) - buttonOffset,
+                        Rectangle.Bottom + buttonOffset, buttonSize.Width, buttonSize.Height);
+                    cancelButton.Rectangle = new RectangleF(Rectangle.Right - buttonSize.Width,
+                        Rectangle.Bottom + buttonOffset, buttonSize.Width, buttonSize.Height);
+                }
+            }
+        }
+
+        public override void OnDraw(Graphics g)
+        {
+            if (IsHorizontalTrim)
+            {
+                g.FillRectangle(EffectBrush, new RectangleF(Rectangle.X, g.ClipBounds.Y, Rectangle.Width, g.ClipBounds.Height));
+            }
+            else if (IsVerticalTrim)
+            {
+                g.FillRectangle(EffectBrush, new RectangleF(g.ClipBounds.X, Rectangle.Y, g.ClipBounds.Width, Rectangle.Height));
+            }
+        }
+
+        public override void OnCreated()
+        {
+            confirmButton = new ImageEditorButton()
+            {
+                Text = "\u2714",
+                ButtonColor = Color.ForestGreen,
+                Rectangle = new Rectangle(new Point(), buttonSize),
+                Visible = true
+            };
+            confirmButton.MouseDown += ConfirmButton_MousePressed;
+            confirmButton.MouseEnter += () => Manager.Form.Cursor = Cursors.Hand;
+            confirmButton.MouseLeave += () => Manager.Form.SetDefaultCursor();
+            Manager.DrawableObjects.Add(confirmButton);
+
+            cancelButton = new ImageEditorButton()
+            {
+                Text = "\u2716",
+                ButtonColor = Color.FromArgb(227, 45, 45),
+                Rectangle = new Rectangle(new Point(), buttonSize),
+                Visible = true
+            };
+            cancelButton.MouseDown += CancelButton_MousePressed;
+            cancelButton.MouseEnter += () => Manager.Form.Cursor = Cursors.Hand;
+            cancelButton.MouseLeave += () => Manager.Form.SetDefaultCursor();
+            Manager.DrawableObjects.Add(cancelButton);
+        }
+
+        private void ConfirmButton_MousePressed(object sender, MouseEventArgs e)
+        {
+            Manager.TrimInterior(Rectangle);
+            Remove();
+        }
+
+        private void CancelButton_MousePressed(object sender, MouseEventArgs e)
+        {
+            Remove();
+        }
+
+        public override void Remove()
+        {
+            base.Remove();
+
+            if (Options.SwitchToSelectionToolAfterDrawing)
+            {
+                Manager.CurrentTool = ShapeType.ToolSelect;
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            if ((confirmButton != null && confirmButton.IsCursorHover) || (cancelButton != null && cancelButton.IsCursorHover))
+            {
+                Manager.Form.SetDefaultCursor();
+            }
+
+            if (confirmButton != null)
+            {
+                Manager.DrawableObjects.Remove(confirmButton);
+            }
+
+            if (cancelButton != null)
+            {
+                Manager.DrawableObjects.Remove(cancelButton);
+            }
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Animations\TextAnimation.cs" />
     <Compile Include="RegionHelpers\WindowsList.cs" />
     <Compile Include="RegionHelpers\WindowsRectangleList.cs" />
+    <Compile Include="Shapes\Tool\TrimInteriorTool.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj">

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -226,7 +226,7 @@
     <Compile Include="Animations\TextAnimation.cs" />
     <Compile Include="RegionHelpers\WindowsList.cs" />
     <Compile Include="RegionHelpers\WindowsRectangleList.cs" />
-    <Compile Include="Shapes\Tool\TrimInteriorTool.cs" />
+    <Compile Include="Shapes\Tool\CutOutTool.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj">


### PR DESCRIPTION
Implement #4513 by adding a tool to "cut out" the middle parts of images.

Example of the result:
![image](https://user-images.githubusercontent.com/1062071/184991781-8b72cd03-0015-421f-b990-59a59a6a973d.png)
![image](https://user-images.githubusercontent.com/1062071/184991348-54a75127-9cc1-4a78-9b41-748fe3bfa580.png)

Feature checklist:
- [x] Select horizontal or vertical regions in the image to remove
- [x] Confirm or cancel the selection similar to the Crop tool
- [x] The selected region to be removed is highlighted
- [x] Other shapes already on the image are trimmed, moved, or removed, to fit the cut out region
- [x] Support for different effects on the cut edge
- - [x] Zig-zag (sawtooth)
- - [x] Wave 
- - [x] Torn edge
- - [x] ~~Gradient crossfade~~ (dropped)
- [x] UI for selecting and configuring cut effects
- [x] Toolbar button graphics
- [x] Interface strings
- [x] ~~Better handling of transparent or adding background to cut effect areas, as well as option for outline or not on the cut effect~~

Handling of outline or background on the cut out effects might be better left for the user to do with Image Effects or external tools. There are some UI issues with making clear that the cut-out effect area is transparent, but implementing edge effects on this would also be excessively much work, and giving a way to fill the cut out effect similarly has some bad UI affordances.
Giving an option to fill or outline the cut out effect would either use the image effects as-is, which could affect other transparent areas on the image, contrary to what the user might expect, or it would need a large amount of work to make the cut out effect code able to draw/fill that part itself, which seems bad from a cost/benefit view.

I am not very familiar with the code so I would appreciate pointers on any parts that need to be structured differently, commit messages, etc.
