### PR TITLE
Add Upload with ShareX to context menu on Windows 11

### DIFF
--- a/ShareX.ContextMenuHandler/ClassFactory.cs
+++ b/ShareX.ContextMenuHandler/ClassFactory.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace ShareX.ContextMenuHandler
+{
+    [ComVisible(true)]
+    public class ContextMenuClassFactory : IClassFactory
+    {
+        public void CreateInstance(IntPtr pUnkOuter, ref Guid riid, out IntPtr ppvObject)
+        {
+            if (pUnkOuter != IntPtr.Zero)
+            {
+                const int CLASS_E_NOAGGREGATION = unchecked((int)0x80040110);
+                Marshal.ThrowExceptionForHR(CLASS_E_NOAGGREGATION);
+            }
+
+            var obj = new ShareXContextMenuHandler();
+            var pUnk = Marshal.GetIUnknownForObject(obj);
+
+            var ex = Marshal.GetExceptionForHR(Marshal.QueryInterface(pUnk, ref riid, out ppvObject));
+            Marshal.Release(pUnk);
+            if (ex != null)
+            {
+                throw ex;
+            }    
+        }
+
+        public void LockServer(bool fLock)
+        {
+            if (fLock)
+            {
+                NativeMethods.CoAddRefServerProcess();
+            }
+            else
+            {
+                ReleaseServerProcess();
+            }
+        }
+
+        private static Thread runThread;
+
+        public static void ReleaseServerProcess()
+        {
+            var count = NativeMethods.CoReleaseServerProcess();
+
+            // There are no remaining outstanding references, so we can shut down the server.
+            if (count == 0)
+            {
+                runThread.Interrupt();
+            }
+        }
+
+        public static void Run()
+        {
+            var timer = new Timer(_ => GC.Collect(), null, TimeSpan.Zero, TimeSpan.FromSeconds(6));
+            runThread = Thread.CurrentThread;
+            var factory = new ContextMenuClassFactory();
+            NativeMethods.CoRegisterClassObject(
+                typeof(ShareXContextMenuHandler).GUID, factory, RegistrationClassContext.LocalServer, RegistrationConnectionType.MultipleUse, out var cookie);
+
+            try
+            {
+                Thread.Sleep(Timeout.Infinite);
+            }
+            catch (ThreadInterruptedException)
+            {
+                NativeMethods.CoRevokeClassObject(cookie);
+            }
+
+            GC.KeepAlive(timer);
+        }
+    }
+}

--- a/ShareX.ContextMenuHandler/NativeInterfaces.cs
+++ b/ShareX.ContextMenuHandler/NativeInterfaces.cs
@@ -158,5 +158,30 @@ namespace ShareX.ContextMenuHandler
 
         void Compare(IShellItem psi, uint hint, out int piOrder);
     }
