### PR TITLE
Implemented Undo/redo function on image editory

### DIFF
--- a/ShareX.ScreenCaptureLib/ImageEditorHistory.cs
+++ b/ShareX.ScreenCaptureLib/ImageEditorHistory.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShareX.ScreenCaptureLib
+{
+    internal class ImageEditorHistory : IDisposable
+    {
+        private Stack<ImageEditorMemento> mementoStack = new Stack<ImageEditorMemento>();
+        private Stack<ImageEditorMemento> redoMementoStack = new Stack<ImageEditorMemento>();
+        private readonly ShapeManager shapeManager;
+        public ImageEditorHistory(ShapeManager shapeManager)
+        {
+
+            this.shapeManager = shapeManager;
+        }
+
+        public void AddMemento(ImageEditorMemento memento)
+        {
+            mementoStack.Push(memento);
+            foreach (var mmnt in redoMementoStack)
+            {
+                mmnt.Dispose();
+            }
+            redoMementoStack.Clear();
+        }
+
+
+        private ImageEditorMemento GetMementoFromCanvas()
+        {
+            Bitmap canvas = shapeManager.Form.Canvas;
+
+            Rectangle rectClone = new Rectangle(0, 0, canvas.Width, canvas.Height);
+            Bitmap currentCanvas = canvas.Clone(rectClone, canvas.PixelFormat);
+            var shapes = shapeManager.Shapes.Select(x => x.Duplicate()).ToList();
+
+            return new ImageEditorMemento(shapes, currentCanvas);
+
+        }
+
+        public void CreateCanvasMemento()
+        {
+            AddMemento(GetMementoFromCanvas());
+        }
+
+        public void CreateShapesMemento()
+        {
+            var shapes = shapeManager.Shapes.Select(x => x.Duplicate()).ToList();
+            AddMemento(new ImageEditorMemento(shapes));
+        }
+
+        public void Undo()
+        {
+            if (mementoStack.Count > 0)
+            {
+                ImageEditorMemento redoMemento;
+                var memento = mementoStack.Pop();
+
+                if (memento.Shapes != null)
+                {
+                    if (memento.Canvas == null)
+                    {
+                        redoMemento = new ImageEditorMemento(shapeManager.Shapes.Select(x => x.Duplicate()).ToList());
+                        redoMementoStack.Push(redoMemento);
+
+                        shapeManager.RestoreState(memento.Shapes);
+                    }
+                    else
+                    {
+                        redoMemento = GetMementoFromCanvas();
+                        redoMementoStack.Push(redoMemento);
+
+                        shapeManager.RestoreState(memento.Shapes, memento.Canvas);
+                    }
+
+                }
+
+            }
+        }
+
+        public void Redo()
+        {
+            if (redoMementoStack.Count > 0)
+            {
+                var redoMemento = redoMementoStack.Pop();
+                if (redoMemento.Shapes != null)
+                {
+                    if (redoMemento.Canvas == null)
+                    {
+                        var shapes = shapeManager.Shapes.Select(x => x.Duplicate()).ToList();
+                        var memento = new ImageEditorMemento(shapes);
+                        mementoStack.Push(memento);
+
+                        shapeManager.RestoreState(redoMemento.Shapes);
+                    }
+                    else
+                    {
+                        var memento = GetMementoFromCanvas();
+                        mementoStack.Push(memento);
+
+                        shapeManager.RestoreState(redoMemento.Shapes, redoMemento.Canvas);
+                    }
+
+                }
+            }
+        }
+        public void Dispose()
+        {
+            foreach (var memnto in mementoStack.Concat(redoMementoStack))
+            {
+                memnto.Dispose();
+            }
+            mementoStack.Clear();
+            redoMementoStack.Clear();
+        }
+
+        public bool HasMementos()
+        {
+            return mementoStack.Count > 0;
+        }
+
+        public bool HasRedoMementos()
+        {
+            return redoMementoStack.Count > 0;
+        }
+    }
+
+}

--- a/ShareX.ScreenCaptureLib/ImageEditorMemento.cs
+++ b/ShareX.ScreenCaptureLib/ImageEditorMemento.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShareX.ScreenCaptureLib
+{
+    internal class ImageEditorMemento
+    {
+        public ImageEditorMemento(List<BaseShape> shapes)
+        {
+            Shapes = shapes;
+        }
+
+        public ImageEditorMemento(List<BaseShape> shapes, Bitmap canvas)
+        {
+            Shapes = shapes;
+            Canvas = canvas;
+        }
+
+        public List<BaseShape> Shapes { get; private set; }
+        public Bitmap Canvas { get; private set; }
+
+    }
+}

