### PR TITLE
Move recorder user arguments to avoid overwrites

### DIFF
--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -147,11 +147,6 @@ namespace ShareX.ScreenCaptureLib
                 args.Append($"-i \"{InputPath}\" ");
             }
 
-            if (!string.IsNullOrEmpty(FFmpeg.UserArgs))
-            {
-                args.Append(FFmpeg.UserArgs + " ");
-            }
-
             if (FFmpeg.IsVideoSourceSelected)
             {
                 if (IsLossless || FFmpeg.VideoCodec != FFmpegVideoCodec.apng)
@@ -257,6 +252,11 @@ namespace ShareX.ScreenCaptureLib
                         args.Append($"-c:a libmp3lame -qscale:a {FFmpeg.MP3_QScale} ");
                         break;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(FFmpeg.UserArgs))
+            {
+                args.Append(FFmpeg.UserArgs + " ");
             }
 
             if (Duration > 0)

--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -340,7 +340,9 @@ namespace ShareX.ScreenCaptureLib
             }
 
             if (!string.IsNullOrEmpty(FFmpeg.UserArgs))
+            {
                 args.Append(FFmpeg.UserArgs + " ");
+            }
 
             if (Duration > 0)
             {

--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -29,7 +29,6 @@ using System;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace ShareX.ScreenCaptureLib


### PR DESCRIPTION
Previously user arguments were appended near the beginning of the line, which resulted in any pre-existing arguments to overwrite them. Now the arguments are appended just before the output, allowing users to actually overwrite any hardcoded options.