### PR TITLE
Quick image combine with drag & drop

### DIFF
--- a/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleLabel.cs
+++ b/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleLabel.cs
@@ -112,7 +112,7 @@ namespace ShareX.HelpersLib
             }
         }
 
-        private Color borderColor;
+        private Color borderColor = Color.Black;
 
         [DefaultValue(typeof(Color), "Black")]
         public Color BorderColor

--- a/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleLabel.cs
+++ b/ShareX.HelpersLib/Controls/BlackStyle/BlackStyleLabel.cs
@@ -112,6 +112,23 @@ namespace ShareX.HelpersLib
             }
         }
 
+        private Color borderColor;
+
+        [DefaultValue(typeof(Color), "Black")]
+        public Color BorderColor
+        {
+            get
+            {
+                return borderColor;
+            }
+            set
+            {
+                borderColor = value;
+
+                Invalidate();
+            }
+        }
+
         private bool autoEllipsis;
 
         [DefaultValue(false)]
@@ -150,7 +167,10 @@ namespace ShareX.HelpersLib
 
                 if (drawBorder)
                 {
-                    g.DrawRectangleProper(Pens.Black, ClientRectangle);
+                    using (Pen pen = new Pen(BorderColor, 1))
+                    {
+                        g.DrawRectangleProper(pen, ClientRectangle);
+                    }
                 }
             }
         }

--- a/ShareX/Controls/TaskThumbnailPanel.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.Designer.cs
@@ -65,6 +65,7 @@
             // 
             // pThumbnail
             // 
+            this.pThumbnail.AllowDrop = true;
             this.pThumbnail.BackColor = System.Drawing.Color.Transparent;
             this.pThumbnail.Controls.Add(this.lblCombineVertical);
             this.pThumbnail.Controls.Add(this.lblError);
@@ -77,6 +78,9 @@
             this.pThumbnail.Radius = 5F;
             this.pThumbnail.Selected = false;
             this.pThumbnail.StatusLocation = ShareX.ThumbnailTitleLocation.Top;
+            this.pThumbnail.DragDrop += new System.Windows.Forms.DragEventHandler(this.pThumbnail_DragDrop);
+            this.pThumbnail.DragEnter += new System.Windows.Forms.DragEventHandler(this.pThumbnail_DragEnter);
+            this.pThumbnail.DragLeave += new System.EventHandler(this.pThumbnail_DragLeave);
             // 
             // lblCombineVertical
             // 
@@ -129,16 +133,12 @@
             // 
             // TaskThumbnailPanel
             // 
-            this.AllowDrop = true;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.pThumbnail);
             this.Controls.Add(this.lblTitle);
             this.Name = "TaskThumbnailPanel";
-            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.TaskThumbnailPanel_DragDrop);
-            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.TaskThumbnailPanel_DragEnter);
-            this.DragLeave += new System.EventHandler(this.TaskThumbnailPanel_DragLeave);
             this.pThumbnail.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pbThumbnail)).EndInit();
             this.ResumeLayout(false);

--- a/ShareX/Controls/TaskThumbnailPanel.Designer.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.Designer.cs
@@ -36,7 +36,9 @@
             this.ttMain = new System.Windows.Forms.ToolTip(this.components);
             this.lblTitle = new ShareX.HelpersLib.BlackStyleLabel();
             this.pThumbnail = new ShareX.TaskRoundedCornerPanel();
+            this.lblCombineVertical = new ShareX.HelpersLib.BlackStyleLabel();
             this.lblError = new ShareX.HelpersLib.BlackStyleLabel();
+            this.lblCombineHorizontal = new ShareX.HelpersLib.BlackStyleLabel();
             this.pbProgress = new ShareX.HelpersLib.BlackStyleProgressBar();
             this.pbThumbnail = new System.Windows.Forms.PictureBox();
             this.pThumbnail.SuspendLayout();
@@ -64,7 +66,9 @@
             // pThumbnail
             // 
             this.pThumbnail.BackColor = System.Drawing.Color.Transparent;
