### PR TITLE
Add button to scan QR code from image on clipboard

### DIFF
--- a/ShareX/Forms/QRCodeForm.Designer.cs
+++ b/ShareX/Forms/QRCodeForm.Designer.cs
@@ -41,6 +41,7 @@
             this.btnUploadImage = new System.Windows.Forms.Button();
             this.btnScanQRCodeFromScreen = new System.Windows.Forms.Button();
             this.btnScanQRCodeFromImageFile = new System.Windows.Forms.Button();
+            this.btnScanQRCodeFromClipboard = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.nudQRCodeSize)).BeginInit();
             this.SuspendLayout();
             // 
@@ -130,11 +131,19 @@
             this.btnScanQRCodeFromImageFile.UseVisualStyleBackColor = true;
             this.btnScanQRCodeFromImageFile.Click += new System.EventHandler(this.btnScanQRCodeFromImageFile_Click);
             // 
+            // btnScanQRCodeFromClipboard
+            // 
+            resources.ApplyResources(this.btnScanQRCodeFromClipboard, "btnScanQRCodeFromClipboard");
+            this.btnScanQRCodeFromClipboard.Name = "btnScanQRCodeFromClipboard";
+            this.btnScanQRCodeFromClipboard.UseVisualStyleBackColor = true;
+            this.btnScanQRCodeFromClipboard.Click += new System.EventHandler(this.btnScanQRCodeFromClipboard_Click);
+            // 
             // QRCodeForm
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
+            this.Controls.Add(this.btnScanQRCodeFromClipboard);
             this.Controls.Add(this.btnScanQRCodeFromImageFile);
             this.Controls.Add(this.btnScanQRCodeFromScreen);
             this.Controls.Add(this.btnUploadImage);
@@ -170,5 +179,6 @@
         private System.Windows.Forms.Button btnUploadImage;
         private System.Windows.Forms.Button btnScanQRCodeFromScreen;
         private System.Windows.Forms.Button btnScanQRCodeFromImageFile;
+        private System.Windows.Forms.Button btnScanQRCodeFromClipboard;
     }
 }

--- a/ShareX/Forms/QRCodeForm.cs
+++ b/ShareX/Forms/QRCodeForm.cs
@@ -213,6 +213,16 @@ namespace ShareX
             ScanFromScreen();
         }
 
+        private void btnScanQRCodeFromClipboard_Click(object sender, EventArgs e)
+        {
+            if (ClipboardHelpers.ContainsImage())
+            {
+                Bitmap bmp = ClipboardHelpers.GetImage();
+
+                ScanImage(bmp);
+            }
+        }
+
         private void btnScanQRCodeFromImageFile_Click(object sender, EventArgs e)
         {
             txtText.ResetText();

--- a/ShareX/Forms/QRCodeForm.resx
+++ b/ShareX/Forms/QRCodeForm.resx
@@ -154,7 +154,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtText.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="lblQRCodeSizeHint.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -187,7 +187,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblQRCodeSizeHint.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="lblQRCodeSize.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -220,7 +220,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblQRCodeSize.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="nudQRCodeSize.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -250,7 +250,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;nudQRCodeSize.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="pbQRCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -277,7 +277,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pbQRCode.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="lblQRCode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -307,7 +307,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblQRCode.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="lblText.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -334,7 +334,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblText.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="btnCopyImage.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -361,7 +361,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCopyImage.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="btnSaveImage.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -388,7 +388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnSaveImage.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="btnUploadImage.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -415,13 +415,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnUploadImage.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnScanQRCodeFromScreen.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 16</value>
   </data>
   <data name="btnScanQRCodeFromScreen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 40</value>
+    <value>180, 45</value>
   </data>
   <data name="btnScanQRCodeFromScreen.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -439,16 +439,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnScanQRCodeFromScreen.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="btnScanQRCodeFromImageFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>296, 16</value>
+    <value>388, 16</value>
   </data>
   <data name="btnScanQRCodeFromImageFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 40</value>
+    <value>180, 45</value>
   </data>
   <data name="btnScanQRCodeFromImageFile.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="btnScanQRCodeFromImageFile.Text" xml:space="preserve">
     <value>Scan QR code from image file...</value>
@@ -463,6 +463,33 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnScanQRCodeFromImageFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnScanQRCodeFromClipboard.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnScanQRCodeFromClipboard.Location" type="System.Drawing.Point, System.Drawing">
+    <value>202, 16</value>
+  </data>
+  <data name="btnScanQRCodeFromClipboard.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 45</value>
+  </data>
+  <data name="btnScanQRCodeFromClipboard.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnScanQRCodeFromClipboard.Text" xml:space="preserve">
+    <value>Scan QR code from image on clipboard...</value>
+  </data>
+  <data name="&gt;&gt;btnScanQRCodeFromClipboard.Name" xml:space="preserve">
+    <value>btnScanQRCodeFromClipboard</value>
+  </data>
+  <data name="&gt;&gt;btnScanQRCodeFromClipboard.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnScanQRCodeFromClipboard.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnScanQRCodeFromClipboard.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">


### PR DESCRIPTION
I find myself copying the QR code image instead of opening the tool first to select the portion of my screen with the QR code in it.

![QR Code form with a "Scan QR code from image on clipboard..." button](https://github.com/ShareX/ShareX/assets/6181929/184d54e9-b261-4917-873d-f6b6cf2d5ad5)

I had to increase the height of the buttons slightly so the text wouldn't be cut off.