--- a/ShareX.ScreenCaptureLib/ImageEditorMemento.cs
+++ b/ShareX.ScreenCaptureLib/ImageEditorMemento.cs
@@ -4,10 +4,11 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace ShareX.ScreenCaptureLib
 {
-    internal class ImageEditorMemento
+    internal class ImageEditorMemento : IDisposable
     {
         public ImageEditorMemento(List<BaseShape> shapes)
         {
@@ -23,5 +24,18 @@ namespace ShareX.ScreenCaptureLib
         public List<BaseShape> Shapes { get; private set; }
         public Bitmap Canvas { get; private set; }
 
+        public void Dispose()
+        {
+            if(Canvas != null)
+            {
+                Canvas.Dispose();
+            }
+            foreach (BaseShape shape in Shapes)
+            {
+                shape.Dispose();
+            }
+
+            Shapes.Clear();
+        }
     }
 }

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -2015,6 +2015,15 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Redo.
+        /// </summary>
+        internal static string ShapeManager_CreateToolbar_Redo {
+            get {
+                return ResourceManager.GetString("ShapeManager_CreateToolbar_Redo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rotate 180°.
         /// </summary>
         internal static string ShapeManager_CreateToolbar_Rotate180 {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
@@ -246,6 +246,9 @@
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>Desfazer</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>Refazer</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
     <value>Sombra projetada</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -227,6 +227,9 @@
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>Undo</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
   <data name="folder_open_image" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\folder-open-image.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -683,13 +683,13 @@ namespace ShareX.ScreenCaptureLib
             tsmiUndo = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_Undo);
             tsmiUndo.Image = Resources.arrow_circle_225_left;
             tsmiUndo.ShortcutKeyDisplayString = "Ctrl+Z";
-            tsmiUndo.Click += (sender, e) => Undo();
+            tsmiUndo.Click += (sender, e) => history.Undo();
             tsddbEdit.DropDownItems.Add(tsmiUndo);
 
             tsmiRedo = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_Redo);
             tsmiRedo.Image = Resources.arrow_circle;
             tsmiRedo.ShortcutKeyDisplayString = "Ctrl+Y";
-            tsmiRedo.Click += (sender, e) => Redo();
+            tsmiRedo.Click += (sender, e) => history.Redo();
             tsddbEdit.DropDownItems.Add(tsmiRedo);
 
             ToolStripMenuItem tsmiPaste = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_PasteImageText);
@@ -1519,8 +1519,8 @@ namespace ShareX.ScreenCaptureLib
                     break;
             }
 
-            tsmiUndo.Enabled = tsmiDeleteAll.Enabled = mementoStack.Count > 0;
-            tsmiRedo.Enabled = tsmiDeleteAll.Enabled = redoMementoStack.Count > 0;
+            tsmiUndo.Enabled = tsmiDeleteAll.Enabled = history.HasMementos();
+            tsmiRedo.Enabled = tsmiDeleteAll.Enabled = history.HasRedoMementos();
             tsmiDuplicate.Enabled = tsmiDelete.Enabled = tsmiMoveTop.Enabled = tsmiMoveUp.Enabled = tsmiMoveDown.Enabled = tsmiMoveBottom.Enabled = CurrentShape != null;
 
             switch (shapeType)

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -48,7 +48,7 @@ namespace ShareX.ScreenCaptureLib
         private ToolStripEx tsMain;
         private ToolStripButton tsbSaveImage, tsbBorderColor, tsbFillColor, tsbHighlightColor;
         private ToolStripDropDownButton tsddbShapeOptions;
-        private ToolStripMenuItem tsmiShadow, tsmiShadowColor, tsmiUndo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
+        private ToolStripMenuItem tsmiShadow, tsmiShadowColor, tsmiUndo, tsmiRedo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
             tsmiMoveTop, tsmiMoveUp, tsmiMoveDown, tsmiMoveBottom, tsmiRegionCapture, tsmiQuickCrop, tsmiShowMagnifier;
         private ToolStripLabeledNumericUpDown tslnudBorderSize, tslnudCornerRadius, tslnudCenterPoints, tslnudBlurRadius, tslnudPixelateSize, tslnudStepFontSize,
             tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength, tslnudCutOutEffectSize;
@@ -683,8 +683,14 @@ namespace ShareX.ScreenCaptureLib
             tsmiUndo = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_Undo);
             tsmiUndo.Image = Resources.arrow_circle_225_left;
             tsmiUndo.ShortcutKeyDisplayString = "Ctrl+Z";