+            this.pThumbnail.Controls.Add(this.lblCombineVertical);
             this.pThumbnail.Controls.Add(this.lblError);
+            this.pThumbnail.Controls.Add(this.lblCombineHorizontal);
             this.pThumbnail.Controls.Add(this.pbProgress);
             this.pThumbnail.Controls.Add(this.pbThumbnail);
             resources.ApplyResources(this.pThumbnail, "pThumbnail");
@@ -73,6 +77,16 @@
             this.pThumbnail.Radius = 5F;
             this.pThumbnail.Selected = false;
             this.pThumbnail.StatusLocation = ShareX.ThumbnailTitleLocation.Top;
+            // 
+            // lblCombineVertical
+            // 
+            this.lblCombineVertical.BackColor = System.Drawing.Color.Transparent;
+            this.lblCombineVertical.BorderColor = System.Drawing.Color.Empty;
+            this.lblCombineVertical.DrawBorder = true;
+            resources.ApplyResources(this.lblCombineVertical, "lblCombineVertical");
+            this.lblCombineVertical.ForeColor = System.Drawing.Color.White;
+            this.lblCombineVertical.Name = "lblCombineVertical";
+            this.lblCombineVertical.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblError
             // 
@@ -83,6 +97,16 @@
             this.lblError.Name = "lblError";
             this.lblError.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.lblError.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lblError_MouseClick);
+            // 
+            // lblCombineHorizontal
+            // 
+            this.lblCombineHorizontal.BackColor = System.Drawing.Color.Transparent;
+            this.lblCombineHorizontal.BorderColor = System.Drawing.Color.Empty;
+            this.lblCombineHorizontal.DrawBorder = true;
+            resources.ApplyResources(this.lblCombineHorizontal, "lblCombineHorizontal");
+            this.lblCombineHorizontal.ForeColor = System.Drawing.Color.White;
+            this.lblCombineHorizontal.Name = "lblCombineHorizontal";
+            this.lblCombineHorizontal.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // pbProgress
             // 
@@ -105,12 +129,16 @@
             // 
             // TaskThumbnailPanel
             // 
+            this.AllowDrop = true;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Transparent;
             this.Controls.Add(this.pThumbnail);
             this.Controls.Add(this.lblTitle);
             this.Name = "TaskThumbnailPanel";
+            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.TaskThumbnailPanel_DragDrop);
+            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.TaskThumbnailPanel_DragEnter);
+            this.DragLeave += new System.EventHandler(this.TaskThumbnailPanel_DragLeave);
             this.pThumbnail.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pbThumbnail)).EndInit();
             this.ResumeLayout(false);
@@ -125,5 +153,7 @@
         private System.Windows.Forms.PictureBox pbThumbnail;
         private System.Windows.Forms.ToolTip ttMain;
         private HelpersLib.BlackStyleLabel lblError;
+        private HelpersLib.BlackStyleLabel lblCombineHorizontal;
+        private HelpersLib.BlackStyleLabel lblCombineVertical;
     }
 }

--- a/ShareX/Controls/TaskThumbnailPanel.cs
+++ b/ShareX/Controls/TaskThumbnailPanel.cs
@@ -233,7 +233,6 @@ namespace ShareX
         public ThumbnailViewClickAction ClickAction { get; set; }
 
         private Rectangle dragBoxFromMouseDown;
-        private Orientation combineOrientation;
 
         public TaskThumbnailPanel(WorkerTask task)
         {
@@ -322,10 +321,10 @@ namespace ShareX
                 lblError.Location = new Point((ClientSize.Width - lblError.Width) / 2, pThumbnail.Height - lblError.Height - 1);
             }
 
