### PR TITLE
fixed #6494: Allow closing OCR form with Esc key

### DIFF
--- a/ShareX/Tools/OCR/OCRForm.Designer.cs
+++ b/ShareX/Tools/OCR/OCRForm.Designer.cs
@@ -164,9 +164,11 @@
             this.Controls.Add(this.lblResult);
             this.Controls.Add(this.cbLanguages);
             this.Controls.Add(this.lblLanguage);
+            this.KeyPreview = true;
             this.Name = "OCRForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Shown += new System.EventHandler(this.OCRForm_Shown);
+            this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.OCRForm_KeyUp);
             ((System.ComponentModel.ISupportInitialize)(this.nudScaleFactor)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/ShareX/Tools/OCR/OCRForm.cs
+++ b/ShareX/Tools/OCR/OCRForm.cs
@@ -171,6 +171,14 @@ namespace ShareX
             await OCR(bmpSource);
         }
 
+        private void OCRForm_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape)
+            {
+                Close();
+            }
+        }
+
         private async void btnSelectRegion_Click(object sender, EventArgs e)
         {
             FormWindowState previousState = WindowState;


### PR DESCRIPTION
Allow closing OCR form with <kbd>Esc</kbd> key.

Fixes issue #6494.