### PR TITLE
fixed #6543: Added "Wrap after" option to "Image combiner" tool

### DIFF
--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -2100,30 +2100,100 @@ namespace ShareX.HelpersLib
         }
 
         public static Bitmap CombineImages(List<Bitmap> images, Orientation orientation, ImageCombinerAlignment alignment = ImageCombinerAlignment.LeftOrTop,
-            int space = 0, bool autoFillBackground = false)
+            int space = 0, int wrapAfter = 0, bool autoFillBackground = false)
         {
-            int width, height;
             int imageCount = images.Count;
-            int spaceSize = space * (imageCount - 1);
+            Rectangle[] imageRects = new Rectangle[imageCount];
+            Point position = new Point(0, 0);
+            int currentSize = 0;
 
-            if (orientation == Orientation.Horizontal)
+            for (int i = 0; i < imageCount; i++)
             {
-                width = images.Sum(x => x.Width) + spaceSize;
-                height = images.Max(x => x.Height);
-            }
-            else
-            {
-                width = images.Max(x => x.Width);
-                height = images.Sum(x => x.Height) + spaceSize;
+                Bitmap image = images[i];
+                Point offset = new Point(0, 0);
+
+                if (orientation == Orientation.Horizontal)
+                {
+                    if (wrapAfter > 0)
+                    {
+                        if (i % wrapAfter == 0)
+                        {
+                            if (i > 0)
+                            {
+                                position.X = 0;
+                                position.Y += currentSize + space;
+                            }
+
+                            currentSize = images.Skip(i).Take(wrapAfter).Max(x => x.Height);
+                        }
+                    }
+                    else if (i == 0)
+                    {
+                        currentSize = images.Max(x => x.Height);
+                    }
+
+                    switch (alignment)
+                    {
+                        default:
+                        case ImageCombinerAlignment.LeftOrTop:
+                            offset.Y = 0;
+                            break;
+                        case ImageCombinerAlignment.Center:
+                            offset.Y = (currentSize / 2) - (image.Height / 2);
+                            break;
+                        case ImageCombinerAlignment.RightOrBottom:
+                            offset.Y = currentSize - image.Height;
+                            break;
+                    }
+
+                    imageRects[i] = new Rectangle(position.X + offset.X, position.Y + offset.Y, image.Width, image.Height);
+                    position.X += image.Width + space;
+                }
+                else
+                {
+                    if (wrapAfter > 0)
+                    {
+                        if (i % wrapAfter == 0)
+                        {
+                            if (i > 0)
+                            {
+                                position.X += currentSize + space;
+                                position.Y = 0;
+                            }
+
+                            currentSize = images.Skip(i).Take(wrapAfter).Max(x => x.Width);
+                        }
+                    }
+                    else if (i == 0)
+                    {
+                        currentSize = images.Max(x => x.Width);
+                    }
+
+                    switch (alignment)
+                    {
+                        default:
+                        case ImageCombinerAlignment.LeftOrTop:
+                            offset.X = 0;
+                            break;
+                        case ImageCombinerAlignment.Center:
+                            offset.X = (currentSize / 2) - (image.Width / 2);
+                            break;
+                        case ImageCombinerAlignment.RightOrBottom:
+                            offset.X = currentSize - image.Width;
+                            break;
+                    }
+
+                    imageRects[i] = new Rectangle(position.X + offset.X, position.Y + offset.Y, image.Width, image.Height);
+                    position.Y += image.Height + space;
+                }
             }
 
-            Bitmap bmp = new Bitmap(width, height);
+            Rectangle totalImageRect = imageRects.Combine();
+            Bitmap bmp = new Bitmap(totalImageRect.Width, totalImageRect.Height);
 
             using (Graphics g = Graphics.FromImage(bmp))
             {
                 g.SetHighQuality();
-
-                Point position = new Point(0, 0);
 
                 for (int i = 0; i < imageCount; i++)
                 {
@@ -2135,49 +2205,7 @@ namespace ShareX.HelpersLib
                         g.Clear(backgroundColor);
                     }
 
-                    Rectangle rect;
-                    Point offset = new Point(0, 0);
-
-                    if (orientation == Orientation.Horizontal)
-                    {
-                        switch (alignment)
-                        {
-                            default:
-                            case ImageCombinerAlignment.LeftOrTop:
-                                offset.Y = 0;
-                                break;
-                            case ImageCombinerAlignment.Center:
-                                offset.Y = (height / 2) - (image.Height / 2);
-                                break;
-                            case ImageCombinerAlignment.RightOrBottom:
-                                offset.Y = height - image.Height;
-                                break;
-                        }
-
-                        rect = new Rectangle(position.X + offset.X, position.Y + offset.Y, image.Width, image.Height);
-                        position.X += image.Width + space;
-                    }
-                    else
-                    {
-                        switch (alignment)
-                        {
-                            default:
-                            case ImageCombinerAlignment.LeftOrTop:
-                                offset.X = 0;
-                                break;
-                            case ImageCombinerAlignment.Center:
-                                offset.X = (width / 2) - (image.Width / 2);
-                                break;
-                            case ImageCombinerAlignment.RightOrBottom:
-                                offset.X = width - image.Width;
-                                break;
-                        }
-
-                        rect = new Rectangle(position.X + offset.X, position.Y + offset.Y, image.Width, image.Height);
-                        position.Y += image.Height + space;
-                    }
-
-                    g.DrawImage(image, rect);
+                    g.DrawImage(image, imageRects[i]);
                 }
             }
 
