### PR TITLE
OneDrive Add Use Direct Link

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/OneDrive.cs
+++ b/ShareX.UploadersLib/FileUploaders/OneDrive.cs
@@ -51,7 +51,8 @@ namespace ShareX.UploadersLib.FileUploaders
             return new OneDrive(config.OneDriveV2OAuth2Info)
             {
                 FolderID = config.OneDriveV2SelectedFolder.id,
-                AutoCreateShareableLink = config.OneDriveAutoCreateShareableLink
+                AutoCreateShareableLink = config.OneDriveAutoCreateShareableLink,
+                UseDirectLink = config.OneDriveUseDirectLink,
             };
         }
 
@@ -67,6 +68,7 @@ namespace ShareX.UploadersLib.FileUploaders
         public OAuth2Info AuthInfo { get; set; }
         public string FolderID { get; set; }
         public bool AutoCreateShareableLink { get; set; }
+        public bool UseDirectLink { get; set; }
 
         public static OneDriveFileInfo RootFolder = new OneDriveFileInfo
         {
@@ -257,7 +259,7 @@ namespace ShareX.UploadersLib.FileUploaders
                 {
                     AllowReportProgress = false;
 
-                    result.URL = CreateShareableLink(uploadInfo.id);
+                    result.URL = CreateShareableLink(uploadInfo.id, UseDirectLink ? OneDriveLinkType.Embed : OneDriveLinkType.Read);
                 }
                 else
                 {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.Designer.cs
@@ -194,6 +194,7 @@ namespace ShareX.UploadersLib
             this.tvOneDrive = new System.Windows.Forms.TreeView();
             this.lblOneDriveFolderID = new System.Windows.Forms.Label();
             this.cbOneDriveCreateShareableLink = new System.Windows.Forms.CheckBox();
+            this.cbOneDriveUseDirectLink = new System.Windows.Forms.CheckBox();
             this.oAuth2OneDrive = new ShareX.UploadersLib.OAuthControl();
             this.tpGoogleDrive = new System.Windows.Forms.TabPage();
             this.oauth2GoogleDrive = new ShareX.UploadersLib.OAuthLoopbackControl();
@@ -1711,6 +1712,7 @@ namespace ShareX.UploadersLib
             this.tpOneDrive.Controls.Add(this.tvOneDrive);
             this.tpOneDrive.Controls.Add(this.lblOneDriveFolderID);
             this.tpOneDrive.Controls.Add(this.cbOneDriveCreateShareableLink);
+            this.tpOneDrive.Controls.Add(this.cbOneDriveUseDirectLink);
             this.tpOneDrive.Controls.Add(this.oAuth2OneDrive);
             resources.ApplyResources(this.tpOneDrive, "tpOneDrive");
             this.tpOneDrive.Name = "tpOneDrive";
@@ -1733,6 +1735,13 @@ namespace ShareX.UploadersLib
             this.cbOneDriveCreateShareableLink.Name = "cbOneDriveCreateShareableLink";
             this.cbOneDriveCreateShareableLink.UseVisualStyleBackColor = true;
             this.cbOneDriveCreateShareableLink.CheckedChanged += new System.EventHandler(this.cbOneDriveCreateShareableLink_CheckedChanged);
+            // 
+            // cbOneDriveUseDirectLink
+            // 
+            resources.ApplyResources(this.cbOneDriveUseDirectLink, "cbOneDriveUseDirectLink");
+            this.cbOneDriveUseDirectLink.Name = "cbOneDriveUseDirectLink";
+            this.cbOneDriveUseDirectLink.UseVisualStyleBackColor = true;
+            this.cbOneDriveUseDirectLink.CheckedChanged += new System.EventHandler(this.cbOneDriveUseDirectLink_CheckedChanged);
             // 
             // oAuth2OneDrive
             // 
@@ -5152,6 +5161,7 @@ namespace ShareX.UploadersLib
         private System.Windows.Forms.Label lblHastebinSyntaxHighlighting;
         private System.Windows.Forms.Label lblHastebinCustomDomain;
         private System.Windows.Forms.CheckBox cbOneDriveCreateShareableLink;
+        private System.Windows.Forms.CheckBox cbOneDriveUseDirectLink;
         private System.Windows.Forms.Label lblOneDriveFolderID;
         private System.Windows.Forms.TreeView tvOneDrive;
         private System.Windows.Forms.Label lblLambdaApiKey;

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -375,6 +375,8 @@ namespace ShareX.UploadersLib
             }
 
             cbOneDriveCreateShareableLink.Checked = Config.OneDriveAutoCreateShareableLink;
+            cbOneDriveUseDirectLink.Checked = Config.OneDriveUseDirectLink;
+            cbOneDriveUseDirectLink.Enabled = Config.OneDriveAutoCreateShareableLink;
             lblOneDriveFolderID.Text = Resources.UploadersConfigForm_LoadSettings_Selected_folder_ + " " + Config.OneDriveV2SelectedFolder.name;
             tvOneDrive.CollapseAll();
 
@@ -1635,6 +1637,12 @@ namespace ShareX.UploadersLib
         private void cbOneDriveCreateShareableLink_CheckedChanged(object sender, EventArgs e)
         {
             Config.OneDriveAutoCreateShareableLink = cbOneDriveCreateShareableLink.Checked;
+            cbOneDriveUseDirectLink.Enabled = cbOneDriveCreateShareableLink.Checked;
+        }
+
+        private void cbOneDriveUseDirectLink_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.OneDriveUseDirectLink = cbOneDriveUseDirectLink.Checked;
         }
 
         private void tvOneDrive_AfterSelect(object sender, TreeViewEventArgs e)

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.es-MX.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.es-MX.resx
@@ -1257,4 +1257,7 @@ Por ejemplo, si el bucket se llama bucket.example.com, la URL será http://bucke
   <data name="tpTeknik.Text" xml:space="preserve">
     <value>Teknik</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Utilizar enlace directo</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.fa-IR.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.fa-IR.resx
@@ -543,4 +543,7 @@
   <data name="rbFTPTransferModePassive.Text" xml:space="preserve">
     <value>غیرفعال</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>از لینک مستقیم استفاده کن</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.fr.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.fr.resx
@@ -1257,4 +1257,7 @@ Utiliser une bibliothèque chiffrée désactive le partage.</value>
   <data name="cbSeafileCreateShareableURLRaw.Text" xml:space="preserve">
     <value>Utiliser l'URL brute</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Utiliser les liens directs</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.he-IL.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.he-IL.resx
@@ -1101,4 +1101,7 @@
   <data name="lblZWSToken.Text" xml:space="preserve">
     <value>טוקן:</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>השתמש בקישור ישיר</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.id-ID.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.id-ID.resx
@@ -1105,4 +1105,7 @@ Menggunakan pustaka terenkripsi menonaktifkan berbagi.</value>
   <data name="tpFTP.Text" xml:space="preserve">
     <value>FTP / FTPS / SFTP</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Gunakan tautan langsung</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.it-IT.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.it-IT.resx
@@ -909,4 +909,7 @@ Ad esempio, se il bucket si chiama "bucket.example.com", l'URL sarà "http://buc
   <data name="cbFlickrDirectLink.Text" xml:space="preserve">
     <value>Usa Collegamento Diretto</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Usa Collegamento Diretto</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.ja-JP.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.ja-JP.resx
@@ -1065,4 +1065,7 @@
   <data name="lblB2ManageLink.Text" xml:space="preserve">
     <value>ここをクリックし、アプリケーションキーを作成、またはバケットを管理</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>ダイレクト リンクを使用</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.ko-KR.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.ko-KR.resx
@@ -1203,4 +1203,7 @@
   <data name="cbOwnCloudAutoExpire.Text" xml:space="preserve">
     <value>자동으로 공유된 링크 만료</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>핫링크 사용하기</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.nl-NL.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.nl-NL.resx
@@ -660,4 +660,7 @@ Een versleutelde bibliotheek gebruiken schakelt delen uit.</value>
   <data name="cbGoogleDriveDirectLink.Text" xml:space="preserve">
     <value>Gebruik directe link</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Gebruik directe link</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.pl.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.pl.resx
@@ -1083,4 +1083,7 @@ Używanie zaszyfrowanej biblioteki wyłącza udostępnianie.</value>
   <data name="lblTeknikPasteAPIUrl.Text" xml:space="preserve">
     <value>Wklej URL API:</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Użyj bezpośredniego linku</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.pt-BR.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.pt-BR.resx
@@ -1290,4 +1290,7 @@ Usar uma biblioteca encriptada desabilita o compartilhamento.</value>
   <data name="tpPlik.Text" xml:space="preserve">
     <value>Plik</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Usar link direto</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.pt-PT.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.pt-PT.resx
@@ -1056,4 +1056,7 @@ Utilizar uma biblioteca encriptada desactiva compartilhamento.</value>
   <data name="$this.Text" xml:space="preserve">
     <value>ShareX - Definições de destino</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Usar hiperligação directa</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.resx
@@ -122,7 +122,7 @@
     <value>88, 84</value>
   </data>
   <data name="txtRapidSharePremiumUserName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>120, 21</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="txtRapidSharePremiumUserName.TabIndex" type="System.Int32, mscorlib">
@@ -148,7 +148,7 @@
     <value>16, 306</value>
   </data>
   <data name="cbAmazonS3CustomCNAME.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 17</value>
