### PR TITLE
Add support for TLS v1.3

### DIFF
--- a/ShareX.UploadersLib/BaseUploaders/Uploader.cs
+++ b/ShareX.UploadersLib/BaseUploaders/Uploader.cs
@@ -63,7 +63,7 @@ namespace ShareX.UploadersLib
             {
                 try
                 {
-                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
                 }
                 catch (NotSupportedException)
                 {


### PR DESCRIPTION
https://github.com/ShareX/ShareX/issues/5635 ????? even though i enable the tls 1.3 experimental feature from Windows internet properties and restart sharex it still gives me that error and this is probably why