### PR TITLE
fixed #6434: Allow dragging file to second file path textbox

### DIFF
--- a/ShareX.HelpersLib/Forms/HashCheckForm.Designer.cs
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.Designer.cs
@@ -173,9 +173,12 @@
             // 
             // txtFilePath2
             // 
+            this.txtFilePath2.AllowDrop = true;
             this.txtFilePath2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             resources.ApplyResources(this.txtFilePath2, "txtFilePath2");
             this.txtFilePath2.Name = "txtFilePath2";
+            this.txtFilePath2.DragDrop += new System.Windows.Forms.DragEventHandler(this.txtFilePath2_DragDrop);
+            this.txtFilePath2.DragEnter += new System.Windows.Forms.DragEventHandler(this.txtFilePath2_DragEnter);
             // 
             // btnFilePathBrowse2
             // 

--- a/ShareX.HelpersLib/Forms/HashCheckForm.cs
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.cs
@@ -191,6 +191,26 @@ namespace ShareX.HelpersLib
             }
         }
 
+        private void txtFilePath2_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop, false))
+            {
+                e.Effect = DragDropEffects.Copy;
+            }
+            else
+            {
+                e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void txtFilePath2_DragDrop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop, false) && e.Data.GetData(DataFormats.FileDrop, false) is string[] files && files.Length > 0)
+            {
+                txtFilePath2.Text = files[0];
+            }
+        }
+
         #endregion File hash check
 
         #region Text conversions

--- a/ShareX.HelpersLib/Forms/HashCheckForm.resx
+++ b/ShareX.HelpersLib/Forms/HashCheckForm.resx
@@ -512,7 +512,6 @@
   </data>
   <data name="lblProgressPercentage.Text" xml:space="preserve">
     <value>0%</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblProgressPercentage.Name" xml:space="preserve">
     <value>lblProgressPercentage</value>
@@ -551,6 +550,273 @@
     <value>tcMain</value>
   </data>
   <data name="&gt;&gt;tpFileHashCheck.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckCopyAll.Name" xml:space="preserve">
+    <value>btnHashCheckCopyAll</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckCopyAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckCopyAll.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckCopyAll.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHash.Name" xml:space="preserve">
+    <value>txtHashCheckHash</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHash.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHash.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHash.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHash.Name" xml:space="preserve">
+    <value>lblHashCheckHash</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHash.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHash.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHash.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBase64.Name" xml:space="preserve">
+    <value>btnHashCheckDecodeBase64</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBase64.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBase64.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBase64.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBase64.Name" xml:space="preserve">
+    <value>txtHashCheckBase64</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBase64.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBase64.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBase64.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBase64.Name" xml:space="preserve">
+    <value>lblHashCheckBase64</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBase64.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBase64.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBase64.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeASCII.Name" xml:space="preserve">
+    <value>btnHashCheckDecodeASCII</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeASCII.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeASCII.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeASCII.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckASCII.Name" xml:space="preserve">
+    <value>txtHashCheckASCII</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckASCII.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckASCII.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckASCII.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckASCII.Name" xml:space="preserve">
+    <value>lblHashCheckASCII</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckASCII.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckASCII.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckASCII.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeHex.Name" xml:space="preserve">
+    <value>btnHashCheckDecodeHex</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeHex.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeHex.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeHex.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHex.Name" xml:space="preserve">
+    <value>txtHashCheckHex</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHex.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHex.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckHex.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHex.Name" xml:space="preserve">
+    <value>lblHashCheckHex</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHex.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHex.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckHex.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBinary.Name" xml:space="preserve">
+    <value>btnHashCheckDecodeBinary</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBinary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBinary.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckDecodeBinary.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBinary.Name" xml:space="preserve">
+    <value>txtHashCheckBinary</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBinary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBinary.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckBinary.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBinary.Name" xml:space="preserve">
+    <value>lblHashCheckBinary</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBinary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBinary.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckBinary.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckEncodeText.Name" xml:space="preserve">
+    <value>btnHashCheckEncodeText</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckEncodeText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckEncodeText.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;btnHashCheckEncodeText.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckText.Name" xml:space="preserve">
+    <value>txtHashCheckText</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckText.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;txtHashCheckText.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckText.Name" xml:space="preserve">
+    <value>lblHashCheckText</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckText.Parent" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;lblHashCheckText.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="tpTextConversions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpTextConversions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpTextConversions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>570, 529</value>
+  </data>
+  <data name="tpTextConversions.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpTextConversions.Text" xml:space="preserve">
+    <value>Text conversions</value>
+  </data>
+  <data name="&gt;&gt;tpTextConversions.Name" xml:space="preserve">
+    <value>tpTextConversions</value>
+  </data>
+  <data name="&gt;&gt;tpTextConversions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpTextConversions.Parent" xml:space="preserve">
+    <value>tcMain</value>
+  </data>
+  <data name="&gt;&gt;tpTextConversions.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tcMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tcMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="tcMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>578, 555</value>
+  </data>
+  <data name="tcMain.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;tcMain.Name" xml:space="preserve">
+    <value>tcMain</value>
+  </data>
+  <data name="&gt;&gt;tcMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tcMain.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tcMain.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="btnHashCheckCopyAll.Location" type="System.Drawing.Point, System.Drawing">
@@ -780,7 +1046,6 @@
   </data>
   <data name="lblHashCheckASCII.Text" xml:space="preserve">
     <value>ASCII:</value>
-    <comment>@Invariant</comment>
   </data>
   <data name="&gt;&gt;lblHashCheckASCII.Name" xml:space="preserve">
     <value>lblHashCheckASCII</value>
@@ -1021,57 +1286,6 @@
   </data>
   <data name="&gt;&gt;lblHashCheckText.ZOrder" xml:space="preserve">
     <value>17</value>
-  </data>
-  <data name="tpTextConversions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpTextConversions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpTextConversions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>570, 529</value>
-  </data>
-  <data name="tpTextConversions.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpTextConversions.Text" xml:space="preserve">
-    <value>Text conversions</value>
-  </data>
-  <data name="&gt;&gt;tpTextConversions.Name" xml:space="preserve">
-    <value>tpTextConversions</value>
-  </data>
-  <data name="&gt;&gt;tpTextConversions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpTextConversions.Parent" xml:space="preserve">
-    <value>tcMain</value>
-  </data>
-  <data name="&gt;&gt;tpTextConversions.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tcMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tcMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="tcMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>578, 555</value>
-  </data>
-  <data name="tcMain.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;tcMain.Name" xml:space="preserve">
-    <value>tcMain</value>
-  </data>
-  <data name="&gt;&gt;tcMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tcMain.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tcMain.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
Allow dragging file from Windows Explorer to second "File path" textbox in "Hash check" window:

![](https://jaex.getsharex.com/2022/10/explorer_8UpOMLbDw9.gif)

Fixes issue #6434.