+    <value>132, 16</value>
   </data>
   <data name="cbAmazonS3CustomCNAME.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -177,7 +177,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 256</value>
   </data>
   <data name="txtB2CustomUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtB2CustomUrl.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -204,7 +204,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 233</value>
   </data>
   <data name="cbB2CustomUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbB2CustomUrl.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -228,7 +228,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtB2Bucket.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtB2Bucket.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -249,7 +249,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 200</value>
   </data>
   <data name="txtB2UploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtB2UploadPath.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -270,7 +270,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtB2ApplicationKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtB2ApplicationKey.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -291,7 +291,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtB2ApplicationKeyId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtB2ApplicationKeyId.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -335,11 +335,14 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
   <data name="&gt;&gt;btnTwitterNameUpdate.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="lbTwitterAccounts.ItemHeight" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
   <data name="lbTwitterAccounts.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 72</value>
   </data>
   <data name="lbTwitterAccounts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 199</value>
+    <value>160, 196</value>
   </data>
   <data name="lbTwitterAccounts.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -366,7 +369,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 312</value>
   </data>
   <data name="lblTwitterDefaultMessage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 13</value>
+    <value>137, 12</value>
   </data>
   <data name="lblTwitterDefaultMessage.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -423,7 +426,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 288</value>
   </data>
   <data name="cbTwitterSkipMessageBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>141, 17</value>
+    <value>156, 16</value>
   </data>
   <data name="cbTwitterSkipMessageBox.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -474,7 +477,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>192, 40</value>
   </data>
   <data name="txtTwitterDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 20</value>
+    <value>208, 21</value>
   </data>
   <data name="txtTwitterDescription.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -501,7 +504,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>189, 21</value>
   </data>
   <data name="lblTwitterDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblTwitterDescription.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -654,7 +657,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 248</value>
   </data>
   <data name="txtBitlyDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtBitlyDomain.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -681,7 +684,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 232</value>
   </data>
   <data name="lblBitlyDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblBitlyDomain.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -753,7 +756,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 200</value>
   </data>
   <data name="txtYourlsPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 20</value>
+    <value>224, 21</value>
   </data>
   <data name="txtYourlsPassword.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -774,7 +777,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 152</value>
   </data>
   <data name="txtYourlsUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 20</value>
+    <value>224, 21</value>
   </data>
   <data name="txtYourlsUsername.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -795,7 +798,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtYourlsSignature.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 20</value>
+    <value>224, 21</value>
   </data>
   <data name="txtYourlsSignature.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -822,7 +825,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblYourlsNote.Size" type="System.Drawing.Size, System.Drawing">
-    <value>357, 13</value>
+    <value>425, 12</value>
   </data>
   <data name="lblYourlsNote.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -852,7 +855,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 184</value>
   </data>
   <data name="lblYourlsPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblYourlsPassword.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -882,7 +885,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 136</value>
   </data>
   <data name="lblYourlsUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblYourlsUsername.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -912,7 +915,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblYourlsSignature.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="lblYourlsSignature.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -936,7 +939,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtYourlsAPIURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>472, 20</value>
+    <value>472, 21</value>
   </data>
   <data name="txtYourlsAPIURL.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -963,7 +966,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblYourlsAPIURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblYourlsAPIURL.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1020,7 +1023,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 15</value>
   </data>
   <data name="llAdflyLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 13</value>
+    <value>251, 12</value>
   </data>
   <data name="llAdflyLink.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1044,7 +1047,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 56</value>
   </data>
   <data name="txtAdflyAPIUID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 20</value>
+    <value>224, 21</value>
   </data>
   <data name="txtAdflyAPIUID.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1071,7 +1074,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 40</value>
   </data>
   <data name="lblAdflyAPIUID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblAdflyAPIUID.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1095,7 +1098,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 104</value>
   </data>
   <data name="txtAdflyAPIKEY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 20</value>
+    <value>224, 21</value>
   </data>
   <data name="txtAdflyAPIKEY.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1122,7 +1125,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 88</value>
   </data>
   <data name="lblAdflyAPIKEY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblAdflyAPIKEY.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1179,7 +1182,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 136</value>
   </data>
   <data name="cbPolrUseAPIv1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 17</value>
+    <value>150, 16</value>
   </data>
   <data name="cbPolrUseAPIv1.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1209,7 +1212,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 112</value>
   </data>
   <data name="cbPolrIsSecret.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
+    <value>102, 16</value>
   </data>
   <data name="cbPolrIsSecret.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1233,7 +1236,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtPolrAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
+    <value>296, 21</value>
   </data>
   <data name="txtPolrAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1260,7 +1263,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblPolrAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblPolrAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1284,7 +1287,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtPolrAPIHostname.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
+    <value>296, 21</value>
   </data>
   <data name="txtPolrAPIHostname.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1311,7 +1314,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblPolrAPIHostname.Size" type="System.Drawing.Size, System.Drawing">
-    <value>286, 13</value>
+    <value>347, 12</value>
   </data>
   <data name="lblPolrAPIHostname.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1365,7 +1368,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>368, 84</value>
   </data>
   <data name="lblFirebaseDomainExample.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 13</value>
+    <value>155, 12</value>
   </data>
   <data name="lblFirebaseDomainExample.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1395,7 +1398,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblFirebaseDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblFirebaseDomain.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1425,7 +1428,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 112</value>
   </data>
   <data name="cbFirebaseIsShort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 17</value>
+    <value>84, 16</value>
   </data>
   <data name="cbFirebaseIsShort.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1449,7 +1452,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtFirebaseDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 20</value>
+    <value>344, 21</value>
   </data>
   <data name="txtFirebaseDomain.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1470,7 +1473,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtFirebaseWebAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>344, 20</value>
+    <value>344, 21</value>
   </data>
   <data name="txtFirebaseWebAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1497,7 +1500,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblFirebaseWebAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblFirebaseWebAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1548,7 +1551,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 176</value>
   </data>
   <data name="txtKuttDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtKuttDomain.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1575,7 +1578,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 160</value>
   </data>
   <data name="lblKuttDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblKuttDomain.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1605,7 +1608,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblKuttPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblKuttPassword.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1629,7 +1632,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtKuttPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtKuttPassword.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1656,7 +1659,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 208</value>
   </data>
   <data name="cbKuttReuse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 17</value>
+    <value>330, 16</value>
   </data>
   <data name="cbKuttReuse.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1680,7 +1683,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtKuttAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtKuttAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1701,7 +1704,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtKuttHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtKuttHost.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1728,7 +1731,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblKuttAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblKuttAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1758,7 +1761,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblKuttHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblKuttHost.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1809,7 +1812,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtZWSToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 20</value>
+    <value>552, 21</value>
   </data>
   <data name="txtZWSToken.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1830,7 +1833,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtZWSURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 20</value>
+    <value>552, 21</value>
   </data>
   <data name="txtZWSURL.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1857,7 +1860,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblZWSToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblZWSToken.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1887,7 +1890,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblZWSURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="lblZWSURL.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1989,7 +1992,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>184, 44</value>
   </data>
   <data name="txtSFTPKeyPassphrase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>392, 20</value>
+    <value>392, 21</value>
   </data>
   <data name="txtSFTPKeyPassphrase.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2043,7 +2046,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 48</value>
   </data>
   <data name="lblSFTPKeyPassphrase.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 13</value>
+    <value>95, 12</value>
   </data>
   <data name="lblSFTPKeyPassphrase.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2067,7 +2070,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>184, 20</value>
   </data>
   <data name="txtSFTPKeyLocation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>392, 20</value>
+    <value>392, 21</value>
   </data>
   <data name="txtSFTPKeyLocation.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2094,7 +2097,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 24</value>
   </data>
   <data name="lblSFTPKeyLocation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="lblSFTPKeyLocation.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2148,7 +2151,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 216</value>
   </data>
   <data name="cbFTPAppendRemoteDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>202, 17</value>
+    <value>234, 16</value>
   </data>
   <data name="cbFTPAppendRemoteDirectory.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -2205,7 +2208,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 48</value>
   </data>
   <data name="lblFTPProtocol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblFTPProtocol.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2235,7 +2238,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 24</value>
   </data>
   <data name="lblFTPName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblFTPName.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2265,7 +2268,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 240</value>
   </data>
   <data name="cbFTPRemoveFileExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>202, 17</value>
+    <value>234, 16</value>
   </data>
   <data name="cbFTPRemoveFileExtension.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -2289,7 +2292,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 20</value>
   </data>
   <data name="txtFTPName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>288, 21</value>
   </data>
   <data name="txtFTPName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2316,7 +2319,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 72</value>
   </data>
   <data name="lblFTPHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblFTPHost.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2370,7 +2373,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>80, 0</value>
   </data>
   <data name="rbFTPTransferModeActive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
+    <value>59, 16</value>
   </data>
   <data name="rbFTPTransferModeActive.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2400,7 +2403,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>0, 0</value>
   </data>
   <data name="rbFTPTransferModePassive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 17</value>
+    <value>65, 16</value>
   </data>
   <data name="rbFTPTransferModePassive.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2445,7 +2448,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 68</value>
   </data>
   <data name="txtFTPHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>288, 21</value>
   </data>
   <data name="txtFTPHost.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2475,7 +2478,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>0, 0</value>
   </data>
   <data name="rbFTPProtocolFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 17</value>
+    <value>41, 16</value>
   </data>
   <data name="rbFTPProtocolFTP.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2505,7 +2508,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>56, 0</value>
   </data>
   <data name="rbFTPProtocolFTPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
+    <value>47, 16</value>
   </data>
   <data name="rbFTPProtocolFTPS.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2535,7 +2538,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>120, 0</value>
   </data>
   <data name="rbFTPProtocolSFTP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
+    <value>47, 16</value>
   </data>
   <data name="rbFTPProtocolSFTP.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2586,7 +2589,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>456, 72</value>
   </data>
   <data name="lblFTPPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblFTPPort.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -2616,7 +2619,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 144</value>
   </data>
   <data name="lblFTPTransferMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblFTPTransferMode.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -2640,7 +2643,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>496, 68</value>
   </data>
   <data name="nudFTPPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
