### PR TITLE
Fix region capture options to 

### DIFF
--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -1805,7 +1805,6 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.es-MX.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.es.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
@@ -1905,7 +1904,6 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\AfterUploadForm.resx">
       <DependentUpon>AfterUploadForm.cs</DependentUpon>
@@ -1964,9 +1962,7 @@
     <EmbeddedResource Include="Tools\PinToScreen\PinToScreenStartupForm.resx">
       <DependentUpon>PinToScreenStartupForm.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.de.resx">
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.de.resx" />
     <EmbeddedResource Include="Properties\Resources.es-MX.resx" />
     <EmbeddedResource Include="Properties\Resources.es.resx" />
     <EmbeddedResource Include="Properties\Resources.fa-IR.resx" />

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -1805,6 +1805,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.es-MX.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.es.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
@@ -1904,6 +1905,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\TaskSettingsForm.resx">
       <DependentUpon>TaskSettingsForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\AfterUploadForm.resx">
       <DependentUpon>AfterUploadForm.cs</DependentUpon>
@@ -1962,7 +1964,9 @@
     <EmbeddedResource Include="Tools\PinToScreen\PinToScreenStartupForm.resx">
       <DependentUpon>PinToScreenStartupForm.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.de.resx" />
+    <EmbeddedResource Include="Properties\Resources.de.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.es-MX.resx" />
     <EmbeddedResource Include="Properties\Resources.es.resx" />
     <EmbeddedResource Include="Properties\Resources.fa-IR.resx" />

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -39,6 +39,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -182,10 +183,10 @@ namespace ShareX
                     OpenRuler(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreen:
-                    PinToScreen();
+                    PinToScreen(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreenFromScreen:
-                    PinToScreenFromScreen();
+                    PinToScreenFromScreen(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreenFromClipboard:
                     PinToScreenFromClipboard();
@@ -1267,7 +1268,7 @@ namespace ShareX
             QRCodeForm.OpenFormScanFromScreen();
         }
 
-        public static void OpenRuler(TaskSettings taskSettings = null)
+        public static void  OpenRuler(TaskSettings taskSettings = null)
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
@@ -1379,9 +1380,11 @@ namespace ShareX
             }
         }
 
-        public static void PinToScreen()
+        public static void PinToScreen(TaskSettings taskSettings = null)
         {
-            using (PinToScreenStartupForm form = new PinToScreenStartupForm())
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
+            using (PinToScreenStartupForm form = new PinToScreenStartupForm(taskSettings.CaptureSettings.SurfaceOptions))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
@@ -1412,9 +1415,11 @@ namespace ShareX
             PinToScreen(image);
         }
 
-        public static void PinToScreenFromScreen()
+        public static void PinToScreenFromScreen(TaskSettings taskSettings = null)
         {
-            Image image = RegionCaptureTasks.GetRegionImage(out Rectangle rect);
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
+            Image image = RegionCaptureTasks.GetRegionImage(out Rectangle rect,taskSettings.CaptureSettings.SurfaceOptions);
 
             PinToScreen(image, rect.Location);
         }

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -39,7 +39,6 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ShareX/Tools/PinToScreen/PinToScreenStartupForm.cs
+++ b/ShareX/Tools/PinToScreen/PinToScreenStartupForm.cs
@@ -37,11 +37,14 @@ namespace ShareX
     {
         public Bitmap Image { get; private set; }
         public Point? PinToScreenLocation { get; private set; }
+        public RegionCaptureOptions RegionCaptureOptions { get; private set; }
 
-        public PinToScreenStartupForm()
+        public PinToScreenStartupForm(RegionCaptureOptions regionCaptureOptions)
         {
             InitializeComponent();
             ShareXResources.ApplyTheme(this, true);
+
+            RegionCaptureOptions = regionCaptureOptions;
         }
 
         private void btnFromScreen_Click(object sender, EventArgs e)
@@ -49,7 +52,7 @@ namespace ShareX
             Hide();
             Thread.Sleep(250);
 
-            Image = RegionCaptureTasks.GetRegionImage(out Rectangle rect);
+            Image = RegionCaptureTasks.GetRegionImage(out Rectangle rect, RegionCaptureOptions);
 
             if (Image != null)
             {


### PR DESCRIPTION
This PR solves #7059.

Previously, users would select "Override capture settings" and modify settings. However, the settings would not be reflected for 'Pin to screen' and 'pin to screen (from screen)'.

This PR passes the region capture options.


