### PR TITLE
Display QR code redirected URLs

### DIFF
--- a/ShareX.UploadersLib/Helpers/ResponseHelpers.cs
+++ b/ShareX.UploadersLib/Helpers/ResponseHelpers.cs
@@ -1,0 +1,21 @@
+﻿using ShareX.HelpersLib;
+
+namespace ShareX.UploadersLib
+{
+    public class ResponseHelpers : Uploader
+    {
+        public static string UrlRedirectLink(string url)
+        {
+            if (!URLHelpers.IsValidURL(url)) return null;
+
+            ResponseHelpers responseHelper = new ResponseHelpers();
+            var response = responseHelper.GetResponse(HttpMethod.GET, url);
+
+            if (response == null) return null;
+
+            if (response.ResponseUri.ToString().ToLower() == url.ToLower()) return null;
+
+            return response.ResponseUri.ToString();
+        }
+    }
+}

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -252,6 +252,7 @@
     </Compile>
     <Compile Include="Helpers\EscapeHelper.cs" />
     <Compile Include="Helpers\MimeTypes.cs" />
+    <Compile Include="Helpers\ResponseHelpers.cs" />
     <Compile Include="Helpers\ResponseInfo.cs" />
     <Compile Include="Helpers\RequestHelpers.cs" />
     <Compile Include="Helpers\UploaderErrorManager.cs" />

--- a/ShareX/Forms/QRCodeForm.cs
+++ b/ShareX/Forms/QRCodeForm.cs
@@ -137,6 +137,11 @@ namespace ShareX
             if (results != null)
             {
                 output = string.Join(Environment.NewLine + Environment.NewLine, results);
+
+                if (UploadersLib.ResponseHelpers.UrlRedirectLink(output) != null)
+                {
+                    output = output + Environment.NewLine + Environment.NewLine + Resources.QRCodeForm_ThisLinkRedirectsTo + UploadersLib.ResponseHelpers.UrlRedirectLink(output);
+                }
             }
 
             rtbDecodeResult.Text = output;

--- a/ShareX/Properties/Resources.Designer.cs
+++ b/ShareX/Properties/Resources.Designer.cs
@@ -2368,6 +2368,15 @@ namespace ShareX.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This link redirects to: .
+        /// </summary>
+        public static string QRCodeForm_ThisLinkRedirectsTo {
+            get {
+                return ResourceManager.GetString("QRCodeForm_ThisLinkRedirectsTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         public static System.Drawing.Bitmap question {

--- a/ShareX/Properties/Resources.resx
+++ b/ShareX/Properties/Resources.resx
@@ -1119,4 +1119,7 @@ Middle click to close</value>
   <data name="FFmpegDoesNotExistAtTheFollowingPath" xml:space="preserve">
     <value>FFmpeg does not exist at the following path:</value>
   </data>
+  <data name="QRCodeForm_ThisLinkRedirectsTo" xml:space="preserve">
+    <value>This link redirects to: </value>
+  </data>
 </root>


### PR DESCRIPTION
Reference issue #6388

Implemented helper class to display URL redirect links after being decoded from QR code. Updated QRCodeForm to also display the redirected URL if it exists.

I'm a noob C# developer looking to gain open source experience so please feel free to let me know if any revisions should be made.