+    <value>72, 21</value>
   </data>
   <data name="nudFTPPort.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2670,7 +2673,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>157, 264</value>
   </data>
   <data name="lblFTPURLPreviewValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
+    <value>0, 12</value>
   </data>
   <data name="lblFTPURLPreviewValue.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2697,7 +2700,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 96</value>
   </data>
   <data name="lblFTPUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblFTPUsername.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -2727,7 +2730,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 264</value>
   </data>
   <data name="lblFTPURLPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblFTPURLPreview.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2751,7 +2754,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 92</value>
   </data>
   <data name="txtFTPUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>288, 21</value>
   </data>
   <data name="txtFTPUsername.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2772,7 +2775,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 188</value>
   </data>
   <data name="cbFTPURLPathProtocol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 21</value>
+    <value>72, 20</value>
   </data>
   <data name="cbFTPURLPathProtocol.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2799,7 +2802,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 120</value>
   </data>
   <data name="lblFTPPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblFTPPassword.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -2823,7 +2826,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>240, 188</value>
   </data>
   <data name="txtFTPURLPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>368, 20</value>
+    <value>368, 21</value>
   </data>
   <data name="txtFTPURLPath.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2844,7 +2847,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 116</value>
   </data>
   <data name="txtFTPPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>288, 21</value>
   </data>
   <data name="txtFTPPassword.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -2871,7 +2874,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 192</value>
   </data>
   <data name="lblFTPURLPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblFTPURLPath.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -2901,7 +2904,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 168</value>
   </data>
   <data name="lblFTPRemoteDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 13</value>
+    <value>107, 12</value>
   </data>
   <data name="lblFTPRemoteDirectory.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -2925,7 +2928,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>160, 164</value>
   </data>
   <data name="txtFTPRemoteDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 20</value>
+    <value>448, 21</value>
   </data>
   <data name="txtFTPRemoteDirectory.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -2973,7 +2976,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>184, 44</value>
   </data>
   <data name="txtFTPSCertificateLocation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>416, 20</value>
+    <value>416, 21</value>
   </data>
   <data name="txtFTPSCertificateLocation.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3000,7 +3003,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 48</value>
   </data>
   <data name="lblFTPSCertificateLocation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 13</value>
+    <value>131, 12</value>
   </data>
   <data name="lblFTPSCertificateLocation.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3024,7 +3027,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>184, 20</value>
   </data>
   <data name="cbFTPSEncryption.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 21</value>
+    <value>120, 20</value>
   </data>
   <data name="cbFTPSEncryption.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3051,7 +3054,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 24</value>
   </data>
   <data name="lblFTPSEncryption.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblFTPSEncryption.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3204,7 +3207,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>128, 12</value>
   </data>
   <data name="cbFTPAccounts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 21</value>
+    <value>352, 20</value>
   </data>
   <data name="cbFTPAccounts.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -3231,7 +3234,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblFTPAccounts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblFTPAccounts.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3261,7 +3264,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>541, 48</value>
   </data>
   <data name="lblFTPFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblFTPFile.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -3291,7 +3294,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>277, 48</value>
   </data>
   <data name="lblFTPText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblFTPText.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3321,7 +3324,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 48</value>
   </data>
   <data name="lblFTPImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblFTPImage.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3345,7 +3348,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>80, 44</value>
   </data>
   <data name="cbFTPImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbFTPImage.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3366,7 +3369,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>608, 44</value>
   </data>
   <data name="cbFTPFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbFTPFile.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -3387,7 +3390,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>344, 44</value>
   </data>
   <data name="cbFTPText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbFTPText.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -3441,7 +3444,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 296</value>
   </data>
   <data name="cbDropboxUseDirectLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbDropboxUseDirectLink.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -3471,7 +3474,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 272</value>
   </data>
   <data name="cbDropboxAutoCreateShareableLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>150, 16</value>
   </data>
   <data name="cbDropboxAutoCreateShareableLink.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3501,7 +3504,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 224</value>
   </data>
   <data name="lblDropboxPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblDropboxPath.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3525,7 +3528,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 240</value>
   </data>
   <data name="txtDropboxPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtDropboxPath.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3564,7 +3567,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4</value>
   </data>
   <data name="tpDropbox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpDropbox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -3624,7 +3627,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>349, 16</value>
   </data>
   <data name="lblOneDriveFolderID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>101, 12</value>
   </data>
   <data name="lblOneDriveFolderID.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3654,7 +3657,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 264</value>
   </data>
   <data name="cbOneDriveCreateShareableLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>150, 16</value>
   </data>
   <data name="cbOneDriveCreateShareableLink.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3673,6 +3676,27 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
   </data>
   <data name="&gt;&gt;cbOneDriveCreateShareableLink.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="cbOneDriveUseDirectLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 286</value>
+  </data>
+  <data name="cbOneDriveUseDirectLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 24</value>
+  </data>
+  <data name="cbOneDriveUseDirectLink.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveUseDirectLink.Name" xml:space="preserve">
+    <value>cbOneDriveUseDirectLink</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveUseDirectLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveUseDirectLink.Parent" xml:space="preserve">
+    <value>tpOneDrive</value>
+  </data>
+  <data name="&gt;&gt;cbOneDriveUseDirectLink.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="oAuth2OneDrive.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 16</value>
@@ -3693,16 +3717,16 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>tpOneDrive</value>
   </data>
   <data name="&gt;&gt;oAuth2OneDrive.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tpOneDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 58</value>
   </data>
   <data name="tpOneDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tpOneDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 0</value>
+    <value>803, 507</value>
   </data>
   <data name="tpOneDrive.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -3747,7 +3771,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 136</value>
   </data>
   <data name="cbGoogleDriveSharedDrive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>256, 21</value>
+    <value>256, 20</value>
   </data>
   <data name="cbGoogleDriveSharedDrive.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3774,7 +3798,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 111</value>
   </data>
   <data name="cbGoogleDriveDirectLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbGoogleDriveDirectLink.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3804,7 +3828,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 167</value>
   </data>
   <data name="cbGoogleDriveUseFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 17</value>
+    <value>210, 16</value>
   </data>
   <data name="cbGoogleDriveUseFolder.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3828,7 +3852,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 208</value>
   </data>
   <data name="txtGoogleDriveFolderID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 20</value>
+    <value>432, 21</value>
   </data>
   <data name="txtGoogleDriveFolderID.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3855,7 +3879,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 191</value>
   </data>
   <data name="lblGoogleDriveFolderID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="lblGoogleDriveFolderID.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3948,7 +3972,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 88</value>
   </data>
   <data name="cbGoogleDriveIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
+    <value>126, 16</value>
   </data>
   <data name="cbGoogleDriveIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3969,7 +3993,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>8</value>
   </data>
   <data name="tpGoogleDrive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpGoogleDrive.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -4005,7 +4029,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 176</value>
   </data>
   <data name="lblPuushAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblPuushAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -4029,7 +4053,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 192</value>
   </data>
   <data name="txtPuushAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtPuushAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -4056,7 +4080,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="llPuushForgottenPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 13</value>
+    <value>119, 12</value>
   </data>
   <data name="llPuushForgottenPassword.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -4107,7 +4131,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtPuushPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtPuushPassword.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -4128,7 +4152,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtPuushEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtPuushEmail.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -4155,7 +4179,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblPuushEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblPuushEmail.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -4185,7 +4209,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblPuushPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPuushPassword.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -4206,7 +4230,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>7</value>
   </data>
   <data name="tpPuush.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpPuush.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -4242,7 +4266,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>349, 425</value>
   </data>
   <data name="lblBoxFolderTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 13</value>
+    <value>389, 12</value>
   </data>
   <data name="lblBoxFolderTip.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -4272,7 +4296,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 256</value>
   </data>
   <data name="cbBoxShare.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>150, 16</value>
   </data>
   <data name="cbBoxShare.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4299,7 +4323,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>5, 5, 5, 5</value>
   </data>
   <data name="cbBoxShareAccessLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>250, 21</value>
+    <value>250, 20</value>
   </data>
   <data name="cbBoxShareAccessLevel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -4383,7 +4407,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>349, 50</value>
   </data>
   <data name="lblBoxFolderID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>101, 12</value>
   </data>
   <data name="lblBoxFolderID.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -4455,7 +4479,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>7</value>
   </data>
   <data name="tpBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -4491,7 +4515,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 48</value>
   </data>
   <data name="cbAmazonS3SignedPayload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
+    <value>108, 16</value>
   </data>
   <data name="cbAmazonS3SignedPayload.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -4521,7 +4545,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 120</value>
   </data>
   <data name="lblAmazonS3StripExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 13</value>
+    <value>155, 12</value>
   </data>
   <data name="lblAmazonS3StripExtension.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -4551,7 +4575,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>328, 118</value>
   </data>
   <data name="cbAmazonS3StripExtensionText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 17</value>
+    <value>48, 16</value>
   </data>
   <data name="cbAmazonS3StripExtensionText.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -4575,7 +4599,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>168, 20</value>
   </data>
   <data name="cbAmazonS3StorageClass.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 21</value>
+    <value>264, 20</value>
   </data>
   <data name="cbAmazonS3StorageClass.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -4602,7 +4626,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>248, 118</value>
   </data>
   <data name="cbAmazonS3StripExtensionVideo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 17</value>
+    <value>54, 16</value>
   </data>
   <data name="cbAmazonS3StripExtensionVideo.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -4632,7 +4656,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 72</value>
   </data>
   <data name="cbAmazonS3PublicACL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 17</value>
