### PR TITLE
Better screen capture with ffmpeg ddagrab.

### DIFF
--- a/ShareX.MediaLib/FFmpegCLIManager.cs
+++ b/ShareX.MediaLib/FFmpegCLIManager.cs
@@ -43,6 +43,11 @@ namespace ShareX.MediaLib
         public const string SourceVideoDevice = "screen-capture-recorder";
         public const string SourceAudioDevice = "virtual-audio-capturer";
 
+        /// <summary>
+        /// Uses the <c>ddagrab</c> ffmpeg video source filter.
+        /// </summary>
+        public const string SourceDxgi = "DXGI";
+
         public const int x264_min = 0;
         public const int x264_max = 51;
         public const int x265_min = 0;
@@ -277,6 +282,14 @@ namespace ShareX.MediaLib
             }
 
             return devices;
+        }
+
+        public bool GetHasDdaGrab()
+        {
+            Run("-hide_banner -filters");
+
+            string output = Output.ToString();
+            return output.Contains("ddagrab");
         }
 
         public void ConcatenateVideos(string[] inputFiles, string outputFile, bool autoDeleteInputFiles = false)

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
@@ -140,6 +140,7 @@ namespace ShareX.ScreenCaptureLib
         {
             btnRefreshSources.Enabled = false;
             DirectShowDevices devices = null;
+            var hasDdaGrab = false;
 
             await Task.Run(() =>
             {
@@ -149,6 +150,14 @@ namespace ShareX.ScreenCaptureLib
                     {
                         devices = ffmpeg.GetDirectShowDevices();
                     }
+
+                    if (Helpers.IsWindows8OrGreater())
+                    {
+                        using (FFmpegCLIManager ffmpeg = new FFmpegCLIManager(Options.FFmpeg.FFmpegPath))
+                        {
+                            hasDdaGrab = ffmpeg.GetHasDdaGrab();
+                        }
+                    }
                 }
             });
 
@@ -157,6 +166,12 @@ namespace ShareX.ScreenCaptureLib
                 cbVideoSource.Items.Clear();
                 cbVideoSource.Items.Add(FFmpegCLIManager.SourceNone);
                 cbVideoSource.Items.Add(FFmpegCLIManager.SourceGDIGrab);
+
+                if (hasDdaGrab)
+                {
+                    cbVideoSource.Items.Add(FFmpegCLIManager.SourceDxgi);
+                }
+
                 cbAudioSource.Items.Clear();
                 cbAudioSource.Items.Add(FFmpegCLIManager.SourceNone);
 


### PR DESCRIPTION
ddagrab is a relatively new filter video source in ffmpeg that uses DXGI Desktop Duplication (Windows 8+) to do screen recording.

This has some advantages over the existing screen-capture-recorder method:

* Doesn't need installation of a separate driver.
* Doesn't induce stutter in whatever you're recording.

It does mean you'll need a relatively new (within the last year) version of ffmpeg.

DXGI Desktop Duplication works per monitor ("output") which means that I need to stitch together multiple monitors if the capture area is across them. I do this with a filter graph ffmpeg-side. Sadly, they aren't synchronized nicely, so you can see the tearing if you move something across a monitor boundary. 

Two TODOs with the current implementation:

* I have not the slightest of a clue how custom ffmpeg args play into this.
* I'm not sure the code to get DXGI output numbers is correct. Ideally I'd check against the DXGI API directly, but that would mean pulling in some sort of dependency to call DXGI from C#. Let me know if that's ok.