+
+    [Guid("00000001-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [SuppressUnmanagedCodeSecurity]
+    public interface IClassFactory
+    {
+        void CreateInstance(IntPtr pUnkOuter, ref Guid riid, out IntPtr ppvObject);
+        void LockServer(bool fLock);
+    }
+
+    [SuppressUnmanagedCodeSecurity]
+    internal static class NativeMethods
+    {
+        [DllImport("ole32", PreserveSig = false, ExactSpelling = true)]
+        internal static extern void CoRegisterClassObject(in Guid rclsid, [MarshalAs(UnmanagedType.IUnknown)] object pUnk, RegistrationClassContext dwClsContext, RegistrationConnectionType flags, out uint lpdwRegister);
+
+        [DllImport("ole32", PreserveSig = false, ExactSpelling = true)]
+        internal static extern void CoRevokeClassObject(uint dwRegister);
+
+        [DllImport("ole32", ExactSpelling = true)]
+        internal static extern uint CoReleaseServerProcess();
+
+        [DllImport("ole32", ExactSpelling = true)]
+        internal static extern uint CoAddRefServerProcess();
+    }
 }
 

--- a/ShareX.ContextMenuHandler/NativeInterfaces.cs
+++ b/ShareX.ContextMenuHandler/NativeInterfaces.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security;
+
+namespace ShareX.ContextMenuHandler
+{
+    using GETPROPERTYSTOREFLAGS = UInt32;
+
+    public enum SIGDN : uint
+    {
+        NORMALDISPLAY,
+        PARENTRELATIVEPARSING = 2147581953,
+        DESKTOPABSOLUTEPARSING = 2147647488,
+        PARENTRELATIVEEDITING = 2147684353,
+        DESKTOPABSOLUTEEDITING = 2147794944,
+        FILESYSPATH = 2147844096,
+        URL = 2147909632,
+        PARENTRELATIVEFORADDRESSBAR = 2147991553,
+        PARENTRELATIVE = 2148007937
+    }
+
+    [Flags]
+    public enum SIATTRIBFLAGS
+    {
+        SIATTRIBFLAGS_AND = 1,
+        SIATTRIBFLAGS_OR = 2,
+        SIATTRIBFLAGS_APPCOMPAT = 3,
+        SIATTRIBFLAGS_MASK = 3,
+        SIATTRIBFLAGS_ALLITEMS = 16384
+    }
+
+    [Flags]
+    public enum EXPCMDSTATE
+    {
+        ECS_ENABLED = 0,
+        ECS_DISABLED = 1,
+        ECS_HIDDEN = 2,
+        ECS_CHECKBOX = 4,
+        ECS_CHECKED = 8,
+        ECS_RADIOCHECK = 16,
+    };
+
+    [Flags]
+    public enum EXPCMDFLAGS
+    {
+        ECF_DEFAULT = 0,
+        ECF_HASSUBCOMMANDS = 1,
+        ECF_HASSPLITBUTTON = 2,
+        ECF_HIDELABEL = 4,
+        ECF_ISSEPARATOR = 8,
+        ECF_HASLUASHIELD = 16,
+        ECF_SEPARATORBEFORE = 32,
+        ECF_SEPARATORAFTER = 64,
+        ECF_ISDROPDOWN = 128,
+        ECF_TOGGLEABLE = 256,
+        ECF_AUTOMENUICONS = 512
+    };
+
+    [Flags]
+    public enum SFGAO : uint
+    {
+        CANCOPY = 1,
+        CANMOVE = 2,
+        CANLINK = 4,
+        STORAGE = 8,
+        CANRENAME = 16,
+        CANDELETE = 32,
+        HASPROPSHEET = 64,
+        DROPTARGET = 256,
+        SYSTEM = 4096,
+        ENCRYPTED = 8192,
+        ISSLOW = 16384,
+        GHOSTED = 32768,
+        LINK = 65536,
+        SHARE = 131072,
+        READONLY = 262144,
+        HIDDEN = 524288,
+        NONENUMERATED = 1048576,
+        NEWCONTENT = 2097152,
+        STREAM = 4194304,
+        STORAGEANCESTOR = 8388608,
+        VALIDATE = 16777216,
+        REMOVABLE = 33554432,
+        COMPRESSED = 67108864,
+        BROWSABLE = 134217728,
+        FILESYSANCESTOR = 268435456,
+        FOLDER = 536870912,
+        FILESYSTEM = 1073741824,
+        HASSUBFOLDER = 2147483648,
+    }
+
+    public struct PROPERTYKEY
+    {
+        public Guid fmtid;
+
+        public uint pid;
+    }
+
+    [ComImport]
+    [Guid("A08CE4D0-FA25-44AB-B57C-C7B1C323E0B9")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [SuppressUnmanagedCodeSecurity]
+    public interface IExplorerCommand
+    {
+        void GetTitle(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+
+        void GetIcon(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszIcon);
+
+        void GetToolTip(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszInfotip);
+
+        void GetCanonicalName(out Guid pguidCommandName);
+
+        void GetState(IShellItemArray psiItemArray, bool fOkToBeSlow, out EXPCMDSTATE pCmdState);
+
+        void Invoke(IShellItemArray psiItemArray, IBindCtx pbc);
+
+        void GetFlags(out EXPCMDFLAGS pFlags);
+
+        void EnumSubCommands(out object ppenum);
+    }
+
+    [ComImport]
+    [Guid("B63EA76D-1F85-456F-A19C-48159EFA858B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [SuppressUnmanagedCodeSecurity]
+    public interface IShellItemArray
+    {
+        void BindToHandler(IBindCtx pbc, in Guid bhid, in Guid riid, out IntPtr ppvOut);
+
+        void GetPropertyStore(GETPROPERTYSTOREFLAGS Flags, in Guid riid, out IntPtr ppv);
+
+        void GetPropertyDescriptionList(in PROPERTYKEY keyType, in Guid riid, out IntPtr ppv);
+
+        void GetAttributes(SIATTRIBFLAGS AttribFlags, SFGAO sfgaoMask, out SFGAO psfgaoAttribs);
+
+        void GetCount(out uint pdwNumItems);
+
+        void GetItemAt(uint dwIndex, out IShellItem ppsi);
+
+        void EnumItems(out object ppenumShellItems);
+    }
+
+    [ComImport]
+
+    [Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [SuppressUnmanagedCodeSecurity]
+    public interface IShellItem
+    {
+        void BindToHandler(IBindCtx pbc, in Guid bhid, in Guid riid, out IntPtr ppv);
+
+        void GetParent(out object ppsi);
+
+        void GetDisplayName(SIGDN sigdnName, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+
+        void GetAttributes(SFGAO sfgaoMask, out SFGAO psfgaoAttribs);
+
+        void Compare(IShellItem psi, uint hint, out int piOrder);
+    }
+}
+

--- a/ShareX.ContextMenuHandler/Program.cs
+++ b/ShareX.ContextMenuHandler/Program.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+
+namespace ShareX.ContextMenuHandler
+{
+    internal class Program
+    {   
+        static void Main(string[] args)
+        {
+            var services = new RegistrationServices();
+            var cookie = services.RegisterTypeForComClients(typeof(ShareXContextMenuHandler), RegistrationClassContext.LocalServer, RegistrationConnectionType.MultipleUse);
+            Console.ReadKey();
+            services.UnregisterTypeForComClients(cookie);
+        }
+    }
+
+    [ComVisible(true)]
+    [Guid("4B905A2A-D71C-48D1-AE87-33B15375E13D")]
+    [ClassInterface(ClassInterfaceType.None)]
+    public class ShareXContextMenuHandler : IExplorerCommand
+    {
+
+        public void GetTitle(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName)
+        {
+            ppszName = "Upload with ShareX";
+        }
+
+        public void GetIcon(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszIcon)
+        {
+            ppszIcon = GetShareXExePath() + ",-32512";
+        }
+
+        public void GetToolTip(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszInfotip)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void GetCanonicalName(out Guid pguidCommandName)
+        {
+            pguidCommandName = default;
+        }
+
+        public void GetState(IShellItemArray psiItemArray, bool fOkToBeSlow, out EXPCMDSTATE pCmdState)
+        {
+            psiItemArray.GetCount(out var count);
+            // For now, we only support selecting one item at a time. 
+            if (count != 1)
+            {
+                pCmdState = EXPCMDSTATE.ECS_HIDDEN;
+                return;
+            }
+
+            // If none of the items have a filesystem path, we shouldn't show the menu item.
+            psiItemArray.GetAttributes(SIATTRIBFLAGS.SIATTRIBFLAGS_OR, SFGAO.FILESYSTEM, out var attribs);
+            if (attribs == 0)
+            {
+                pCmdState = EXPCMDSTATE.ECS_HIDDEN;
+                return;
+            }
+
+            pCmdState = EXPCMDSTATE.ECS_ENABLED;
+        }
+
+        public void Invoke(IShellItemArray psiItemArray, IBindCtx pbc)
+        {
+            psiItemArray.GetItemAt(0, out var shellItem);
+            shellItem.GetDisplayName(SIGDN.FILESYSPATH, out var name);
+            Process.Start(GetShareXExePath(), $"\"{name}\"");
+        }
+
+        public void GetFlags(out EXPCMDFLAGS pFlags)
+        {
+            pFlags = EXPCMDFLAGS.ECF_DEFAULT;
+        }
+
+        public void EnumSubCommands(out object ppenum)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static string GetShareXExePath()
+        {
+            var thisLocation = typeof(ShareXContextMenuHandler).Assembly.Location;
+            var dir = Path.GetDirectoryName(thisLocation);
+            return Path.Combine(dir, "ShareX.exe");
+        }
+    }
+}

--- a/ShareX.ContextMenuHandler/Program.cs
+++ b/ShareX.ContextMenuHandler/Program.cs
@@ -4,17 +4,13 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 
-
 namespace ShareX.ContextMenuHandler
 {
     internal class Program
     {   
         static void Main(string[] args)
         {
-            var services = new RegistrationServices();
-            var cookie = services.RegisterTypeForComClients(typeof(ShareXContextMenuHandler), RegistrationClassContext.LocalServer, RegistrationConnectionType.MultipleUse);
-            Console.ReadKey();
-            services.UnregisterTypeForComClients(cookie);
+            ContextMenuClassFactory.Run();
         }
     }
 
@@ -23,6 +19,15 @@ namespace ShareX.ContextMenuHandler
     [ClassInterface(ClassInterfaceType.None)]
     public class ShareXContextMenuHandler : IExplorerCommand
     {
+        public ShareXContextMenuHandler()
+        {
+            NativeMethods.CoAddRefServerProcess();
+        }
+
+        ~ShareXContextMenuHandler()
+        {
+            ContextMenuClassFactory.ReleaseServerProcess();
+        }
 
         public void GetTitle(IShellItemArray psiItemArray, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName)
         {
@@ -47,7 +52,8 @@ namespace ShareX.ContextMenuHandler
         public void GetState(IShellItemArray psiItemArray, bool fOkToBeSlow, out EXPCMDSTATE pCmdState)
         {
             psiItemArray.GetCount(out var count);
-            // For now, we only support selecting one item at a time. 
+            // For now, we only support selecting one item at a time.
+            // Implementing support for multi-selection may need better UI in ShareX.
             if (count != 1)
             {
                 pCmdState = EXPCMDSTATE.ECS_HIDDEN;

--- a/ShareX.ContextMenuHandler/ShareX.ContextMenuHandler.csproj
+++ b/ShareX.ContextMenuHandler/ShareX.ContextMenuHandler.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net48</TargetFramework>
-    <Configurations>Debug;Release;MicrosoftStoreDebug;MicrosoftStore;Steam;</Configurations>
+    <Configurations>Debug;Release;Steam;MicrosoftStore;MicrosoftStoreDebug</Configurations>
   </PropertyGroup>
 
 </Project>

--- a/ShareX.ContextMenuHandler/ShareX.ContextMenuHandler.csproj
+++ b/ShareX.ContextMenuHandler/ShareX.ContextMenuHandler.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <Configurations>Debug;Release;MicrosoftStoreDebug;MicrosoftStore;Steam;</Configurations>
+  </PropertyGroup>
+
+</Project>

--- a/ShareX.Setup/MicrosoftStore/AppxManifest.xml
+++ b/ShareX.Setup/MicrosoftStore/AppxManifest.xml
@@ -1,5 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2" IgnorableNamespaces="desktop2">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
+         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+         xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+         xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+         xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+         xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+         IgnorableNamespaces="uap uap2 uap3 rescap desktop desktop2 desktop4 desktop5 com">
   <Identity Name="19568ShareX.ShareX" ProcessorArchitecture="x64" Publisher="CN=366A5DE5-2EC7-43FD-B559-05986578C4CC" Version="14.1.0.0" />
   <Properties>
     <DisplayName>ShareX</DisplayName>
@@ -32,6 +42,23 @@
         </uap:DefaultTile>
       </uap:VisualElements>
       <Extensions>
+        <desktop4:Extension Category="windows.fileExplorerContextMenus">
+          <desktop4:FileExplorerContextMenus>
+            <desktop5:ItemType Type="Directory">
+              <desktop5:Verb Id="UploadWithShareX" Clsid="4B905A2A-D71C-48D1-AE87-33B15375E13D" />
+            </desktop5:ItemType>
+            <desktop4:ItemType Type="*">
+              <desktop4:Verb Id="UploadWithShareX" Clsid="4B905A2A-D71C-48D1-AE87-33B15375E13D" />
+            </desktop4:ItemType>
+          </desktop4:FileExplorerContextMenus>
+        </desktop4:Extension>
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="ShareX.ContextMenuHandler.exe" DisplayName="Context menu verb handler">
+              <com:Class Id="4B905A2A-D71C-48D1-AE87-33B15375E13D" />
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
         <desktop:Extension Category="windows.startupTask" Executable="ShareX.exe" EntryPoint="Windows.FullTrustApplication">
           <desktop:StartupTask TaskId="ShareX" Enabled="true" DisplayName="ShareX" />
         </desktop:Extension>

--- a/ShareX.sln
+++ b/ShareX.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShareX.ContextMenuHandler", "ShareX.ContextMenuHandler\ShareX.ContextMenuHandler.csproj", "{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -152,6 +154,16 @@ Global
 		{254E398D-F7F5-4B2A-9024-5C121EA6C564}.Release|Any CPU.Build.0 = Release|Any CPU
 		{254E398D-F7F5-4B2A-9024-5C121EA6C564}.Steam|Any CPU.ActiveCfg = Steam|Any CPU
 		{254E398D-F7F5-4B2A-9024-5C121EA6C564}.Steam|Any CPU.Build.0 = Steam|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStore|Any CPU.ActiveCfg = MicrosoftStore|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStore|Any CPU.Build.0 = MicrosoftStore|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStoreDebug|Any CPU.ActiveCfg = MicrosoftStoreDebug|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStoreDebug|Any CPU.Build.0 = MicrosoftStoreDebug|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Steam|Any CPU.ActiveCfg = Steam|Any CPU
+		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Steam|Any CPU.Build.0 = Steam|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ShareX.sln
+++ b/ShareX.sln
@@ -33,7 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShareX.ContextMenuHandler", "ShareX.ContextMenuHandler\ShareX.ContextMenuHandler.csproj", "{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ShareX.ContextMenuHandler", "ShareX.ContextMenuHandler\ShareX.ContextMenuHandler.csproj", "{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -155,15 +155,12 @@ Global
 		{254E398D-F7F5-4B2A-9024-5C121EA6C564}.Steam|Any CPU.ActiveCfg = Steam|Any CPU
 		{254E398D-F7F5-4B2A-9024-5C121EA6C564}.Steam|Any CPU.Build.0 = Steam|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStore|Any CPU.ActiveCfg = MicrosoftStore|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStore|Any CPU.Build.0 = MicrosoftStore|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStoreDebug|Any CPU.ActiveCfg = MicrosoftStoreDebug|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.MicrosoftStoreDebug|Any CPU.Build.0 = MicrosoftStoreDebug|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Steam|Any CPU.ActiveCfg = Steam|Any CPU
-		{F5E784E2-7D2A-4A39-A83C-F3836F3C7DEC}.Steam|Any CPU.Build.0 = Steam|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi @Jaex, I believe we talked about this a few months ago on the C# discord server :-)

This adds the context menu support to the Microsoft Store version of ShareX. Importantly, the mechanism used to do this allows the context menu item to show up on the primary Windows 11 menu. (It also lets the context menu item appear in the Store version on Windows 10.)

<img src="https://cdn.discordapp.com/attachments/194170124859736065/1046904441917419550/Screenshot_2022-11-28_164252.png" alt="The primary Windows 11 context menu with an Upload with ShareX option" width="350"/>

This cannot be implemented for the non-Store version, since a code signing certificate is required. 

Closes #6550 
Closes #5872 