@@ -2185,7 +2213,7 @@ namespace ShareX.HelpersLib
         }
 
         public static Bitmap CombineImages(IEnumerable<string> imageFiles, Orientation orientation, ImageCombinerAlignment alignment = ImageCombinerAlignment.LeftOrTop,
-            int space = 0, bool autoFillBackground = false)
+            int space = 0, int wrapAfter = 0, bool autoFillBackground = false)
         {
             List<Bitmap> images = new List<Bitmap>();
 
@@ -2203,7 +2231,7 @@ namespace ShareX.HelpersLib
 
                 if (images.Count > 1)
                 {
-                    return CombineImages(images, orientation, alignment, space, autoFillBackground);
+                    return CombineImages(images, orientation, alignment, space, wrapAfter, autoFillBackground);
                 }
             }
             finally

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.Designer.cs
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.Designer.cs
@@ -46,8 +46,12 @@
             this.rbOrientationHorizontal = new System.Windows.Forms.RadioButton();
             this.rbOrientationVertical = new System.Windows.Forms.RadioButton();
             this.cbAutoFillBackground = new System.Windows.Forms.CheckBox();
+            this.lblWrapAfter = new System.Windows.Forms.Label();
+            this.nudWrapAfter = new System.Windows.Forms.NumericUpDown();
+            this.lblWrapAfterImages = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nudSpace)).BeginInit();
             this.flpOrientation.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWrapAfter)).BeginInit();
             this.SuspendLayout();
             // 
             // btnAdd
@@ -175,6 +179,27 @@
             this.cbAutoFillBackground.UseVisualStyleBackColor = true;
             this.cbAutoFillBackground.CheckedChanged += new System.EventHandler(this.cbAutoFillBackground_CheckedChanged);
             // 
+            // lblWrapAfter
+            // 
+            resources.ApplyResources(this.lblWrapAfter, "lblWrapAfter");
+            this.lblWrapAfter.Name = "lblWrapAfter";
+            // 
+            // nudWrapAfter
+            // 
+            resources.ApplyResources(this.nudWrapAfter, "nudWrapAfter");
+            this.nudWrapAfter.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudWrapAfter.Name = "nudWrapAfter";
+            this.nudWrapAfter.ValueChanged += new System.EventHandler(this.nudWrapAfter_ValueChanged);
+            // 
+            // lblWrapAfterImages
+            // 
+            resources.ApplyResources(this.lblWrapAfterImages, "lblWrapAfterImages");
+            this.lblWrapAfterImages.Name = "lblWrapAfterImages";
+            // 
             // ImageCombinerForm
             // 
             this.AcceptButton = this.btnCombine;
