### PR TITLE
Add MagnifyShape

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -213,6 +213,12 @@ namespace ShareX.HelpersLib
         RomanNumeralsLowercase
     }
 
+    public enum MagnifyShape
+    {
+        Ellipse,
+        Rectangle
+    }
+
     public enum CutOutEffectType // Localized
     {
         None,

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1979,6 +1979,15 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Magnify shape.
+        /// </summary>
+        internal static string ShapeManager_CreateToolbar_MagnifyShape {
+            get {
+                return ResourceManager.GetString("ShapeManager_CreateToolbar_MagnifyShape", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New image....
         /// </summary>
         internal static string ShapeManager_CreateToolbar_NewImage {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -299,6 +299,9 @@
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>Interpolation mode:</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_MagnifyShape" xml:space="preserve">
+    <value>Magnify shape</value>
+  </data> 
   <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
     <value>Width:</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
@@ -88,6 +88,7 @@ namespace ShareX.ScreenCaptureLib
 
         // Magnify drawing
         public int MagnifyStrength { get; set; } = 200;
+        public MagnifyShape MagnifyShape { get; set; } = MagnifyShape.Ellipse;
 
         // Sticker drawing
         public List<StickerPackInfo> StickerPacks = new List<StickerPackInfo>()

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -53,7 +53,7 @@ namespace ShareX.ScreenCaptureLib
         private ToolStripLabeledNumericUpDown tslnudBorderSize, tslnudCornerRadius, tslnudCenterPoints, tslnudBlurRadius, tslnudPixelateSize, tslnudStepFontSize,
             tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength, tslnudCutOutEffectSize;
         private ToolStripLabel tslDragLeft, tslDragRight;
-        private ToolStripLabeledComboBox tscbBorderStyle, tscbArrowHeadDirection, tscbImageInterpolationMode, tscbCursorTypes, tscbStepType, tscbCutOutEffectType;
+        private ToolStripLabeledComboBox tscbBorderStyle, tscbArrowHeadDirection, tscbImageInterpolationMode, tscbMagnifyShape, tscbCursorTypes, tscbStepType, tscbCutOutEffectType;
 
         internal void CreateToolbar()
         {
@@ -457,6 +457,16 @@ namespace ShareX.ScreenCaptureLib
             tsddbShapeOptions.DisplayStyle = ToolStripItemDisplayStyle.Image;
             tsddbShapeOptions.Image = Resources.layer__pencil;
             tsMain.Items.Add(tsddbShapeOptions);
+
+            tscbMagnifyShape = new ToolStripLabeledComboBox(Resources.ShapeManager_CreateToolbar_MagnifyShape);
+            tscbMagnifyShape.Content.AddRange(Helpers.GetLocalizedEnumDescriptions<MagnifyShape>());
+            tscbMagnifyShape.Content.SelectedIndexChanged += (sender, e) =>
+            {
+                AnnotationOptions.MagnifyShape = (MagnifyShape)tscbMagnifyShape.Content.SelectedIndex;
+                tscbMagnifyShape.Invalidate();
+                UpdateCurrentShape();
+            };
+            tsddbShapeOptions.DropDownItems.Add(tscbMagnifyShape);
 
             tslnudMagnifyStrength = new ToolStripLabeledNumericUpDown(Resources.MagnifyStrength);
             tslnudMagnifyStrength.Content.Text2 = "%";
@@ -1458,6 +1468,8 @@ namespace ShareX.ScreenCaptureLib
 
             tscbBorderStyle.Content.SelectedIndex = (int)AnnotationOptions.BorderStyle;
 
+            tscbMagnifyShape.Content.SelectedIndex = (int)AnnotationOptions.MagnifyShape;
+
             tscbImageInterpolationMode.Content.SelectedIndex = (int)AnnotationOptions.ImageInterpolationMode;
 
             tslnudBlurRadius.Content.Value = AnnotationOptions.BlurRadius;
@@ -1587,6 +1599,7 @@ namespace ShareX.ScreenCaptureLib
 
             tslnudCenterPoints.Visible = shapeType == ShapeType.DrawingLine || shapeType == ShapeType.DrawingArrow;
             tscbArrowHeadDirection.Visible = shapeType == ShapeType.DrawingArrow || shapeType == ShapeType.DrawingFreehandArrow;
+            tscbMagnifyShape.Visible = shapeType == ShapeType.DrawingMagnify;
             tscbImageInterpolationMode.Visible = shapeType == ShapeType.DrawingImage || shapeType == ShapeType.DrawingImageScreen || shapeType == ShapeType.DrawingMagnify;
             tslnudStartingStepValue.Visible = shapeType == ShapeType.DrawingStep;
             tslnudStepFontSize.Visible = tscbStepType.Visible = shapeType == ShapeType.DrawingStep;


### PR DESCRIPTION
Allows users to choose the magnify shape (ellipse, rectangle). This is done via the "Tool Options" (new dropdown).
fixes: #4836
![image](https://github.com/ShareX/ShareX/assets/28874499/1ad3393f-b99d-4b81-93f4-14ffb26c6c33)
