### PR TITLE
Add QuickSync AV1 encoder option

### DIFF
--- a/ShareX.ScreenCaptureLib/Enums.cs
+++ b/ShareX.ScreenCaptureLib/Enums.cs
@@ -106,6 +106,8 @@ namespace ShareX.ScreenCaptureLib
         h264_qsv,
         [Description("HEVC / Quick Sync")]
         hevc_qsv,
+        [Description("AV1 / Quick Sync")]
+        av1_qsv,
         [Description("GIF")]
         gif,
         [Description("WebP")]

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
@@ -347,6 +347,7 @@ namespace ShareX.ScreenCaptureLib
                         break;
                     case FFmpegVideoCodec.h264_qsv:
                     case FFmpegVideoCodec.hevc_qsv:
+                    case FFmpegVideoCodec.av1_qsv:
                         tcFFmpegVideoCodecs.SelectedIndex = 6;
                         break;
                 }

--- a/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
@@ -94,6 +94,7 @@ namespace ShareX.ScreenCaptureLib
                         case FFmpegVideoCodec.hevc_amf:
                         case FFmpegVideoCodec.h264_qsv:
                         case FFmpegVideoCodec.hevc_qsv:
+                        case FFmpegVideoCodec.av1_qsv:
                             return "mp4";
                         case FFmpegVideoCodec.libvpx:
                         case FFmpegVideoCodec.libvpx_vp9:

--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -224,6 +224,7 @@ namespace ShareX.ScreenCaptureLib
                             break;
                         case FFmpegVideoCodec.h264_qsv: // https://trac.ffmpeg.org/wiki/Hardware/QuickSync
                         case FFmpegVideoCodec.hevc_qsv:
+                        case FFmpegVideoCodec.av1_qsv:
                             args.Append($"-preset {FFmpeg.QSV_Preset} ");
                             args.Append($"-b:v {FFmpeg.QSV_Bitrate}k ");
                             break;


### PR DESCRIPTION
### Description
Adds Intel QuickSync AV1 encoder as an option.

### Motivation
I take a bunch of clips with ShareX, since I got an Intel Arc card for encoding now I felt it'd be nice to utilize it with ShareX.

### Testing
Works with Intel Arc A380 installed on my system as secondary GPU and with latest FFMPEG master-branch build from https://github.com/BtbN/FFmpeg-Builds/releases.

### Note
Should probably not be merged until next stable FFMPEG version lands? Currently only master-branch version of FFMPEG has QSV AV1 support.