### PR TITLE
Add Cache Control settings to Azure Uploader

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -52,7 +52,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public override GenericUploader CreateUploader(UploadersConfig config, TaskReferenceHelper taskInfo)
         {
             return new AzureStorage(config.AzureStorageAccountName, config.AzureStorageAccountAccessKey, config.AzureStorageContainer,
-                config.AzureStorageEnvironment, config.AzureStorageCustomDomain, config.AzureStorageUploadPath);
+                config.AzureStorageEnvironment, config.AzureStorageCustomDomain, config.AzureStorageUploadPath, config.AzureStorageCacheControl);
         }
 
         public override TabPage GetUploadersConfigTabPage(UploadersConfigForm form) => form.tpAzureStorage;
@@ -68,9 +68,10 @@ namespace ShareX.UploadersLib.FileUploaders
         public string AzureStorageEnvironment { get; private set; }
         public string AzureStorageCustomDomain { get; private set; }
         public string AzureStorageUploadPath { get; private set; }
+        public string AzureStorageCacheControl { get; private set; }
 
         public AzureStorage(string azureStorageAccountName, string azureStorageAccessKey, string azureStorageContainer, string azureStorageEnvironment,
-            string customDomain, string uploadPath)
+            string customDomain, string uploadPath, string cacheControl)
         {
             AzureStorageAccountName = azureStorageAccountName;
             AzureStorageAccountAccessKey = azureStorageAccessKey;
@@ -78,6 +79,7 @@ namespace ShareX.UploadersLib.FileUploaders
             AzureStorageEnvironment = (!string.IsNullOrEmpty(azureStorageEnvironment)) ? azureStorageEnvironment : "blob.core.windows.net";
             AzureStorageCustomDomain = customDomain;
             AzureStorageUploadPath = uploadPath;
+            AzureStorageCacheControl = cacheControl;
         }
 
         public override UploadResult Upload(Stream stream, string fileName)
@@ -104,8 +106,9 @@ namespace ShareX.UploadersLib.FileUploaders
             requestHeaders["x-ms-date"] = date;
             requestHeaders["x-ms-version"] = APIVersion;
             requestHeaders["x-ms-blob-type"] = "BlockBlob";
+            if (!String.IsNullOrEmpty(AzureStorageCacheControl)) requestHeaders["x-ms-blob-cache-control"] = AzureStorageCacheControl;
 
-            string canonicalizedHeaders = $"x-ms-blob-type:BlockBlob\nx-ms-date:{date}\nx-ms-version:{APIVersion}\n";
+            string canonicalizedHeaders = $"{((!String.IsNullOrEmpty(AzureStorageCacheControl)) ? $"x-ms-blob-cache-control:{AzureStorageCacheControl}\n" : "")}x-ms-blob-type:BlockBlob\nx-ms-date:{date}\nx-ms-version:{APIVersion}\n";
             string canonicalizedResource = $"/{AzureStorageAccountName}/{AzureStorageContainer}/{uploadPath}";
             string stringToSign = GenerateStringToSign(canonicalizedHeaders, canonicalizedResource, stream.Length.ToString(), contentType);
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -274,6 +274,8 @@ namespace ShareX.UploadersLib
             this.lblGoogleCloudStorageBucket = new System.Windows.Forms.Label();
             this.txtGoogleCloudStorageBucket = new System.Windows.Forms.TextBox();
             this.tpAzureStorage = new System.Windows.Forms.TabPage();
+            this.txtAzureStorageCacheControl = new System.Windows.Forms.TextBox();
+            this.lblAzureStorageCacheControl = new System.Windows.Forms.Label();
             this.lblAzureStorageURLPreview = new System.Windows.Forms.Label();
             this.lblAzureStorageURLPreviewLabel = new System.Windows.Forms.Label();
             this.txtAzureStorageUploadPath = new System.Windows.Forms.TextBox();
@@ -2334,6 +2336,8 @@ namespace ShareX.UploadersLib
             // tpAzureStorage
             // 
             this.tpAzureStorage.BackColor = System.Drawing.SystemColors.Window;