+    <value>186, 16</value>
   </data>
   <data name="cbAmazonS3PublicACL.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -4662,7 +4686,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>168, 118</value>
   </data>
   <data name="cbAmazonS3StripExtensionImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
+    <value>54, 16</value>
   </data>
   <data name="cbAmazonS3StripExtensionImage.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -4692,7 +4716,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 96</value>
   </data>
   <data name="cbAmazonS3UsePathStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>156, 16</value>
   </data>
   <data name="cbAmazonS3UsePathStyle.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -4749,7 +4773,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 24</value>
   </data>
   <data name="lblAmazonS3StorageClass.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblAmazonS3StorageClass.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -4803,7 +4827,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 160</value>
   </data>
   <data name="lblAmazonS3Endpoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblAmazonS3Endpoint.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -4827,7 +4851,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 176</value>
   </data>
   <data name="txtAmazonS3Endpoint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3Endpoint.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -4854,7 +4878,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>373, 160</value>
   </data>
   <data name="lblAmazonS3Region.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblAmazonS3Region.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -4878,7 +4902,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>376, 176</value>
   </data>
   <data name="txtAmazonS3Region.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>120, 21</value>
   </data>
   <data name="txtAmazonS3Region.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -4899,7 +4923,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 328</value>
   </data>
   <data name="txtAmazonS3CustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3CustomDomain.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -4926,7 +4950,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 360</value>
   </data>
   <data name="lblAmazonS3PathPreviewLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAmazonS3PathPreviewLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -4956,7 +4980,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 379</value>
   </data>
   <data name="lblAmazonS3PathPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblAmazonS3PathPreview.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -5034,7 +5058,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="cbAmazonS3Endpoints.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 21</value>
+    <value>352, 20</value>
   </data>
   <data name="cbAmazonS3Endpoints.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -5061,7 +5085,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 208</value>
   </data>
   <data name="lblAmazonS3BucketName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAmazonS3BucketName.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -5085,7 +5109,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 224</value>
   </data>
   <data name="txtAmazonS3BucketName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3BucketName.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -5112,7 +5136,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblAmazonS3Endpoints.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="lblAmazonS3Endpoints.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -5136,7 +5160,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 272</value>
   </data>
   <data name="txtAmazonS3ObjectPrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3ObjectPrefix.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -5163,7 +5187,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 256</value>
   </data>
   <data name="lblAmazonS3ObjectPrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAmazonS3ObjectPrefix.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -5187,7 +5211,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtAmazonS3SecretKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3SecretKey.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5214,7 +5238,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>12, 64</value>
   </data>
   <data name="lblAmazonS3SecretKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 13</value>
+    <value>113, 12</value>
   </data>
   <data name="lblAmazonS3SecretKey.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5244,7 +5268,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblAmazonS3AccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblAmazonS3AccessKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5268,7 +5292,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtAmazonS3AccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>352, 21</value>
   </data>
   <data name="txtAmazonS3AccessKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5286,7 +5310,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>20</value>
   </data>
   <data name="tpAmazonS3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpAmazonS3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -5343,7 +5367,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>6, 62</value>
   </data>
   <data name="lblGoogleCloudStorageStripExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 13</value>
+    <value>155, 12</value>
   </data>
   <data name="lblGoogleCloudStorageStripExtension.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5373,7 +5397,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>321, 60</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 17</value>
+    <value>48, 16</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionText.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5403,7 +5427,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>241, 60</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionVideo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 17</value>
+    <value>54, 16</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionVideo.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5433,7 +5457,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>9, 29</value>
   </data>
   <data name="cbGoogleCloudStorageSetPublicACL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 17</value>
+    <value>186, 16</value>
   </data>
   <data name="cbGoogleCloudStorageSetPublicACL.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5463,7 +5487,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>161, 60</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
+    <value>54, 16</value>
   </data>
   <data name="cbGoogleCloudStorageStripExtensionImage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5517,7 +5541,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 252</value>
   </data>
   <data name="lblGoogleCloudStoragePathPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblGoogleCloudStoragePathPreview.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -5547,7 +5571,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 233</value>
   </data>
   <data name="lblGoogleCloudStoragePathPreviewLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblGoogleCloudStoragePathPreviewLabel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -5571,7 +5595,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 153</value>
   </data>
   <data name="txtGoogleCloudStorageObjectPrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtGoogleCloudStorageObjectPrefix.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5598,7 +5622,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 137</value>
   </data>
   <data name="lblGoogleCloudStorageObjectPrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblGoogleCloudStorageObjectPrefix.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5628,7 +5652,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 185</value>
   </data>
   <data name="lblGoogleCloudStorageDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblGoogleCloudStorageDomain.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -5652,7 +5676,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 201</value>
   </data>
   <data name="txtGoogleCloudStorageDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtGoogleCloudStorageDomain.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -5679,7 +5703,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 88</value>
   </data>
   <data name="lblGoogleCloudStorageBucket.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblGoogleCloudStorageBucket.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5703,7 +5727,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 104</value>
   </data>
   <data name="txtGoogleCloudStorageBucket.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtGoogleCloudStorageBucket.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5721,7 +5745,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>9</value>
   </data>
   <data name="tpGoogleCloudStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpGoogleCloudStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -5751,7 +5775,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 326</value>
   </data>
   <data name="txtAzureStorageCacheControl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageCacheControl.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -5778,7 +5802,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 310</value>
   </data>
   <data name="lblAzureStorageCacheControl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 13</value>
+    <value>131, 12</value>
   </data>
   <data name="lblAzureStorageCacheControl.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -5808,7 +5832,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>10, 387</value>
   </data>
   <data name="lblAzureStorageURLPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblAzureStorageURLPreview.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -5838,7 +5862,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>10, 368</value>
   </data>
   <data name="lblAzureStorageURLPreviewLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAzureStorageURLPreviewLabel.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -5862,7 +5886,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 223</value>
   </data>
   <data name="txtAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -5889,7 +5913,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 207</value>
   </data>
   <data name="lblAzureStorageUploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAzureStorageUploadPath.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -5925,7 +5949,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 173</value>
   </data>
   <data name="cbAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 21</value>
+    <value>526, 20</value>
   </data>
   <data name="cbAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -5952,7 +5976,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 156</value>
   </data>
   <data name="lblAzureStorageEnvironment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblAzureStorageEnvironment.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -6003,7 +6027,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -6030,7 +6054,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblAzureStorageContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="lblAzureStorageContainer.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6054,7 +6078,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6084,7 +6108,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4, 0, 4, 0</value>
   </data>
   <data name="lblAzureStorageAccessKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblAzureStorageAccessKey.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6108,7 +6132,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6138,7 +6162,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4, 0, 4, 0</value>
   </data>
   <data name="lblAzureStorageAccountName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="lblAzureStorageAccountName.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6162,7 +6186,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 273</value>
   </data>
   <data name="txtAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>526, 20</value>
+    <value>526, 21</value>
   </data>
   <data name="txtAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -6189,7 +6213,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 257</value>
   </data>
   <data name="lblAzureStorageCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblAzureStorageCustomDomain.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -6210,7 +6234,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16</value>
   </data>
   <data name="tpAzureStorage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpAzureStorage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -6246,7 +6270,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 307</value>
   </data>
   <data name="lblB2UrlPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblB2UrlPreview.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -6276,7 +6300,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 160</value>
   </data>
   <data name="lblB2ManageLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 13</value>
+    <value>383, 12</value>
   </data>
   <data name="lblB2ManageLink.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6306,7 +6330,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 288</value>
   </data>
   <data name="lblB2UrlPreviewLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblB2UrlPreviewLabel.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -6336,7 +6360,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblB2Bucket.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblB2Bucket.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -6366,7 +6390,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 184</value>
   </data>
   <data name="lblB2UploadPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblB2UploadPath.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -6396,7 +6420,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblB2ApplicationKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 13</value>
+    <value>155, 12</value>
   </data>
   <data name="lblB2ApplicationKey.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -6426,7 +6450,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblB2ApplicationKeyId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 13</value>
+    <value>119, 12</value>
   </data>
   <data name="lblB2ApplicationKeyId.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -6447,7 +6471,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>11</value>
   </data>
   <data name="tpBackblazeB2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpBackblazeB2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -6510,7 +6534,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 34</value>
   </data>
   <data name="lblMegaStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 13</value>
+    <value>167, 12</value>
   </data>
   <data name="lblMegaStatus.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6567,7 +6591,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 152</value>
   </data>
   <data name="lblMegaFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblMegaFolder.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -6597,7 +6621,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblMegaStatusTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>43, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblMegaStatusTitle.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6621,7 +6645,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 168</value>
   </data>
   <data name="cbMegaFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 21</value>
+    <value>264, 20</value>
   </data>
   <data name="cbMegaFolder.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -6648,7 +6672,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 56</value>
   </data>
   <data name="lblMegaEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblMegaEmail.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6699,7 +6723,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 72</value>
   </data>
   <data name="txtMegaEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 20</value>
+    <value>264, 21</value>
   </data>
   <data name="txtMegaEmail.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6720,7 +6744,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 120</value>
   </data>
   <data name="txtMegaPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 20</value>
+    <value>264, 21</value>
   </data>
   <data name="txtMegaPassword.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -6747,7 +6771,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 104</value>
   </data>
   <data name="lblMegaPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblMegaPassword.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6768,7 +6792,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>10</value>
   </data>
   <data name="tpMega.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpMega.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 0</value>
@@ -6801,7 +6825,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 304</value>
   </data>
   <data name="cbOwnCloudAppendFileNameToURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>145, 17</value>
