### PR TITLE
Fix region capture options for 'pin-to-screen' and 'pin-to-screen (from screen)'

### DIFF
--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -182,10 +182,10 @@ namespace ShareX
                     OpenRuler(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreen:
-                    PinToScreen();
+                    PinToScreen(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreenFromScreen:
-                    PinToScreenFromScreen();
+                    PinToScreenFromScreen(safeTaskSettings);
                     break;
                 case HotkeyType.PinToScreenFromClipboard:
                     PinToScreenFromClipboard();
@@ -1379,9 +1379,10 @@ namespace ShareX
             }
         }
 
-        public static void PinToScreen()
+        public static void PinToScreen(TaskSettings taskSettings = null)
         {
-            using (PinToScreenStartupForm form = new PinToScreenStartupForm())
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+            using (PinToScreenStartupForm form = new PinToScreenStartupForm(taskSettings.CaptureSettings.SurfaceOptions))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
@@ -1412,9 +1413,11 @@ namespace ShareX
             PinToScreen(image);
         }
 
-        public static void PinToScreenFromScreen()
+        public static void PinToScreenFromScreen(TaskSettings taskSettings = null)
         {
-            Image image = RegionCaptureTasks.GetRegionImage(out Rectangle rect);
+            if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
+
+            Image image = RegionCaptureTasks.GetRegionImage(out Rectangle rect,taskSettings.CaptureSettings.SurfaceOptions);
 
             PinToScreen(image, rect.Location);
         }

--- a/ShareX/Tools/PinToScreen/PinToScreenStartupForm.cs
+++ b/ShareX/Tools/PinToScreen/PinToScreenStartupForm.cs
@@ -37,11 +37,14 @@ namespace ShareX
     {
         public Bitmap Image { get; private set; }
         public Point? PinToScreenLocation { get; private set; }
+        public RegionCaptureOptions RegionCaptureOptions { get; private set; }
 
-        public PinToScreenStartupForm()
+        public PinToScreenStartupForm(RegionCaptureOptions regionCaptureOptions)
         {
             InitializeComponent();
             ShareXResources.ApplyTheme(this, true);
+
+            RegionCaptureOptions = regionCaptureOptions;
         }
 
         private void btnFromScreen_Click(object sender, EventArgs e)
@@ -49,7 +52,7 @@ namespace ShareX
             Hide();
             Thread.Sleep(250);
 
-            Image = RegionCaptureTasks.GetRegionImage(out Rectangle rect);
+            Image = RegionCaptureTasks.GetRegionImage(out Rectangle rect,RegionCaptureOptions);
 
             if (Image != null)
             {


### PR DESCRIPTION
Fixes #7059 

Previously, any region capture settings set by users were not being applied to pin-to-screen and pin-to-screen (from screen). This merge adds the safeTaskSettings to pin-to-screen.