+            this.tpAzureStorage.Controls.Add(this.txtAzureStorageCacheControl);
+            this.tpAzureStorage.Controls.Add(this.lblAzureStorageCacheControl);
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageURLPreview);
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageURLPreviewLabel);
             this.tpAzureStorage.Controls.Add(this.txtAzureStorageUploadPath);
@@ -2351,6 +2355,17 @@ namespace ShareX.UploadersLib
             this.tpAzureStorage.Controls.Add(this.lblAzureStorageCustomDomain);
             resources.ApplyResources(this.tpAzureStorage, "tpAzureStorage");
             this.tpAzureStorage.Name = "tpAzureStorage";
+            // 
+            // txtAzureStorageCacheControl
+            // 
+            resources.ApplyResources(this.txtAzureStorageCacheControl, "txtAzureStorageCacheControl");
+            this.txtAzureStorageCacheControl.Name = "txtAzureStorageCacheControl";
+            this.txtAzureStorageCacheControl.TextChanged += new System.EventHandler(this.txtAzureStorageCacheControl_TextChanged);
+            // 
+            // lblAzureStorageCacheControl
+            // 
+            resources.ApplyResources(this.lblAzureStorageCacheControl, "lblAzureStorageCacheControl");
+            this.lblAzureStorageCacheControl.Name = "lblAzureStorageCacheControl";
             // 
             // lblAzureStorageURLPreview
             // 
@@ -5688,5 +5703,7 @@ namespace ShareX.UploadersLib
         private OAuthLoopbackControl oauth2GooglePhotos;
         private OAuthLoopbackControl oauth2GoogleDrive;
         private OAuthLoopbackControl oauth2GoogleCloudStorage;
+        private System.Windows.Forms.TextBox txtAzureStorageCacheControl;
+        private System.Windows.Forms.Label lblAzureStorageCacheControl;
     }
 }

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -670,6 +670,7 @@ namespace ShareX.UploadersLib
             cbAzureStorageEnvironment.Text = Config.AzureStorageEnvironment;
             txtAzureStorageCustomDomain.Text = Config.AzureStorageCustomDomain;
             txtAzureStorageUploadPath.Text = Config.AzureStorageUploadPath;
+            txtAzureStorageCacheControl.Text = Config.AzureStorageCacheControl;
             UpdateAzureStorageStatus();
 
             #endregion Azure Storage
@@ -2858,6 +2859,12 @@ namespace ShareX.UploadersLib
         private void txtAzureStorageCustomDomain_TextChanged(object sender, EventArgs e)
         {
             Config.AzureStorageCustomDomain = txtAzureStorageCustomDomain.Text;
+            UpdateAzureStorageStatus();
+        }
+
+        private void txtAzureStorageCacheControl_TextChanged(object sender, EventArgs e)
+        {
+            Config.AzureStorageCacheControl = txtAzureStorageCacheControl.Text;
             UpdateAzureStorageStatus();
         }
 

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -5747,6 +5747,57 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
   <data name="&gt;&gt;tpGoogleCloudStorage.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="txtAzureStorageCacheControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 326</value>
+  </data>
+  <data name="txtAzureStorageCacheControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>526, 20</value>
+  </data>
+  <data name="txtAzureStorageCacheControl.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCacheControl.Name" xml:space="preserve">
+    <value>txtAzureStorageCacheControl</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCacheControl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCacheControl.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;txtAzureStorageCacheControl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 310</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 13</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="lblAzureStorageCacheControl.Text" xml:space="preserve">
+    <value>Cache-Control header:</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCacheControl.Name" xml:space="preserve">
+    <value>lblAzureStorageCacheControl</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCacheControl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCacheControl.Parent" xml:space="preserve">
+    <value>tpAzureStorage</value>
+  </data>
+  <data name="&gt;&gt;lblAzureStorageCacheControl.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="lblAzureStorageURLPreview.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -5754,7 +5805,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>NoControl</value>
   </data>
   <data name="lblAzureStorageURLPreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 323</value>
