### PR TITLE
FFmpeg encoding defaults

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.es-MX.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.es-MX.resx
@@ -195,7 +195,7 @@ El preajuste debe ser el más rápido para codificación en tiempo real (ej. gra
     <value>Tasa de bits variable:</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Factor de velocidad constante (CRF): el valor puede estar entre 0 y 51; 0 es sin pérdida, 30 es predefinido y 51 es el peor posible.
+    <value>Factor de velocidad constante (CRF): el valor puede estar entre 0 y 51; 0 es sin pérdida, 23 es predefinido y 51 es el peor posible.
 Un valor alto produce un archivo de mala calidad pero menor tamaño.</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.fr.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.fr.resx
@@ -127,7 +127,7 @@
     <value>Bitrate :</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Constante Rate Factor (CRF) : La valeur peut être comprise entre 0 à 51, 0 étant sans perte, 30 étant la valeur par défaut et 51 étant la pire possible.
+    <value>Constante Rate Factor (CRF) : La valeur peut être comprise entre 0 à 51, 0 étant sans perte, 23 étant la valeur par défaut et 51 étant la pire possible.
 Une valeur élevée signifie une mauvaise qualité d'image mais un fichier léger.</value>
   </data>
   <data name="btnCopyPreview.Text" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.id-ID.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.id-ID.resx
@@ -200,7 +200,7 @@
 Bila tidak, tidak bisa mengikuti rekaman dan banyak frame yang terbuang akan terjadi.</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Faktor Laju Konstan (CRF): Nilai bisa antara 0-51, 0 (lossless), 30 (bawaan), dan 51 (terburuk).
+    <value>Faktor Laju Konstan (CRF): Nilai bisa antara 0-51, 0 (lossless), 23 (bawaan), dan 51 (terburuk).
 Nilai lebih tinggi berarti kualitas buruk, tetapi ukuran file kecil.</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.it-IT.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.it-IT.resx
@@ -202,7 +202,7 @@ Altrimenti ci sarà una perdita considerevole di frame.</value>
 
 Valore 0-51:
 - 00: Senza perdita di qualità
-- 30: Predefinito
+- 23: Predefinito
 - 51: Peggiore
 
 Un valore alto significa cattiva qualità, ma dimensione del file inferiore.</value>

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ja-JP.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ja-JP.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>CRF (Constant Rate Factor): 範囲は0-51、0 はロスレス、30 が既定、51 は最低画質。
+    <value>CRF (Constant Rate Factor): 範囲は0-51、0 はロスレス、23 が既定、51 は最低画質。
 値が大きいほど画質は悪くなるが、ファイルサイズは小さくなる。</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ko-KR.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ko-KR.resx
@@ -160,7 +160,7 @@
     <value>품질:</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>항율 인자 (CRF): 값의 범위는 0부터 51까지이며, 0은 무손실, 30이 기본값, 그리고 51이 가능한 최저 품질입니다.
+    <value>항율 인자 (CRF): 값의 범위는 0부터 51까지이며, 0은 무손실, 23이 기본값, 그리고 51이 가능한 최저 품질입니다.
 값이 높아질수록 품질은 낮아지지만, 파일 크기 또한 줄어듭니다.</value>
   </data>
   <data name="tbMP3_qscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pl.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pl.resx
@@ -220,7 +220,7 @@ W przypadku enkodowania w czasie rzeczywistym (np. nagrywanie ekranu), ustawieni
     <value>Kontroluje indeks skali Bayera, wyższa skala spowoduje wyświetlenie większej liczby pasm. Wartość domyślna to 2.</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Constant Rate Factor (CRF): Wartość może zawierać się w przedziale 0-51, gdzie 0 oznacza bezstratność, 30 to wartość domyślna, a 51 to najgorsza z możliwych.
+    <value>Constant Rate Factor (CRF): Wartość może zawierać się w przedziale 0-51, gdzie 0 oznacza bezstratność, 23 to wartość domyślna, a 51 to najgorsza z możliwych.
 Wyższa wartość oznacza złą jakość, ale niski rozmiar pliku.</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pt-BR.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pt-BR.resx
@@ -187,7 +187,7 @@
     <value>Modo de pontilhado:</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Constant Rate Factor (CRF): O valor pode ser entre 0-51, onde 0 é sem perdas, 30 é o padrão, e 51 é o pior possível.
+    <value>Constant Rate Factor (CRF): O valor pode ser entre 0-51, onde 0 é sem perdas, 23 é o padrão, e 51 é o pior possível.
 Um valor maior significa uma qualidade pior mas tamanho reduzido.</value>
   </data>
   <data name="cbx264Preset.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pt-PT.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.pt-PT.resx
@@ -121,7 +121,7 @@
     <value>CRF:</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Factor de taxa constante (CRF): O valor pode ser entre 0-51, em que 0 é sem perdas, 30 é padrão, e 51 é pior qualidade possível.
+    <value>Factor de taxa constante (CRF): O valor pode ser entre 0-51, em que 0 é sem perdas, 23 é padrão, e 51 é pior qualidade possível.
 
 Um valor mais alto significa pior qualidade, mas com um tamanho de ficheiro menor.</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
@@ -163,7 +163,7 @@
     <value>Center</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Constant Rate Factor (CRF): The value can be between 0-51, where 0 is lossless, 30 is default, and 51 is the worst possible.
+    <value>Constant Rate Factor (CRF): The value can be between 0-51, where 0 is lossless, 23 is default, and 51 is the worst possible.
 A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="&gt;&gt;nudx264CRF.Name" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ro.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.ro.resx
@@ -121,7 +121,7 @@
     <value>CRF:</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Factor de rată constantă (CRF): Valoarea poate fi cuprinsă între 0-51, unde 0 este fără pierderi, 30 este valoarea implicită, iar 51 este cea mai proastă valoare posibilă.
+    <value>Factor de rată constantă (CRF): Valoarea poate fi cuprinsă între 0-51, unde 0 este fără pierderi, 23 este valoarea implicită, iar 51 este cea mai proastă valoare posibilă.
 O valoare mai mare înseamnă o calitate proastă, dar o dimensiune redusă a fișierului.</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.uk.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.uk.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Постійний коефіцієнт (CRF): можливий діапазон 0–51, де 0 — без втрат, 30 — типовий, а 51 — найгірший можливий.
+    <value>Постійний коефіцієнт (CRF): можливий діапазон 0–51, де 0 — без втрат, 23 — типовий, а 51 — найгірший можливий.
 Більше значення означає гіршу якість, проте менший розмір файлу.</value>
   </data>
   <data name="nudXvidQscale.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.vi-VN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.vi-VN.resx
@@ -127,7 +127,7 @@
     <value>Sử dụng đường dẫn tùy chỉnh</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>Nhân tố thừa số không đổi (Constant Rate Factor - CRF): Phạm vi của bộ lượng tử hóa là 0-51: trong đó 0 là lossless (không mất mát thông tin), 30 là mặc định, 51 là tồi nhất.
+    <value>Nhân tố thừa số không đổi (Constant Rate Factor - CRF): Phạm vi của bộ lượng tử hóa là 0-51: trong đó 0 là lossless (không mất mát thông tin), 23 là mặc định, 51 là tồi nhất.
 Giá trị cao hơn cho kết quả tệ hơn nhưng kích thước tệp sẽ nhỏ hơn</value>
   </data>
   <data name="tbAACBitrate.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-CN.resx
@@ -154,7 +154,7 @@
     <value>质量：</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>CRF：范围为 0-51。其中，0 表示无损，30 为默认值，51 表示最差质量。
+    <value>CRF：范围为 0-51。其中，0 表示无损，23 为默认值，51 表示最差质量。
 值越高质量越差，但文件体积越小。</value>
   </data>
   <data name="tbAACBitrate.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-TW.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.zh-TW.resx
@@ -153,7 +153,7 @@
     <value>品質：</value>
   </data>
   <data name="nudx264CRF.ToolTip" xml:space="preserve">
-    <value>CRF：範圍為 0-51，其中 0 為無損，30 為預設值，51 為最差品質。
+    <value>CRF：範圍為 0-51，其中 0 為無損，23 為預設值，51 為最差品質。
 值越高品質越差，但檔案越小。</value>
   </data>
   <data name="tbAACBitrate.ToolTip" xml:space="preserve">

--- a/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
@@ -44,7 +44,7 @@ namespace ShareX.ScreenCaptureLib
 
         // Video
         public FFmpegPreset x264_Preset { get; set; } = FFmpegPreset.ultrafast;
-        public int x264_CRF { get; set; } = 28;
+        public int x264_CRF { get; set; } = 23;
         public bool x264_Use_Bitrate { get; set; } = false;
         public int x264_Bitrate { get; set; } = 3000; // kbit/s
         public int VPx_Bitrate { get; set; } = 3000; // kbit/s


### PR DESCRIPTION
Closes #6616 

Updates FFmpeg Options form and all resource strings with correct default CRF value of 23, based on official docs, and the form control default value:

https://github.com/ShareX/ShareX/blob/2de97eea497ab9c1796b889c3079b0223e0e3649/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs#L152-L158

The previous value of 28 is only correct [if using X265](https://trac.ffmpeg.org/wiki/Encode/H.265#Ratecontrolmodes), and produces same output as [23 with X264](https://trac.ffmpeg.org/wiki/Encode/H.264#crf). `ShareX.MediaLib` already used the correct default value for X264, so this PR also fixes an inconsistency between library defaults:

https://github.com/ShareX/ShareX/blob/2de97eea497ab9c1796b889c3079b0223e0e3649/ShareX.MediaLib/VideoConverterOptions.cs#L53-L54

https://github.com/ShareX/ShareX/blob/2de97eea497ab9c1796b889c3079b0223e0e3649/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs#L46-L47