+    <value>162, 16</value>
   </data>
   <data name="cbOwnCloudAppendFileNameToURL.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -6825,7 +6849,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 224</value>
   </data>
   <data name="txtOwnCloudExpiryTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtOwnCloudExpiryTime.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -6852,7 +6876,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 352</value>
   </data>
   <data name="cbOwnCloudAutoExpire.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 17</value>
+    <value>168, 16</value>
   </data>
   <data name="cbOwnCloudAutoExpire.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -6882,7 +6906,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 208</value>
   </data>
   <data name="lblOwnCloudExpiryTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 13</value>
+    <value>119, 12</value>
   </data>
   <data name="lblOwnCloudExpiryTime.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -6912,7 +6936,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 376</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 17</value>
+    <value>228, 16</value>
   </data>
   <data name="cbOwnCloudUsePreviewLinks.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -6942,7 +6966,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>272, 36</value>
   </data>
   <data name="lblOwnCloudHostExample.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 13</value>
+    <value>221, 12</value>
   </data>
   <data name="lblOwnCloudHostExample.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -6972,7 +6996,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 328</value>
   </data>
   <data name="cbOwnCloud81Compatibility.Size" type="System.Drawing.Size, System.Drawing">
-    <value>157, 17</value>
+    <value>186, 16</value>
   </data>
   <data name="cbOwnCloud81Compatibility.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -7002,7 +7026,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 280</value>
   </data>
   <data name="cbOwnCloudDirectLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 17</value>
+    <value>90, 16</value>
   </data>
   <data name="cbOwnCloudDirectLink.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -7032,7 +7056,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 256</value>
   </data>
   <data name="cbOwnCloudCreateShare.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>144, 16</value>
   </data>
   <data name="cbOwnCloudCreateShare.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -7056,7 +7080,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 176</value>
   </data>
   <data name="txtOwnCloudPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtOwnCloudPath.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -7077,7 +7101,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtOwnCloudPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtOwnCloudPassword.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -7098,7 +7122,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtOwnCloudUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtOwnCloudUsername.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -7119,7 +7143,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtOwnCloudHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtOwnCloudHost.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -7146,7 +7170,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 160</value>
   </data>
   <data name="lblOwnCloudPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblOwnCloudPath.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -7176,7 +7200,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblOwnCloudPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblOwnCloudPassword.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7206,7 +7230,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblOwnCloudUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblOwnCloudUsername.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7236,7 +7260,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblOwnCloudHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="lblOwnCloudHost.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7257,7 +7281,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16</value>
   </data>
   <data name="tpOwnCloud.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpOwnCloud.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -7293,7 +7317,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 160</value>
   </data>
   <data name="cbMediaFireUseLongLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 17</value>
+    <value>252, 16</value>
   </data>
   <data name="cbMediaFireUseLongLink.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -7317,7 +7341,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtMediaFirePath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtMediaFirePath.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -7344,7 +7368,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblMediaFirePath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblMediaFirePath.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -7368,7 +7392,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtMediaFirePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtMediaFirePassword.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -7389,7 +7413,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtMediaFireEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 20</value>
+    <value>248, 21</value>
   </data>
   <data name="txtMediaFireEmail.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7416,7 +7440,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblMediaFirePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblMediaFirePassword.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7446,7 +7470,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblMediaFireEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblMediaFireEmail.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7467,7 +7491,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>6</value>
   </data>
   <data name="tpMediaFire.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpMediaFire.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -7503,7 +7527,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblPushbulletDevices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblPushbulletDevices.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7530,7 +7554,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="cbPushbulletDevices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 21</value>
+    <value>346, 20</value>
   </data>
   <data name="cbPushbulletDevices.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -7587,7 +7611,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblPushbulletUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="lblPushbulletUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7611,7 +7635,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtPushbulletUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 20</value>
+    <value>346, 21</value>
   </data>
   <data name="txtPushbulletUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7629,7 +7653,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4</value>
   </data>
   <data name="tpPushbullet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpPushbullet.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -7692,7 +7716,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 112</value>
   </data>
   <data name="lblSendSpacePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblSendSpacePassword.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -7722,7 +7746,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblSendSpaceUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblSendSpaceUsername.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7746,7 +7770,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 128</value>
   </data>
   <data name="txtSendSpacePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 20</value>
+    <value>136, 21</value>
   </data>
   <data name="txtSendSpacePassword.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -7767,7 +7791,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtSendSpaceUserName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 20</value>
+    <value>136, 21</value>
   </data>
   <data name="txtSendSpaceUserName.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7806,7 +7830,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>5</value>
   </data>
   <data name="tpSendSpace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpSendSpace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -7842,7 +7866,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 112</value>
   </data>
   <data name="cbLocalhostrDirectURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>162, 16</value>
   </data>
   <data name="cbLocalhostrDirectURL.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -7872,7 +7896,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblLocalhostrPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblLocalhostrPassword.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7902,7 +7926,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblLocalhostrEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblLocalhostrEmail.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7926,7 +7950,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtLocalhostrPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>168, 20</value>
+    <value>168, 21</value>
   </data>
   <data name="txtLocalhostrPassword.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -7947,7 +7971,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtLocalhostrEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>168, 20</value>
+    <value>168, 21</value>
   </data>
   <data name="txtLocalhostrEmail.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7965,7 +7989,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4</value>
   </data>
   <data name="tpHostr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpHostr.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -7995,7 +8019,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>472, 277</value>
   </data>
   <data name="txtJiraIssuePrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>320, 20</value>
+    <value>320, 21</value>
   </data>
   <data name="txtJiraIssuePrefix.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -8025,7 +8049,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>469, 259</value>
   </data>
   <data name="lblJiraIssuePrefix.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>113, 12</value>
   </data>
   <data name="lblJiraIssuePrefix.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -8079,7 +8103,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>8, 40</value>
   </data>
   <data name="txtJiraHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>385, 20</value>
+    <value>385, 21</value>
   </data>
   <data name="txtJiraHost.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -8109,7 +8133,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>5, 24</value>
   </data>
   <data name="lblJiraHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>49, 13</value>
+    <value>65, 12</value>
   </data>
   <data name="lblJiraHost.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -8175,7 +8199,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>3</value>
   </data>
   <data name="tpJira.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpJira.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 0</value>
@@ -8208,7 +8232,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblLambdaInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>554, 13</value>
+    <value>683, 12</value>
   </data>
   <data name="lblLambdaInfo.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -8238,7 +8262,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 40</value>
   </data>
   <data name="lblLambdaApiKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblLambdaApiKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -8262,7 +8286,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 57</value>
   </data>
   <data name="txtLambdaApiKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 20</value>
+    <value>346, 21</value>
   </data>
   <data name="txtLambdaApiKey.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -8289,7 +8313,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 86</value>
   </data>
   <data name="lblLambdaUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblLambdaUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -8313,7 +8337,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 102</value>
   </data>
   <data name="cbLambdaUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 21</value>
+    <value>216, 20</value>
   </data>
   <data name="cbLambdaUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -8331,7 +8355,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>4</value>
   </data>
   <data name="tpLambda.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpLambda.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -8361,7 +8385,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 80</value>
   </data>
   <data name="txtPomfResultURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 20</value>
+    <value>216, 21</value>
   </data>
   <data name="txtPomfResultURL.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -8382,7 +8406,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="txtPomfUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 20</value>
+    <value>216, 21</value>
   </data>
   <data name="txtPomfUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -8409,7 +8433,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 64</value>
   </data>
   <data name="lblPomfResultURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblPomfResultURL.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -8439,7 +8463,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 16</value>
   </data>
   <data name="lblPomfUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblPomfUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -8460,7 +8484,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>3</value>
   </data>
   <data name="tpPomf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpPomf.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -8496,7 +8520,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 32</value>
   </data>
   <data name="cbSeafileAPIURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 21</value>
+    <value>297, 20</value>
   </data>
   <data name="cbSeafileAPIURL.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -8517,7 +8541,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>19, 79</value>
   </data>
   <data name="txtSeafileSharePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="txtSeafileSharePassword.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -8544,7 +8568,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 63</value>
   </data>
   <data name="lblSeafileSharePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 13</value>
+    <value>95, 12</value>
   </data>
   <data name="lblSeafileSharePassword.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -8568,7 +8592,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>19, 35</value>
   </data>
   <data name="nudSeafileExpireDays.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="nudSeafileExpireDays.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -8595,7 +8619,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 19</value>
   </data>
   <data name="lblSeafileDaysToExpire.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 13</value>
+    <value>119, 12</value>
   </data>
   <data name="lblSeafileDaysToExpire.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -8670,7 +8694,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 480</value>
   </data>
   <data name="txtSeafileLibraryPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 20</value>
+    <value>297, 21</value>
   </data>
   <data name="txtSeafileLibraryPassword.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -8697,7 +8721,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 464</value>
   </data>
   <data name="lblSeafileLibraryPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 13</value>
+    <value>107, 12</value>
   </data>
   <data name="lblSeafileLibraryPassword.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -8784,7 +8808,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>16, 438</value>
   </data>
   <data name="txtSeafileDirectoryPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 20</value>
+    <value>297, 21</value>
   </data>
   <data name="txtSeafileDirectoryPath.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -8811,7 +8835,7 @@ For example, if your bucket is called "bucket.example.com" then URL will be "htt
     <value>13, 387</value>
   </data>
   <data name="lblSeafileWritePermNotif.Size" type="System.Drawing.Size, System.Drawing">
-    <value>221, 26</value>
+    <value>287, 24</value>
   </data>
   <data name="lblSeafileWritePermNotif.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -8842,7 +8866,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 421</value>
   </data>
   <data name="lblSeafilePath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblSeafilePath.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -8899,7 +8923,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 169</value>
   </data>
   <data name="lblSeafileSelectLibrary.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