@@ -182,6 +207,9 @@
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Window;
+            this.Controls.Add(this.lblWrapAfterImages);
+            this.Controls.Add(this.nudWrapAfter);
+            this.Controls.Add(this.lblWrapAfter);
             this.Controls.Add(this.cbAutoFillBackground);
             this.Controls.Add(this.flpOrientation);
             this.Controls.Add(this.cbAlignment);
@@ -202,6 +230,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudSpace)).EndInit();
             this.flpOrientation.ResumeLayout(false);
             this.flpOrientation.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWrapAfter)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -226,5 +255,8 @@
         private System.Windows.Forms.RadioButton rbOrientationHorizontal;
         private System.Windows.Forms.RadioButton rbOrientationVertical;
         private System.Windows.Forms.CheckBox cbAutoFillBackground;
+        private System.Windows.Forms.Label lblWrapAfter;
+        private System.Windows.Forms.NumericUpDown nudWrapAfter;
+        private System.Windows.Forms.Label lblWrapAfterImages;
     }
 }

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.Designer.cs
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.Designer.cs
@@ -49,6 +49,7 @@
             this.lblWrapAfter = new System.Windows.Forms.Label();
             this.nudWrapAfter = new System.Windows.Forms.NumericUpDown();
             this.lblWrapAfterImages = new System.Windows.Forms.Label();
+            this.lblImageCount = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nudSpace)).BeginInit();
             this.flpOrientation.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudWrapAfter)).BeginInit();
@@ -200,6 +201,11 @@
             resources.ApplyResources(this.lblWrapAfterImages, "lblWrapAfterImages");
             this.lblWrapAfterImages.Name = "lblWrapAfterImages";
             // 
+            // lblImageCount
+            // 
+            resources.ApplyResources(this.lblImageCount, "lblImageCount");
+            this.lblImageCount.Name = "lblImageCount";
+            // 
             // ImageCombinerForm
             // 
             this.AcceptButton = this.btnCombine;
@@ -207,6 +213,7 @@
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.Window;
+            this.Controls.Add(this.lblImageCount);
             this.Controls.Add(this.lblWrapAfterImages);
             this.Controls.Add(this.nudWrapAfter);
             this.Controls.Add(this.lblWrapAfter);
@@ -258,5 +265,6 @@
         private System.Windows.Forms.Label lblWrapAfter;
         private System.Windows.Forms.NumericUpDown nudWrapAfter;
         private System.Windows.Forms.Label lblWrapAfterImages;
+        private System.Windows.Forms.Label lblImageCount;
     }
 }

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.cs
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.cs
@@ -61,6 +61,19 @@ namespace ShareX.MediaLib
             cbAutoFillBackground.Checked = Options.AutoFillBackground;
         }
 
+        public ImageCombinerForm(ImageCombinerOptions options, IEnumerable<string> imageFiles) : this(options)
+        {
+            if (imageFiles != null)
+            {
+                foreach (string image in imageFiles)
+                {
+                    lvImages.Items.Add(image);
+                }
+
+                lblImageCount.Text = lvImages.Items.Count.ToString();
+            }
+        }
+
         private void UpdateOrientation()
         {
             if (rbOrientationHorizontal.Checked)
@@ -93,17 +106,6 @@ namespace ShareX.MediaLib
             cbAlignment.SelectedIndex = (int)Options.Alignment;
         }
 
-        public ImageCombinerForm(ImageCombinerOptions options, IEnumerable<string> imageFiles) : this(options)
-        {
-            if (imageFiles != null)
-            {
-                foreach (string image in imageFiles)
-                {
-                    lvImages.Items.Add(image);
-                }
-            }
-        }
-
         private void btnAdd_Click(object sender, EventArgs e)
         {
             string[] images = ImageHelpers.OpenImageFileDialog(true);
@@ -114,6 +116,8 @@ namespace ShareX.MediaLib
                 {
                     lvImages.Items.Add(image);
                 }
+
+                lblImageCount.Text = lvImages.Items.Count.ToString();
             }
         }
 
@@ -125,6 +129,8 @@ namespace ShareX.MediaLib
                 {
                     lvImages.Items.Remove(lvi);
                 }
+
+                lblImageCount.Text = lvImages.Items.Count.ToString();
             }
         }
 
@@ -228,6 +234,8 @@ namespace ShareX.MediaLib
                 {
                     lvImages.Items.Add(file);
                 }