-            lblCombineHorizontal.Location = new Point(0, 0);
-            lblCombineHorizontal.Size = new Size(pThumbnail.Width, pThumbnail.Height / 2);
-            lblCombineVertical.Location = new Point(0, pThumbnail.Height / 2 - 1);
-            lblCombineVertical.Size = new Size(pThumbnail.Width, pThumbnail.Height / 2);
+            lblCombineHorizontal.Location = new Point(pbThumbnail.Left, pbThumbnail.Top);
+            lblCombineHorizontal.Size = new Size(pbThumbnail.Width, pbThumbnail.Height / 2);
+            lblCombineVertical.Location = new Point(pbThumbnail.Left, pbThumbnail.Top + pbThumbnail.Height / 2 - 1);
+            lblCombineVertical.Size = new Size(pbThumbnail.Width, pbThumbnail.Height / 2 + 1);
         }
 
         public void UpdateThumbnail(Bitmap bmp = null)
@@ -570,7 +569,7 @@ namespace ShareX
             {
                 if (Task.Info != null && !string.IsNullOrEmpty(Task.Info.FilePath) && File.Exists(Task.Info.FilePath))
                 {
-                    AllowDrop = false;
+                    pThumbnail.AllowDrop = false;
                     Program.MainForm.AllowDrop = false;
 
                     try
@@ -581,7 +580,7 @@ namespace ShareX
                     }
                     finally
                     {
-                        AllowDrop = true;
+                        pThumbnail.AllowDrop = true;
                         Program.MainForm.AllowDrop = true;
                     }
                 }
@@ -592,7 +591,7 @@ namespace ShareX
             }
         }
 
-        private void TaskThumbnailPanel_DragEnter(object sender, DragEventArgs e)
+        private void pThumbnail_DragEnter(object sender, DragEventArgs e)
         {
             string filePath = Task.Info.FilePath;
 
@@ -610,28 +609,21 @@ namespace ShareX
             }
         }
 
-        private void TaskThumbnailPanel_DragLeave(object sender, EventArgs e)
+        private void pThumbnail_DragLeave(object sender, EventArgs e)
         {
             lblCombineHorizontal.Visible = false;
             lblCombineVertical.Visible = false;
         }
 