-            tsmiUndo.Click += (sender, e) => UndoShape();
+            tsmiUndo.Click += (sender, e) => Undo();
             tsddbEdit.DropDownItems.Add(tsmiUndo);
+
+            tsmiRedo = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_Redo);
+            tsmiRedo.Image = Resources.arrow_circle;
+            tsmiRedo.ShortcutKeyDisplayString = "Ctrl+Y";
+            tsmiRedo.Click += (sender, e) => Redo();
+            tsddbEdit.DropDownItems.Add(tsmiRedo);
 
             ToolStripMenuItem tsmiPaste = new ToolStripMenuItem(Resources.ShapeManager_CreateToolbar_PasteImageText);
             tsmiPaste.Image = Resources.clipboard;
@@ -1513,7 +1519,8 @@ namespace ShareX.ScreenCaptureLib
                     break;
             }
 
-            tsmiUndo.Enabled = tsmiDeleteAll.Enabled = Shapes.Count > 0;
+            tsmiUndo.Enabled = tsmiDeleteAll.Enabled = mementoStack.Count > 0;
+            tsmiRedo.Enabled = tsmiDeleteAll.Enabled = redoMementoStack.Count > 0;
             tsmiDuplicate.Enabled = tsmiDelete.Enabled = tsmiMoveTop.Enabled = tsmiMoveUp.Enabled = tsmiMoveDown.Enabled = tsmiMoveBottom.Enabled = CurrentShape != null;
 
             switch (shapeType)

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Helpers\ImageEditorScrollbar.cs" />
     <Compile Include="Helpers\ScrollbarManager.cs" />
     <Compile Include="Helpers\ScrollingCaptureManager.cs" />
+    <Compile Include="ImageEditorHistory.cs" />
     <Compile Include="ImageEditorMemento.cs" />
     <Compile Include="ScreenRecording\FFmpegCaptureDevice.cs" />
     <Compile Include="Shapes\AnnotationOptions.cs" />

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Helpers\ImageEditorScrollbar.cs" />
     <Compile Include="Helpers\ScrollbarManager.cs" />
     <Compile Include="Helpers\ScrollingCaptureManager.cs" />
+    <Compile Include="ImageEditorMemento.cs" />
     <Compile Include="ScreenRecording\FFmpegCaptureDevice.cs" />
     <Compile Include="Shapes\AnnotationOptions.cs" />
     <Compile Include="Enums.cs" />


### PR DESCRIPTION
I have reworked the existing implementation of the undo (CTRL+Z) funtion and implemented a redo (CTRL+Y) one.
First I created the ImageEditorMemento class to store a state of the Image being edited, by keeping  the list of shapes drawn and the Bitmap canvas. I decided to have a constructor with only Shapes in order to avoid cloning and storing the whole Image all the time.
![image](https://github.com/ShareX/ShareX/assets/16940557/8b19c148-604a-45e3-89ef-318f44557e1f)

Next I added two stacks of this ImageEditorMemento class in to the shape manager to keep all the past states of the editor and the undone ones.
![image](https://github.com/ShareX/ShareX/assets/16940557/2af58cb1-edb3-4399-b260-34cce45a6140)


Then I have created two methods that create and stack the current state of the editor. One will store just the Shapes list and the other will store both the Shapes and the canvas.
![image](https://github.com/ShareX/ShareX/assets/16940557/1a4ac6eb-4311-44de-a0fa-c102e47d421c)

Finally I have added the Undo and Redo methods, that will unstack the past state or the undone state and restore them in the Shapes list and updating the canvas when it is not null.
![image](https://github.com/ShareX/ShareX/assets/16940557/f2f76d68-456b-464c-868e-56daa31539ef)

The previous UndoShape method was replaced by the Undo. 

Also a menu item was added for the Redo function under the Undo one.

fixes: #4079 