+    <value>10, 387</value>
   </data>
   <data name="lblAzureStorageURLPreview.Size" type="System.Drawing.Size, System.Drawing">
     <value>45, 13</value>
@@ -5775,7 +5826,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageURLPreview.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="lblAzureStorageURLPreviewLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5784,7 +5835,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>NoControl</value>
   </data>
   <data name="lblAzureStorageURLPreviewLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 304</value>
+    <value>10, 368</value>
   </data>
   <data name="lblAzureStorageURLPreviewLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>72, 13</value>
@@ -5805,7 +5856,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageURLPreviewLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="txtAzureStorageUploadPath.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 223</value>
@@ -5826,7 +5877,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;txtAzureStorageUploadPath.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="lblAzureStorageUploadPath.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5856,7 +5907,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageUploadPath.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="cbAzureStorageEnvironment.Items" xml:space="preserve">
     <value>blob.core.windows.net</value>
@@ -5889,7 +5940,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;cbAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="lblAzureStorageEnvironment.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5919,7 +5970,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageEnvironment.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="btnAzureStoragePortal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -5946,7 +5997,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;btnAzureStoragePortal.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="txtAzureStorageContainer.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 128</value>
@@ -5967,7 +6018,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;txtAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="lblAzureStorageContainer.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5997,7 +6048,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageContainer.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="txtAzureStorageAccessKey.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 80</value>
@@ -6018,7 +6069,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;txtAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="lblAzureStorageAccessKey.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6051,7 +6102,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageAccessKey.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="txtAzureStorageAccountName.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 32</value>
@@ -6072,7 +6123,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;txtAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="lblAzureStorageAccountName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6105,7 +6156,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageAccountName.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="txtAzureStorageCustomDomain.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 273</value>
@@ -6126,7 +6177,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;txtAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="lblAzureStorageCustomDomain.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6156,16 +6207,16 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpAzureStorage</value>
   </data>
   <data name="&gt;&gt;lblAzureStorageCustomDomain.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>16</value>
   </data>
   <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 58</value>
   </data>
   <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tpAzureStorage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
+    <value>803, 507</value>
   </data>
   <data name="tpAzureStorage.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>

--- a/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigFormHelper.cs
@@ -282,7 +282,7 @@ namespace ShareX.UploadersLib
         private void UpdateAzureStorageStatus()
         {
             AzureStorage azure = new AzureStorage(Config.AzureStorageAccountName, Config.AzureStorageAccountAccessKey, Config.AzureStorageContainer,
-                Config.AzureStorageEnvironment, Config.AzureStorageCustomDomain, Config.AzureStorageUploadPath);
+                Config.AzureStorageEnvironment, Config.AzureStorageCustomDomain, Config.AzureStorageUploadPath, Config.AzureStorageCacheControl);
 
             lblAzureStorageURLPreview.Text = azure.GetPreviewURL();
         }

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -398,6 +398,7 @@ namespace ShareX.UploadersLib
         public string AzureStorageEnvironment { get; set; } = "blob.core.windows.net";
         public string AzureStorageCustomDomain { get; set; } = "";
         public string AzureStorageUploadPath { get; set; } = "";
+        public string AzureStorageCacheControl { get; set; } = "";
 
         #endregion Azure Storage
 


### PR DESCRIPTION
The documentation covering this isn't straightforward on azure docs, but I gave it a shot anyway.
We can't apply cache-control to an entire storage container, so we have to do these per file, therefore putting it as a part of the upload process is necessary unless you want to do this through a separate rest request/azure cli

Adds a text box to the uploader config for users to specify their header
![image](https://user-images.githubusercontent.com/12771982/223492970-db4f8a68-b4cb-4210-851d-7fc0f1c3c452.png)

These are implemented directly onto the blob
![23-03-08_03-56-00-20230323-03-08_03-39-08-tiendasubirAzure php_at_3e](https://user-images.githubusercontent.com/12771982/223493253-154733c7-55df-43ad-8446-511dbc8c34ac.png)