-        private void TaskThumbnailPanel_DragDrop(object sender, DragEventArgs e)
+        private void pThumbnail_DragDrop(object sender, DragEventArgs e)
         {
-            Rectangle horizontal = lblCombineHorizontal.RectangleToScreen(lblCombineHorizontal.ClientRectangle);
+            Orientation combineOrientation = Orientation.Horizontal;
 
-            if (horizontal.Contains(e.X, e.Y))
-            {
-                combineOrientation = Orientation.Horizontal;
-            }
-            else
-            {
-                Rectangle vertical = lblCombineVertical.RectangleToScreen(lblCombineVertical.ClientRectangle);
+            Point vertical = lblCombineVertical.PointToScreen(lblCombineVertical.ClientRectangle.Location);
 
-                if (vertical.Contains(e.X, e.Y))
-                {
-                    combineOrientation = Orientation.Vertical;
-                }
+            if (e.Y >= vertical.Y)
+            {
+                combineOrientation = Orientation.Vertical;
             }
 
             string filePath = Task.Info.FilePath;

--- a/ShareX/Controls/TaskThumbnailPanel.resx
+++ b/ShareX/Controls/TaskThumbnailPanel.resx
@@ -138,13 +138,43 @@
     <value>lblTitle</value>
   </data>
   <data name="&gt;&gt;lblTitle.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=13.6.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTitle.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblTitle.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="lblCombineVertical.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 20.25pt</value>
+  </data>
+  <data name="lblCombineVertical.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 128</value>
+  </data>
+  <data name="lblCombineVertical.Size" type="System.Drawing.Size, System.Drawing">
+    <value>184, 80</value>
+  </data>
+  <data name="lblCombineVertical.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblCombineVertical.Text" xml:space="preserve">
+    <value>Vertical</value>
+  </data>
+  <data name="lblCombineVertical.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblCombineVertical.Name" xml:space="preserve">
+    <value>lblCombineVertical</value>
+  </data>
+  <data name="&gt;&gt;lblCombineVertical.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lblCombineVertical.Parent" xml:space="preserve">
+    <value>pThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblCombineVertical.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblError.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -172,13 +202,43 @@
     <value>lblError</value>
   </data>
   <data name="&gt;&gt;lblError.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=13.6.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblError.Parent" xml:space="preserve">
     <value>pThumbnail</value>
   </data>
   <data name="&gt;&gt;lblError.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
+  </data>
+  <data name="lblCombineHorizontal.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 20.25pt</value>
+  </data>
+  <data name="lblCombineHorizontal.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 40</value>
+  </data>
+  <data name="lblCombineHorizontal.Size" type="System.Drawing.Size, System.Drawing">
+    <value>184, 80</value>
+  </data>
+  <data name="lblCombineHorizontal.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblCombineHorizontal.Text" xml:space="preserve">
+    <value>Horizontal</value>
+  </data>
+  <data name="lblCombineHorizontal.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblCombineHorizontal.Name" xml:space="preserve">
+    <value>lblCombineHorizontal</value>
+  </data>
+  <data name="&gt;&gt;lblCombineHorizontal.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.BlackStyleLabel, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lblCombineHorizontal.Parent" xml:space="preserve">
+    <value>pThumbnail</value>
+  </data>
+  <data name="&gt;&gt;lblCombineHorizontal.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="pbProgress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -205,16 +265,19 @@
     <value>pbProgress</value>
   </data>
   <data name="&gt;&gt;pbProgress.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.BlackStyleProgressBar, ShareX.HelpersLib, Version=13.6.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.BlackStyleProgressBar, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pbProgress.Parent" xml:space="preserve">
     <value>pThumbnail</value>
   </data>
   <data name="&gt;&gt;pbProgress.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="pbThumbnail.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
+  </data>
+  <data name="pbThumbnail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="pbThumbnail.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 4</value>
@@ -235,7 +298,7 @@
     <value>pThumbnail</value>
   </data>
   <data name="&gt;&gt;pbThumbnail.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="pThumbnail.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 24</value>
@@ -253,7 +316,7 @@
     <value>pThumbnail</value>
   </data>
   <data name="&gt;&gt;pThumbnail.Type" xml:space="preserve">
-    <value>ShareX.TaskRoundedCornerPanel, ShareX, Version=13.6.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.TaskRoundedCornerPanel, ShareX, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pThumbnail.Parent" xml:space="preserve">
     <value>$this</value>

--- a/ShareX/Controls/TaskThumbnailPanel.resx
+++ b/ShareX/Controls/TaskThumbnailPanel.resx
@@ -147,7 +147,7 @@
     <value>1</value>
   </data>
   <data name="lblCombineVertical.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 20.25pt</value>
+    <value>Segoe UI, 14.25pt</value>
   </data>
   <data name="lblCombineVertical.Location" type="System.Drawing.Point, System.Drawing">
     <value>40, 128</value>
@@ -159,7 +159,8 @@
     <value>6</value>
   </data>
   <data name="lblCombineVertical.Text" xml:space="preserve">
-    <value>Vertical</value>
+    <value>Combine images
+(Vertical)</value>
   </data>
   <data name="lblCombineVertical.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -211,7 +212,7 @@
     <value>1</value>
   </data>
   <data name="lblCombineHorizontal.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Segoe UI, 20.25pt</value>
+    <value>Segoe UI, 14.25pt</value>
   </data>
   <data name="lblCombineHorizontal.Location" type="System.Drawing.Point, System.Drawing">
     <value>40, 40</value>
@@ -223,7 +224,8 @@
     <value>5</value>
   </data>
   <data name="lblCombineHorizontal.Text" xml:space="preserve">
-    <value>Horizontal</value>
+    <value>Combine images
+(Horizontal)</value>
   </data>
   <data name="lblCombineHorizontal.Visible" type="System.Boolean, mscorlib">
     <value>False</value>


### PR DESCRIPTION
Allow quickly combining images from main window by dragging thumbnails:

![](https://jaex.getsharex.com/2022/10/ShareX_Z0FIGB2i7v.gif)

Dragging to top combines images horizontally, dragging to bottom combines vertically.

Also users can drag image file from Windows Explorer to thumbnail.