+    <value>95, 12</value>
   </data>
   <data name="lblSeafileSelectLibrary.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -8950,7 +8974,7 @@ Using an encrypted library disables sharing.</value>
     <value>19, 79</value>
   </data>
   <data name="txtSeafileAccInfoUsage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="txtSeafileAccInfoUsage.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -8971,7 +8995,7 @@ Using an encrypted library disables sharing.</value>
     <value>20, 35</value>
   </data>
   <data name="txtSeafileAccInfoEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="txtSeafileAccInfoEmail.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -8998,7 +9022,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 19</value>
   </data>
   <data name="lblSeafileAccInfoEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblSeafileAccInfoEmail.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -9028,7 +9052,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 63</value>
   </data>
   <data name="lblSeafileAccInfoUsage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblSeafileAccInfoUsage.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -9157,7 +9181,7 @@ Using an encrypted library disables sharing.</value>
     <value>19, 79</value>
   </data>
   <data name="txtSeafilePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="txtSeafilePassword.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -9178,7 +9202,7 @@ Using an encrypted library disables sharing.</value>
     <value>20, 35</value>
   </data>
   <data name="txtSeafileUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 20</value>
+    <value>188, 21</value>
   </data>
   <data name="txtSeafileUsername.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -9205,7 +9229,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 19</value>
   </data>
   <data name="lblSeafileUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblSeafileUsername.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -9235,7 +9259,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 63</value>
   </data>
   <data name="lblSeafilePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblSeafilePassword.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -9289,7 +9313,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 149</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 17</value>
+    <value>204, 16</value>
   </data>
   <data name="cbSeafileIgnoreInvalidCert.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -9319,7 +9343,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 103</value>
   </data>
   <data name="cbSeafileCreateShareableURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>144, 16</value>
   </data>
   <data name="cbSeafileCreateShareableURL.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -9349,7 +9373,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 126</value>
   </data>
   <data name="cbSeafileCreateShareableURLRaw.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
+    <value>90, 16</value>
   </data>
   <data name="cbSeafileCreateShareableURLRaw.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -9373,7 +9397,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 77</value>
   </data>
   <data name="txtSeafileAuthToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>297, 20</value>
+    <value>297, 21</value>
   </data>
   <data name="txtSeafileAuthToken.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -9400,7 +9424,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 61</value>
   </data>
   <data name="lblSeafileAuthToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblSeafileAuthToken.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -9430,7 +9454,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblSeafileAPIURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblSeafileAPIURL.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -9451,7 +9475,7 @@ Using an encrypted library disables sharing.</value>
     <value>21</value>
   </data>
   <data name="tpSeafile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpSeafile.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -9487,7 +9511,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 112</value>
   </data>
   <data name="cbStreamableUseDirectURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbStreamableUseDirectURL.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -9514,7 +9538,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 6, 6, 6</value>
   </data>
   <data name="txtStreamablePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>372, 20</value>
+    <value>372, 21</value>
   </data>
   <data name="txtStreamablePassword.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -9538,7 +9562,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 6, 6, 6</value>
   </data>
   <data name="txtStreamableUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>372, 20</value>
+    <value>372, 21</value>
   </data>
   <data name="txtStreamableUsername.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -9568,7 +9592,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 0, 6, 0</value>
   </data>
   <data name="lblStreamableUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblStreamableUsername.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -9601,7 +9625,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 0, 6, 0</value>
   </data>
   <data name="lblStreamablePassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblStreamablePassword.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -9622,7 +9646,7 @@ Using an encrypted library disables sharing.</value>
     <value>4</value>
   </data>
   <data name="tpStreamable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpStreamable.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 0</value>
@@ -9676,7 +9700,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtSulAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 20</value>
+    <value>400, 21</value>
   </data>
   <data name="txtSulAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -9703,7 +9727,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblSulAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblSulAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -9724,7 +9748,7 @@ Using an encrypted library disables sharing.</value>
     <value>2</value>
   </data>
   <data name="tpSul.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpSul.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -9781,7 +9805,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtLithiioPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 20</value>
+    <value>272, 21</value>
   </data>
   <data name="txtLithiioPassword.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -9802,7 +9826,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtLithiioEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 20</value>
+    <value>272, 21</value>
   </data>
   <data name="txtLithiioEmail.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -9829,7 +9853,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblLithiioPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblLithiioPassword.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -9859,7 +9883,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblLithiioEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblLithiioEmail.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -9916,7 +9940,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 144</value>
   </data>
   <data name="lblLithiioApiKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblLithiioApiKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -9940,7 +9964,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 160</value>
   </data>
   <data name="txtLithiioApiKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>272, 20</value>
+    <value>272, 21</value>
   </data>
   <data name="txtLithiioApiKey.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -9958,7 +9982,7 @@ Using an encrypted library disables sharing.</value>
     <value>7</value>
   </data>
   <data name="tpLithiio.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpLithiio.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -9994,7 +10018,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 34</value>
   </data>
   <data name="cbPlikOneShot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 17</value>
+    <value>222, 16</value>
   </data>
   <data name="cbPlikOneShot.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -10048,7 +10072,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 54</value>
   </data>
   <data name="cbPlikComment.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 17</value>
+    <value>132, 16</value>
   </data>
   <data name="cbPlikComment.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -10078,7 +10102,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 15</value>
   </data>
   <data name="cbPlikRemovable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>78, 16</value>
   </data>
   <data name="cbPlikRemovable.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -10126,7 +10150,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 217</value>
   </data>
   <data name="nudPlikTTL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 20</value>
+    <value>102, 21</value>
   </data>
   <data name="nudPlikTTL.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -10159,7 +10183,7 @@ Using an encrypted library disables sharing.</value>
     <value>117, 217</value>
   </data>
   <data name="cbPlikTTLUnit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 21</value>
+    <value>147, 20</value>
   </data>
   <data name="cbPlikTTLUnit.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -10186,7 +10210,7 @@ Using an encrypted library disables sharing.</value>
     <value>7, 202</value>
   </data>
   <data name="lblPlikTTL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 13</value>
+    <value>233, 12</value>
   </data>
   <data name="lblPlikTTL.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -10210,7 +10234,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 31</value>
   </data>
   <data name="txtPlikURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 20</value>
+    <value>255, 21</value>
   </data>
   <data name="txtPlikURL.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -10237,7 +10261,7 @@ Using an encrypted library disables sharing.</value>
     <value>8, 15</value>
   </data>
   <data name="lblPlikURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 13</value>
+    <value>29, 12</value>
   </data>
   <data name="lblPlikURL.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -10267,7 +10291,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 100</value>
   </data>
   <data name="cbPlikIsSecured.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 17</value>
+    <value>210, 16</value>
   </data>
   <data name="cbPlikIsSecured.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -10297,7 +10321,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 58</value>
   </data>
   <data name="lblPlikAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblPlikAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -10321,7 +10345,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 74</value>
   </data>
   <data name="txtPlikAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 20</value>
+    <value>255, 21</value>
   </data>
   <data name="txtPlikAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -10348,7 +10372,7 @@ Using an encrypted library disables sharing.</value>
     <value>8, 159</value>
   </data>
   <data name="lblPlikPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPlikPassword.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -10378,7 +10402,7 @@ Using an encrypted library disables sharing.</value>
     <value>6, 120</value>
   </data>
   <data name="lblPlikUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPlikUsername.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -10402,7 +10426,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 175</value>
   </data>
   <data name="txtPlikPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 20</value>
+    <value>255, 21</value>
   </data>
   <data name="txtPlikPassword.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -10423,7 +10447,7 @@ Using an encrypted library disables sharing.</value>
     <value>9, 136</value>
   </data>
   <data name="txtPlikLogin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 20</value>
+    <value>255, 21</value>
   </data>
   <data name="txtPlikLogin.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -10465,7 +10489,7 @@ Using an encrypted library disables sharing.</value>
     <value>1</value>
   </data>
   <data name="tpPlik.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpPlik.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -10522,7 +10546,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 105</value>
   </data>
   <data name="llYouTubePermissionsLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 13</value>
+    <value>245, 12</value>
   </data>
   <data name="llYouTubePermissionsLink.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -10552,7 +10576,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 88</value>
   </data>
   <data name="lblYouTubePermissionsTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>294, 13</value>
+    <value>359, 12</value>
   </data>
   <data name="lblYouTubePermissionsTip.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -10582,7 +10606,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 200</value>
   </data>
   <data name="cbYouTubeShowDialog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 17</value>
+    <value>174, 16</value>
   </data>
   <data name="cbYouTubeShowDialog.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -10612,7 +10636,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 176</value>
   </data>
   <data name="cbYouTubeUseShortenedLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 17</value>
+    <value>132, 16</value>
   </data>
   <data name="cbYouTubeUseShortenedLink.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -10636,7 +10660,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 144</value>
   </data>
   <data name="cbYouTubePrivacyType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 21</value>
+    <value>128, 20</value>
   </data>
   <data name="cbYouTubePrivacyType.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -10663,7 +10687,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 128</value>
   </data>
   <data name="lblYouTubePrivacyType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblYouTubePrivacyType.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -10684,7 +10708,7 @@ Using an encrypted library disables sharing.</value>
     <value>6</value>
   </data>
   <data name="tpYouTube.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpYouTube.Size" type="System.Drawing.Size, System.Drawing">
     <value>178, 0</value>
@@ -10709,6 +10733,9 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="lbSharedFolderAccounts.IntegralHeight" type="System.Boolean, mscorlib">
     <value>False</value>
