### PR TITLE
Migrate the GitHub Workflow Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ShareX
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ShareX/ShareX/Build%20ShareX?label=Build&cacheSeconds=3600)](https://github.com/ShareX/ShareX/actions/workflows/build.yml)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ShareX/ShareX/build.yml?branch=develop&label=Build&cacheSeconds=3600)](https://github.com/ShareX/ShareX/actions/workflows/build.yml)
 [![CodeFactor](https://img.shields.io/codefactor/grade/github/ShareX/ShareX?label=CodeFactor&cacheSeconds=3600)](https://www.codefactor.io/repository/github/sharex/sharex)
 [![License](https://img.shields.io/github/license/ShareX/ShareX?label=License&color=brightgreen&cacheSeconds=3600)](./LICENSE.txt)
 [![Release](https://img.shields.io/github/v/release/ShareX/ShareX?label=Release&color=brightgreen&cacheSeconds=3600)](https://github.com/ShareX/ShareX/releases/latest)


### PR DESCRIPTION
Shields.io changed the syntax used for GitHub Workflow Status badges to use workflow's filename instead of its friendly name. They also changed the format of the URL from `github/workflow/status/...` to `/github/actions/workflow/status/...`

This PR migrates the badge to the new format. It also adds the `branch` parameter, which is now recommended. The new URL is <https://img.shields.io/github/actions/workflow/status/ShareX/ShareX/build.yml?branch=develop&label=Build&cacheSeconds=3600>; the visuals of the badge haven't changed.

For more information about the change, you can read [the issue announcing the breaking change on the shields repo](https://github.com/badges/shields/issues/8671).