+
+                lblImageCount.Text = lvImages.Items.Count.ToString();
             }
         }
     }

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.cs
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.cs
@@ -57,6 +57,7 @@ namespace ShareX.MediaLib
 
             UpdateAlignmentComboBox();
             nudSpace.SetValue(Options.Space);
+            nudWrapAfter.SetValue(Options.WrapAfter);
             cbAutoFillBackground.Checked = Options.AutoFillBackground;
         }
 
@@ -163,6 +164,11 @@ namespace ShareX.MediaLib
         private void nudSpace_ValueChanged(object sender, EventArgs e)
         {
             Options.Space = (int)nudSpace.Value;
+        }
+
+        private void nudWrapAfter_ValueChanged(object sender, EventArgs e)
+        {
+            Options.WrapAfter = (int)nudWrapAfter.Value;
         }
 
         private void cbAutoFillBackground_CheckedChanged(object sender, EventArgs e)

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.cs
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.cs
@@ -180,7 +180,8 @@ namespace ShareX.MediaLib
 
                     if (imageFiles.Count > 1)
                     {
-                        Bitmap output = ImageHelpers.CombineImages(imageFiles, Options.Orientation, Options.Alignment, Options.Space, Options.AutoFillBackground);
+                        Bitmap output = ImageHelpers.CombineImages(imageFiles, Options.Orientation, Options.Alignment, Options.Space, Options.WrapAfter,
+                            Options.AutoFillBackground);
 
                         if (output != null)
                         {

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.resx
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.resx
@@ -141,7 +141,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnAdd.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="btnRemove.Location" type="System.Drawing.Point, System.Drawing">
     <value>136, 8</value>
@@ -165,7 +165,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRemove.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="btnMoveUp.Location" type="System.Drawing.Point, System.Drawing">
     <value>264, 8</value>
@@ -189,7 +189,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnMoveUp.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="btnMoveDown.Location" type="System.Drawing.Point, System.Drawing">
     <value>392, 8</value>
@@ -213,7 +213,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnMoveDown.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lvImages.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -229,7 +229,7 @@
     <value>8, 40</value>
   </data>
   <data name="lvImages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>504, 344</value>
+    <value>504, 320</value>
   </data>
   <data name="lvImages.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -238,13 +238,13 @@
     <value>lvImages</value>
   </data>
   <data name="&gt;&gt;lvImages.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=13.7.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=14.1.3.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lvImages.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lvImages.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="btnCombine.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -256,7 +256,7 @@
     <value>504, 31</value>
   </data>
   <data name="btnCombine.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="btnCombine.Text" xml:space="preserve">
     <value>Combine images and save/upload depending on after capture settings</value>
@@ -271,7 +271,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCombine.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="lblSpace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -280,7 +280,7 @@
     <value>True</value>
   </data>
   <data name="lblSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 448</value>
+    <value>5, 424</value>
   </data>
   <data name="lblSpace.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 13</value>
@@ -301,13 +301,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSpace.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="nudSpace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
   <data name="nudSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 444</value>
+    <value>200, 420</value>
   </data>
   <data name="nudSpace.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 20</value>
@@ -328,7 +328,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;nudSpace.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="lblOrientation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -337,7 +337,7 @@
     <value>True</value>
   </data>
   <data name="lblOrientation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 400</value>
+    <value>5, 376</value>
   </data>
   <data name="lblOrientation.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 13</value>
@@ -358,7 +358,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblOrientation.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="lblSpacePixel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -367,7 +367,7 @@
     <value>True</value>
   </data>
   <data name="lblSpacePixel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>272, 448</value>
+    <value>272, 424</value>
   </data>
   <data name="lblSpacePixel.Size" type="System.Drawing.Size, System.Drawing">
     <value>33, 13</value>
@@ -388,7 +388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSpacePixel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="lblImageAlignment.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -397,7 +397,7 @@
     <value>True</value>
   </data>
   <data name="lblImageAlignment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 424</value>
+    <value>5, 400</value>
   </data>
   <data name="lblImageAlignment.Size" type="System.Drawing.Size, System.Drawing">
     <value>87, 13</value>
@@ -418,13 +418,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblImageAlignment.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="cbAlignment.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
   <data name="cbAlignment.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 420</value>
+    <value>200, 396</value>
   </data>
   <data name="cbAlignment.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 21</value>
@@ -442,7 +442,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbAlignment.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="flpOrientation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -508,7 +508,7 @@
     <value>1</value>
   </data>
   <data name="flpOrientation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 395</value>
+    <value>200, 371</value>
   </data>
   <data name="flpOrientation.Size" type="System.Drawing.Size, System.Drawing">
     <value>141, 23</value>
@@ -526,7 +526,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;flpOrientation.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="cbAutoFillBackground.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -541,7 +541,7 @@
     <value>120, 17</value>
   </data>
   <data name="cbAutoFillBackground.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="cbAutoFillBackground.Text" xml:space="preserve">
     <value>Auto fill background</value>
@@ -556,6 +556,93 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbAutoFillBackground.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblWrapAfter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="lblWrapAfter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblWrapAfter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 448</value>
+  </data>
+  <data name="lblWrapAfter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="lblWrapAfter.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblWrapAfter.Text" xml:space="preserve">
+    <value>Wrap after:</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfter.Name" xml:space="preserve">
+    <value>lblWrapAfter</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfter.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfter.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="nudWrapAfter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="nudWrapAfter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 444</value>
+  </data>
+  <data name="nudWrapAfter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 20</value>
+  </data>
+  <data name="nudWrapAfter.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="nudWrapAfter.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudWrapAfter.Name" xml:space="preserve">
+    <value>nudWrapAfter</value>
+  </data>
+  <data name="&gt;&gt;nudWrapAfter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudWrapAfter.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;nudWrapAfter.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblWrapAfterImages.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="lblWrapAfterImages.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblWrapAfterImages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>272, 448</value>
+  </data>
+  <data name="lblWrapAfterImages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="lblWrapAfterImages.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="lblWrapAfterImages.Text" xml:space="preserve">
+    <value>images</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfterImages.Name" xml:space="preserve">
+    <value>lblWrapAfterImages</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfterImages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfterImages.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblWrapAfterImages.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.resx
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.resx
@@ -122,7 +122,7 @@
     <value>8, 8</value>
   </data>
   <data name="btnAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
+    <value>120, 25</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnAdd.TabIndex" type="System.Int32, mscorlib">
@@ -141,13 +141,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnAdd.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="btnRemove.Location" type="System.Drawing.Point, System.Drawing">
     <value>136, 8</value>
   </data>
   <data name="btnRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
+    <value>120, 25</value>
   </data>
   <data name="btnRemove.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -165,13 +165,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRemove.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="btnMoveUp.Location" type="System.Drawing.Point, System.Drawing">
     <value>264, 8</value>
   </data>
   <data name="btnMoveUp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
+    <value>120, 25</value>
   </data>
   <data name="btnMoveUp.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -189,13 +189,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnMoveUp.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="btnMoveDown.Location" type="System.Drawing.Point, System.Drawing">
     <value>392, 8</value>
   </data>
   <data name="btnMoveDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 23</value>
+    <value>120, 25</value>
   </data>
   <data name="btnMoveDown.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -213,17 +213,11 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnMoveDown.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lvImages.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="chFilepath.Text" xml:space="preserve">
-    <value>Image file path</value>
-  </data>
-  <data name="chFilepath.Width" type="System.Int32, mscorlib">
-    <value>487</value>
   </data>
   <data name="lvImages.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 40</value>
@@ -244,7 +238,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lvImages.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
+  </data>
+  <data name="chFilepath.Text" xml:space="preserve">
+    <value>Image file path</value>
+  </data>
+  <data name="chFilepath.Width" type="System.Int32, mscorlib">
+    <value>487</value>
   </data>
   <data name="btnCombine.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -271,7 +271,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCombine.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="lblSpace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -301,7 +301,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSpace.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="nudSpace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -328,7 +328,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;nudSpace.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="lblOrientation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -358,7 +358,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblOrientation.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="lblSpacePixel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -388,7 +388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblSpacePixel.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="lblImageAlignment.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -418,7 +418,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblImageAlignment.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="cbAlignment.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -442,13 +442,58 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbAlignment.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="flpOrientation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
   <data name="flpOrientation.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationHorizontal.Name" xml:space="preserve">
+    <value>rbOrientationHorizontal</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationHorizontal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationHorizontal.Parent" xml:space="preserve">
+    <value>flpOrientation</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationHorizontal.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationVertical.Name" xml:space="preserve">
+    <value>rbOrientationVertical</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationVertical.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationVertical.Parent" xml:space="preserve">
+    <value>flpOrientation</value>
+  </data>
+  <data name="&gt;&gt;rbOrientationVertical.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="flpOrientation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 371</value>
+  </data>
+  <data name="flpOrientation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>141, 23</value>
+  </data>
+  <data name="flpOrientation.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;flpOrientation.Name" xml:space="preserve">
+    <value>flpOrientation</value>
+  </data>
+  <data name="&gt;&gt;flpOrientation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flpOrientation.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;flpOrientation.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="rbOrientationHorizontal.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -507,27 +552,6 @@
   <data name="&gt;&gt;rbOrientationVertical.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="flpOrientation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 371</value>
-  </data>
-  <data name="flpOrientation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>141, 23</value>
-  </data>
-  <data name="flpOrientation.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;flpOrientation.Name" xml:space="preserve">
-    <value>flpOrientation</value>
-  </data>
-  <data name="&gt;&gt;flpOrientation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flpOrientation.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;flpOrientation.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="cbAutoFillBackground.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -556,7 +580,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbAutoFillBackground.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblWrapAfter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -586,7 +610,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblWrapAfter.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="nudWrapAfter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -613,7 +637,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;nudWrapAfter.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblWrapAfterImages.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -643,6 +667,36 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblWrapAfterImages.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblImageCount.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="lblImageCount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>472, 368</value>
+  </data>
+  <data name="lblImageCount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 24</value>
+  </data>
+  <data name="lblImageCount.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="lblImageCount.Text" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblImageCount.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="&gt;&gt;lblImageCount.Name" xml:space="preserve">
+    <value>lblImageCount</value>
+  </data>
+  <data name="&gt;&gt;lblImageCount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblImageCount.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblImageCount.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -653,6 +707,9 @@
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>521, 536</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>537, 400</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/ShareX.MediaLib/ImageCombinerOptions.cs
+++ b/ShareX.MediaLib/ImageCombinerOptions.cs
@@ -33,6 +33,7 @@ namespace ShareX.MediaLib
         public Orientation Orientation { get; set; } = Orientation.Vertical;
         public ImageCombinerAlignment Alignment { get; set; } = ImageCombinerAlignment.LeftOrTop;
         public int Space { get; set; } = 0;
+        public int WrapAfter { get; set; } = 0;
         public bool AutoFillBackground { get; set; } = true;
     }
 }

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -833,7 +833,8 @@ namespace ShareX
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
             Bitmap output = ImageHelpers.CombineImages(imageFiles, orientation, taskSettings.ToolsSettings.ImageCombinerOptions.Alignment,
-                taskSettings.ToolsSettings.ImageCombinerOptions.Space, taskSettings.ToolsSettings.ImageCombinerOptions.AutoFillBackground);
+                taskSettings.ToolsSettings.ImageCombinerOptions.Space, taskSettings.ToolsSettings.ImageCombinerOptions.WrapAfter,
+                taskSettings.ToolsSettings.ImageCombinerOptions.AutoFillBackground);
 
             if (output != null)
             {


### PR DESCRIPTION
Added "Wrap after" option to "Image combiner" tool:

![](https://jaex.getsharex.com/2022/10/ShareX_mrJU9AB6a0.png)

**Examples:**

Wrap after: `2`

![](https://jaex.getsharex.com/2022/10/QlSycn9nFk.png)

Wrap after: `4`

![](https://jaex.getsharex.com/2022/10/yIv5b3pJmw.png)

Wrap after: `6`

![](https://jaex.getsharex.com/2022/10/wPvAKIQE9e.png)

Also added image count:

![](https://jaex.getsharex.com/2022/10/ShareX_gGneEuACZx.png)

Fixes issue #6543.