+  </data>
+  <data name="lbSharedFolderAccounts.ItemHeight" type="System.Int32, mscorlib">
+    <value>12</value>
   </data>
   <data name="lbSharedFolderAccounts.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 80</value>
@@ -10843,7 +10870,7 @@ Using an encrypted library disables sharing.</value>
     <value>544, 16</value>
   </data>
   <data name="lblSharedFolderFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblSharedFolderFiles.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -10873,7 +10900,7 @@ Using an encrypted library disables sharing.</value>
     <value>280, 16</value>
   </data>
   <data name="lblSharedFolderText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblSharedFolderText.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -10897,7 +10924,7 @@ Using an encrypted library disables sharing.</value>
     <value>608, 12</value>
   </data>
   <data name="cbSharedFolderFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbSharedFolderFiles.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -10924,7 +10951,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 16</value>
   </data>
   <data name="lblSharedFolderImages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblSharedFolderImages.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -10948,7 +10975,7 @@ Using an encrypted library disables sharing.</value>
     <value>344, 12</value>
   </data>
   <data name="cbSharedFolderText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbSharedFolderText.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -10969,7 +10996,7 @@ Using an encrypted library disables sharing.</value>
     <value>80, 12</value>
   </data>
   <data name="cbSharedFolderImages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>184, 20</value>
   </data>
   <data name="cbSharedFolderImages.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -10987,7 +11014,7 @@ Using an encrypted library disables sharing.</value>
     <value>10</value>
   </data>
   <data name="tpSharedFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpSharedFolder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -11017,7 +11044,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 408</value>
   </data>
   <data name="txtEmailAutomaticSendTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtEmailAutomaticSendTo.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -11044,7 +11071,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 384</value>
   </data>
   <data name="cbEmailAutomaticSend.Size" type="System.Drawing.Size, System.Drawing">
-    <value>275, 17</value>
+    <value>342, 16</value>
   </data>
   <data name="cbEmailAutomaticSend.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -11074,7 +11101,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblEmailSmtpServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblEmailSmtpServer.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -11104,7 +11131,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 112</value>
   </data>
   <data name="lblEmailPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblEmailPassword.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -11134,7 +11161,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 160</value>
   </data>
   <data name="cbEmailRememberLastTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 17</value>
+    <value>210, 16</value>
   </data>
   <data name="cbEmailRememberLastTo.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -11158,7 +11185,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtEmailFrom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtEmailFrom.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -11179,7 +11206,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 128</value>
   </data>
   <data name="txtEmailPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtEmailPassword.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -11230,7 +11257,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblEmailFrom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblEmailFrom.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -11254,7 +11281,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtEmailSmtpServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtEmailSmtpServer.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -11281,7 +11308,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 184</value>
   </data>
   <data name="lblEmailDefaultSubject.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 13</value>
+    <value>101, 12</value>
   </data>
   <data name="lblEmailDefaultSubject.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -11311,7 +11338,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 232</value>
   </data>
   <data name="lblEmailDefaultBody.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 13</value>
+    <value>101, 12</value>
   </data>
   <data name="lblEmailDefaultBody.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -11335,7 +11362,7 @@ Using an encrypted library disables sharing.</value>
     <value>224, 32</value>
   </data>
   <data name="nudEmailSmtpPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>64, 21</value>
   </data>
   <data name="nudEmailSmtpPort.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -11365,7 +11392,7 @@ Using an encrypted library disables sharing.</value>
     <value>221, 16</value>
   </data>
   <data name="lblEmailSmtpPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 13</value>
+    <value>35, 12</value>
   </data>
   <data name="lblEmailSmtpPort.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -11389,7 +11416,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 200</value>
   </data>
   <data name="txtEmailDefaultSubject.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 20</value>
+    <value>400, 21</value>
   </data>
   <data name="txtEmailDefaultSubject.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -11407,7 +11434,7 @@ Using an encrypted library disables sharing.</value>
     <value>14</value>
   </data>
   <data name="tpEmail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 220</value>
+    <value>4, 238</value>
   </data>
   <data name="tpEmail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
@@ -11512,7 +11539,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 336</value>
   </data>
   <data name="cbPastebinRaw.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
+    <value>90, 16</value>
   </data>
   <data name="cbPastebinRaw.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -11536,7 +11563,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 256</value>
   </data>
   <data name="cbPastebinSyntax.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 21</value>
+    <value>152, 20</value>
   </data>
   <data name="cbPastebinSyntax.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -11590,7 +11617,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 240</value>
   </data>
   <data name="lblPastebinSyntax.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
+    <value>83, 12</value>
   </data>
   <data name="lblPastebinSyntax.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -11620,7 +11647,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 192</value>
   </data>
   <data name="lblPastebinExpiration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblPastebinExpiration.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -11650,7 +11677,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 144</value>
   </data>
   <data name="lblPastebinPrivacy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblPastebinPrivacy.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -11680,7 +11707,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 288</value>
   </data>
   <data name="lblPastebinTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>77, 12</value>
   </data>
   <data name="lblPastebinTitle.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -11710,7 +11737,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblPastebinPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPastebinPassword.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -11740,7 +11767,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblPastebinUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPastebinUsername.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -11764,7 +11791,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 208</value>
   </data>
   <data name="cbPastebinExpiration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 21</value>
+    <value>152, 20</value>
   </data>
   <data name="cbPastebinExpiration.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -11785,7 +11812,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 160</value>
   </data>
   <data name="cbPastebinPrivacy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 21</value>
+    <value>152, 20</value>
   </data>
   <data name="cbPastebinPrivacy.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -11806,7 +11833,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 304</value>
   </data>
   <data name="txtPastebinTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 20</value>
+    <value>152, 21</value>
   </data>
   <data name="txtPastebinTitle.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -11827,7 +11854,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtPastebinPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 20</value>
+    <value>152, 21</value>
   </data>
   <data name="txtPastebinPassword.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -11848,7 +11875,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtPastebinUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 20</value>
+    <value>152, 21</value>
   </data>
   <data name="txtPastebinUsername.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -11875,7 +11902,7 @@ Using an encrypted library disables sharing.</value>
     <value>256, 117</value>
   </data>
   <data name="lblPastebinLoginStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
+    <value>47, 12</value>
   </data>
   <data name="lblPastebinLoginStatus.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -11986,7 +12013,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 48</value>
   </data>
   <data name="lblPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -12010,7 +12037,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 64</value>
   </data>
   <data name="txtPaste_eeUserAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 20</value>
+    <value>296, 21</value>
   </data>
   <data name="txtPaste_eeUserAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -12064,7 +12091,7 @@ Using an encrypted library disables sharing.</value>
     <value>224, 316</value>
   </data>
   <data name="lblGistCustomURLExample.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 13</value>
+    <value>191, 12</value>
   </data>
   <data name="lblGistCustomURLExample.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -12094,7 +12121,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblGistOAuthInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 13</value>
+    <value>251, 12</value>
   </data>
   <data name="lblGistOAuthInfo.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -12124,7 +12151,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 296</value>
   </data>
   <data name="lblGistCustomURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblGistCustomURL.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -12148,7 +12175,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 312</value>
   </data>
   <data name="txtGistCustomURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtGistCustomURL.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -12175,7 +12202,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 272</value>
   </data>
   <data name="cbGistUseRawURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
+    <value>90, 16</value>
   </data>
   <data name="cbGistUseRawURL.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -12205,7 +12232,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 248</value>
   </data>
   <data name="cbGistPublishPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
+    <value>132, 16</value>
   </data>
   <data name="cbGistPublishPublic.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -12280,7 +12307,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 64</value>
   </data>
   <data name="cbUpasteIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
+    <value>126, 16</value>
   </data>
   <data name="cbUpasteIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -12310,7 +12337,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblUpasteUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblUpasteUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -12334,7 +12361,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtUpasteUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 20</value>
+    <value>264, 21</value>
   </data>
   <data name="txtUpasteUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -12388,7 +12415,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 112</value>
   </data>
   <data name="cbHastebinUseFileExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 17</value>
+    <value>360, 16</value>
   </data>
   <data name="cbHastebinUseFileExtension.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -12412,7 +12439,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtHastebinSyntaxHighlighting.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 20</value>
+    <value>100, 21</value>
   </data>
   <data name="txtHastebinSyntaxHighlighting.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -12433,7 +12460,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtHastebinCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 20</value>
+    <value>336, 21</value>
   </data>
   <data name="txtHastebinCustomDomain.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -12460,7 +12487,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblHastebinSyntaxHighlighting.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 13</value>
+    <value>125, 12</value>
   </data>
   <data name="lblHastebinSyntaxHighlighting.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -12490,7 +12517,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblHastebinCustomDomain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>89, 12</value>
   </data>
   <data name="lblHastebinCustomDomain.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -12547,7 +12574,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 55</value>
   </data>
   <data name="lblOneTimeSecretAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblOneTimeSecretAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -12577,7 +12604,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblOneTimeSecretEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>41, 12</value>
   </data>
   <data name="lblOneTimeSecretEmail.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -12601,7 +12628,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 71</value>
   </data>
   <data name="txtOneTimeSecretAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 20</value>
+    <value>304, 21</value>
   </data>
   <data name="txtOneTimeSecretAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -12622,7 +12649,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtOneTimeSecretEmail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 20</value>
+    <value>152, 21</value>
   </data>
   <data name="txtOneTimeSecretEmail.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -12676,7 +12703,7 @@ Using an encrypted library disables sharing.</value>
     <value>17, 22</value>
   </data>
   <data name="cbPastieIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
+    <value>126, 16</value>
   </data>
   <data name="cbPastieIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -12784,7 +12811,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 376</value>
   </data>
   <data name="cbImgurUseGIFV.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 17</value>
