### PR TITLE
Restore mpql to credits

### DIFF
--- a/ShareX/Forms/AboutForm.cs
+++ b/ShareX/Forms/AboutForm.cs
@@ -112,6 +112,7 @@ ZXing.Net: https://github.com/micjahn/ZXing.Net
 MegaApiClient: https://github.com/gpailler/MegaApiClient
 Inno Setup Dependency Installer: https://github.com/DomGries/InnoDependencyInstaller
 Blob Emoji: http://blobs.gg
+Original Logo Design: https://mpql.net
 ", FontStyle.Regular);
 
             rtbInfo.AppendText("Copyright (c) 2007-2023 ShareX Team", FontStyle.Bold, 13);


### PR DESCRIPTION
Hello McoreD and Jaex! 👋

Y'all might remember me as Mopsy or Mopquill; I made the original ShareX logo for you (inspired by a camera shutter and a pinwheel) way back in the 2010 - 2012 range when we were differentiating from ZScreen and did the whole ShareXmod thing. I noticed y'all have iterated on the logo (and that's good!), but I would still like credit for the design. I did mention this a while back, but I think we probably all lost track of it (Hangouts / Google Code was a mess, and I no longer use Hangouts, haha).

I'm not sure what order the credits are meant to be in, so I just added it to the bottom of the "Credits" section, trying to follow the existing conventions. I've enabled edits on this PR, so feel free to move it around as y'all see fit; apologies in advance if I did something out of place there.

Also, I'm in the ShareX Discord as Mopsy; feel free to add me if you'd like to chat or catch up! I hope y'all are doing well! 😊

\- mpql