+    <value>192, 16</value>
   </data>
   <data name="cbImgurUseGIFV.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -12814,7 +12841,7 @@ Using an encrypted library disables sharing.</value>
     <value>352, 19</value>
   </data>
   <data name="cbImgurUploadSelectedAlbum.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 17</value>
+    <value>210, 16</value>
   </data>
   <data name="cbImgurUploadSelectedAlbum.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -12844,7 +12871,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 304</value>
   </data>
   <data name="cbImgurDirectLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbImgurDirectLink.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -12976,7 +13003,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 344</value>
   </data>
   <data name="cbImgurThumbnailType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 21</value>
+    <value>128, 20</value>
   </data>
   <data name="cbImgurThumbnailType.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -13003,7 +13030,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 328</value>
   </data>
   <data name="lblImgurThumbnailType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 13</value>
+    <value>95, 12</value>
   </data>
   <data name="lblImgurThumbnailType.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -13114,7 +13141,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 120</value>
   </data>
   <data name="cbImageShackIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
+    <value>126, 16</value>
   </data>
   <data name="cbImageShackIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -13171,7 +13198,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblImageShackUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblImageShackUsername.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -13195,7 +13222,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtImageShackUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 20</value>
+    <value>208, 21</value>
   </data>
   <data name="txtImageShackUsername.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -13216,7 +13243,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 82</value>
   </data>
   <data name="txtImageShackPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 20</value>
+    <value>208, 21</value>
   </data>
   <data name="txtImageShackPassword.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -13243,7 +13270,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 66</value>
   </data>
   <data name="lblImageShackPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lblImageShackPassword.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -13300,7 +13327,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 224</value>
   </data>
   <data name="cbFlickrDirectLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>114, 16</value>
   </data>
   <data name="cbFlickrDirectLink.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -13426,7 +13453,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 24</value>
   </data>
   <data name="cbPhotobucketAlbumPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>440, 21</value>
+    <value>440, 20</value>
   </data>
   <data name="cbPhotobucketAlbumPaths.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -13477,7 +13504,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 72</value>
   </data>
   <data name="lblPhotobucketNewAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>643, 13</value>
+    <value>797, 12</value>
   </data>
   <data name="lblPhotobucketNewAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -13507,7 +13534,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 24</value>
   </data>
   <data name="lblPhotobucketParentAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 13</value>
+    <value>107, 12</value>
   </data>
   <data name="lblPhotobucketParentAlbumPath.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -13531,7 +13558,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 88</value>
   </data>
   <data name="txtPhotobucketNewAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 20</value>
+    <value>216, 21</value>
   </data>
   <data name="txtPhotobucketNewAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -13552,7 +13579,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 40</value>
   </data>
   <data name="txtPhotobucketParentAlbumPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 20</value>
+    <value>448, 21</value>
   </data>
   <data name="txtPhotobucketParentAlbumPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -13630,7 +13657,7 @@ Using an encrypted library disables sharing.</value>
     <value>493, 128</value>
   </data>
   <data name="lblPhotobucketDefaultAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
+    <value>113, 12</value>
   </data>
   <data name="lblPhotobucketDefaultAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -13681,7 +13708,7 @@ Using an encrypted library disables sharing.</value>
     <value>496, 144</value>
   </data>
   <data name="txtPhotobucketDefaultAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 20</value>
+    <value>200, 21</value>
   </data>
   <data name="txtPhotobucketDefaultAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -13708,7 +13735,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblPhotobucketVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>292, 13</value>
+    <value>377, 12</value>
   </data>
   <data name="lblPhotobucketVerificationCode.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -13759,7 +13786,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtPhotobucketVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 20</value>
+    <value>360, 21</value>
   </data>
   <data name="txtPhotobucketVerificationCode.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -13786,7 +13813,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 151</value>
   </data>
   <data name="lblPhotobucketAccountStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>95, 12</value>
   </data>
   <data name="lblPhotobucketAccountStatus.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -13888,7 +13915,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 505</value>
   </data>
   <data name="lblGooglePhotosCreateAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblGooglePhotosCreateAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -13912,7 +13939,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 521</value>
   </data>
   <data name="txtGooglePhotosCreateAlbumName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>328, 20</value>
+    <value>328, 21</value>
   </data>
   <data name="txtGooglePhotosCreateAlbumName.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -13966,7 +13993,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 88</value>
   </data>
   <data name="cbGooglePhotosIsPublic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
+    <value>102, 16</value>
   </data>
   <data name="cbGooglePhotosIsPublic.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -13990,7 +14017,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 160</value>
   </data>
   <data name="txtPicasaAlbumID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>432, 20</value>
+    <value>432, 21</value>
   </data>
   <data name="txtPicasaAlbumID.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -14017,7 +14044,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 144</value>
   </data>
   <data name="lblPicasaAlbumID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 13</value>
+    <value>281, 12</value>
   </data>
   <data name="lblPicasaAlbumID.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -14143,7 +14170,7 @@ Using an encrypted library disables sharing.</value>
     <value>264, 36</value>
   </data>
   <data name="lblCheveretoUploadURLExample.Size" type="System.Drawing.Size, System.Drawing">
-    <value>213, 13</value>
+    <value>245, 12</value>
   </data>
   <data name="lblCheveretoUploadURLExample.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -14173,7 +14200,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 112</value>
   </data>
   <data name="cbCheveretoDirectURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 17</value>
+    <value>84, 16</value>
   </data>
   <data name="cbCheveretoDirectURL.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -14203,7 +14230,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lblCheveretoUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>71, 12</value>
   </data>
   <data name="lblCheveretoUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -14227,7 +14254,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtCheveretoUploadURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 20</value>
+    <value>240, 21</value>
   </data>
   <data name="txtCheveretoUploadURL.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -14248,7 +14275,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 80</value>
   </data>
   <data name="txtCheveretoAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 20</value>
+    <value>240, 21</value>
   </data>
   <data name="txtCheveretoAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -14275,7 +14302,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 64</value>
   </data>
   <data name="lblCheveretoAPIKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>53, 12</value>
   </data>
   <data name="lblCheveretoAPIKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -14332,7 +14359,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 64</value>
   </data>
   <data name="llVgymeAccountDetailsPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 13</value>
+    <value>287, 12</value>
   </data>
   <data name="llVgymeAccountDetailsPage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -14356,7 +14383,7 @@ Using an encrypted library disables sharing.</value>
     <value>16, 32</value>
   </data>
   <data name="txtVgymeUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>472, 20</value>
+    <value>472, 21</value>
   </data>
   <data name="txtVgymeUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -14383,7 +14410,7 @@ Using an encrypted library disables sharing.</value>
     <value>13, 16</value>
   </data>
   <data name="lvlVgymeUserKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
+    <value>59, 12</value>
   </data>
   <data name="lvlVgymeUserKey.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -14657,5 +14684,8 @@ Using an encrypted library disables sharing.</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Use direct link</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.ru.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.ru.resx
@@ -1089,4 +1089,7 @@
   <data name="lblAzureStorageCacheControl.Text" xml:space="preserve">
     <value>Cache-Control заголовок:</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Использовать прямую ссылку</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.tr.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.tr.resx
@@ -1086,4 +1086,7 @@ Mesela klasör ismi "bucket.example.com" ise o zaman adres "http://bucket.exampl
   <data name="cbYouTubeShowDialog.Text" xml:space="preserve">
     <value>Video seçenekleri penceresini göster</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Direkt link kullan</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.uk.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.uk.resx
@@ -921,4 +921,7 @@
   <data name="$this.Text" xml:space="preserve">
     <value>ShareX — Налаштування призначень</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Використовувати пряме посилання</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.vi-VN.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.vi-VN.resx
@@ -1284,4 +1284,7 @@ Sử dụng thư viện được mã hóa sẽ vô hiệu hóa chia sẻ.</value
   <data name="lblZWSToken.Text" xml:space="preserve">
     <value>Token:</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>Dùng liên kết trực tiếp</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-CN.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-CN.resx
@@ -1290,4 +1290,7 @@
   <data name="tpZeroWidthShortener.Text" xml:space="preserve">
     <value>Zero Width 缩短器</value>
   </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>使用直链</value>
+  </data>
 </root>

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-TW.resx
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.zh-TW.resx
@@ -53,6 +53,7 @@
     value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
+
     mimetype: application/x-microsoft.net.object.bytearray.base64
     value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
@@ -1057,5 +1058,8 @@
   </data>
   <data name="tpGooglePhotos.Text" xml:space="preserve">
     <value>Google 相簿</value>
+  </data>
+  <data name="cbOneDriveUseDirectLink.Text" xml:space="preserve">
+    <value>使用直接連結</value>
   </data>
 </root>

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -176,6 +176,7 @@ namespace ShareX.UploadersLib
         public OAuth2Info OneDriveV2OAuth2Info { get; set; } = null;
         public OneDriveFileInfo OneDriveV2SelectedFolder { get; set; } = OneDrive.RootFolder;
         public bool OneDriveAutoCreateShareableLink { get; set; } = true;
+        public bool OneDriveUseDirectLink { get; set; } = false;
 
         #endregion OneDrive
 


### PR DESCRIPTION
I have added the ability to generate direct links for OneDrive (using OneDrive's "Embed" feature). I noticed that there is an implementation for embedding in the source code for OneDrive, but it seems that this is not being called. Therefore, this pull request introduces a new switch to control it.

Additionally, after adding the switch control and relocating it, I observed that there have been numerous changes in ShareX.UploadersLib/Forms/UploadersConfigForm.resx. I'm not sure if this is normal. :D

Its translation is entirely based on other similar switch options.