### PR TITLE
fix: change from http to https on all api endpoints

### DIFF
--- a/ShareX.HelpersLib/Links.cs
+++ b/ShareX.HelpersLib/Links.cs
@@ -38,7 +38,7 @@ namespace ShareX.HelpersLib
         public const string Actions = Website + "/actions";
         public const string Jaex = "https://github.com/Jaex";
         public const string McoreD = "https://github.com/McoreD";
-        public const string Steam = "http://store.steampowered.com/app/400040/";
+        public const string Steam = "https://store.steampowered.com/app/400040/";
         public const string Discord = "https://discord.gg/ShareX";
         public const string Twitter = "https://twitter.com/ShareX";
         private const string Docs = Website + "/docs";

--- a/ShareX.UploadersLib/FileUploaders/DropIO.cs
+++ b/ShareX.UploadersLib/FileUploaders/DropIO.cs
@@ -67,12 +67,12 @@ namespace ShareX.UploadersLib.FileUploaders
             args.Add("token", drop.AdminToken);
             args.Add("drop_name", drop.Name);
 
-            UploadResult result = SendRequestFile("http://assets.drop.io/upload", stream, fileName, "file", args);
+            UploadResult result = SendRequestFile("https://assets.drop.io/upload", stream, fileName, "file", args);
 
             if (result.IsSuccess)
             {
                 Asset asset = ParseAsset(result.Response);
-                result.URL = string.Format("http://drop.io/{0}/asset/{1}", drop.Name, asset.Name);
+                result.URL = string.Format("https://drop.io/{0}/asset/{1}", drop.Name, asset.Name);
             }
 
             return result;
@@ -110,7 +110,7 @@ namespace ShareX.UploadersLib.FileUploaders
             // determines whether guests can delete assets
             args.Add("guests_can_delete", guests_can_delete.ToString());
 
-            string response = SendRequestMultiPart("http://api.drop.io/drops", args);
+            string response = SendRequestMultiPart("https://api.drop.io/drops", args);
 
             XDocument doc = XDocument.Parse(response);
             XElement root = doc.Element("drop");

--- a/ShareX.UploadersLib/FileUploaders/FileBin.cs
+++ b/ShareX.UploadersLib/FileUploaders/FileBin.cs
@@ -35,7 +35,7 @@ namespace ShareX.UploadersLib.FileUploaders
             Dictionary<string, string> args = new Dictionary<string, string>();
             args.Add("MAX_FILE_SIZE", "82428800");
 
-            UploadResult result = SendRequestFile("http://filebin.ca/upload.php", stream, fileName, "file", args);
+            UploadResult result = SendRequestFile("https://filebin.ca/upload.php", stream, fileName, "file", args);
 
             if (result.IsSuccess)
             {

--- a/ShareX.UploadersLib/FileUploaders/FileSonic.cs
+++ b/ShareX.UploadersLib/FileUploaders/FileSonic.cs
@@ -36,7 +36,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         public string Password { get; set; }
 
-        private const string APIURL = "http://api.filesonic.com/upload";
+        private const string APIURL = "https://api.filesonic.com/upload";
 
         public FileSonic(string username, string password)
         {

--- a/ShareX.UploadersLib/FileUploaders/Hostr.cs
+++ b/ShareX.UploadersLib/FileUploaders/Hostr.cs
@@ -83,7 +83,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     {
                         if (DirectURL && response.direct != null)
                         {
-                            result.URL = string.Format("http://hostr.co/file/{0}/{1}", response.id, response.name);
+                            result.URL = string.Format("https://hostr.co/file/{0}/{1}", response.id, response.name);
                             result.ThumbnailURL = response.direct.direct_150x;
                         }
                         else

--- a/ShareX.UploadersLib/FileUploaders/MediaFire.cs
+++ b/ShareX.UploadersLib/FileUploaders/MediaFire.cs
@@ -150,7 +150,7 @@ namespace ShareX.UploadersLib.FileUploaders
             {
                 if (resp.doupload.quickkey == null) throw new IOException("Invalid response");
 
-                string url = URLHelpers.CombineURL("http://www.mediafire.com/view", resp.doupload.quickkey);
+                string url = URLHelpers.CombineURL("https://www.mediafire.com/view", resp.doupload.quickkey);
                 if (UseLongLink) url = URLHelpers.CombineURL(url, URLHelpers.URLEncode(resp.doupload.filename));
                 return url;
             }

--- a/ShareX.UploadersLib/FileUploaders/SendSpace.cs
+++ b/ShareX.UploadersLib/FileUploaders/SendSpace.cs
@@ -66,7 +66,7 @@ namespace ShareX.UploadersLib.FileUploaders
     {
         private string APIKey;
 
-        private const string APIURL = "http://api.sendspace.com/rest/";
+        private const string APIURL = "https://api.sendspace.com/rest/";
         private const string APIVersion = "1.0";
 
         public AccountType AccountType { get; set; }
@@ -255,7 +255,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Creates a new user account. An activation/validation email will be sent automatically to the user.
-        /// http://www.sendspace.com/dev_method.html?method=auth.register
+        /// https://www.sendspace.com/dev_method.html?method=auth.register
         /// </summary>
         /// <param name="username">a-z/A-Z/0-9, 3-20 chars</param>
         /// <param name="fullname">a-z/A-Z/space, 3-20 chars</param>
@@ -284,7 +284,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Obtains a new and random token per session. Required for login.
-        /// http://www.sendspace.com/dev_method.html?method=auth.createToken
+        /// https://www.sendspace.com/dev_method.html?method=auth.createToken
         /// </summary>
         /// <returns>A token to be used with the auth.login method</returns>
         public string AuthCreateToken()
@@ -313,7 +313,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Starts a session and returns user API method capabilities -- which features the given user can and cannot use.
-        /// http://www.sendspace.com/dev_method.html?method=auth.login
+        /// https://www.sendspace.com/dev_method.html?method=auth.login
         /// </summary>
         /// <param name="token">Received on create token</param>
         /// <param name="username">Registered user name</param>
@@ -347,7 +347,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Checks if a session is valid or not.
-        /// http://www.sendspace.com/dev_method.html?method=auth.checksession
+        /// https://www.sendspace.com/dev_method.html?method=auth.checksession
         /// </summary>
         /// <param name="sessionKey">Received from auth.login</param>
         /// <returns>true = success, false = error</returns>
@@ -379,7 +379,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Logs out from a session.
-        /// http://www.sendspace.com/dev_method.html?method=auth.logout
+        /// https://www.sendspace.com/dev_method.html?method=auth.logout
         /// </summary>
         /// <param name="sessionKey">Received from auth.login</param>
         /// <returns>true = success, false = error</returns>
@@ -405,7 +405,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         /// <summary>
         /// Obtains the information needed to perform an upload.
-        /// http://www.sendspace.com/dev_method.html?method=upload.getInfo
+        /// https://www.sendspace.com/dev_method.html?method=upload.getInfo
         /// </summary>
         /// <param name="sessionKey">Received from auth.login</param>
         /// <returns>URL to upload the file to, progress_url for real-time progress information, max_file_size for max size current user can upload, upload_identifier & extra_info to be passed with the upload form</returns>
@@ -462,7 +462,7 @@ namespace ShareX.UploadersLib.FileUploaders
         }
 
         /// <summary>
-        /// http://www.sendspace.com/dev_method.html?method=upload.getInfo
+        /// https://www.sendspace.com/dev_method.html?method=upload.getInfo
         /// </summary>
         /// <param name="max_file_size">max_file_size value received in UploadGetInfo response</param>
         /// <param name="upload_identifier">upload_identifier value received in UploadGetInfo response</param>
@@ -514,7 +514,7 @@ namespace ShareX.UploadersLib.FileUploaders
                     if (result.Response.StartsWith("upload_status=ok")) // User
                     {
                         string fileid = Regex.Match(result.Response, @"file_id=(\w+)").Groups[1].Value;
-                        result.URL = "http://www.sendspace.com/file/" + fileid;
+                        result.URL = "https://www.sendspace.com/file/" + fileid;
                     }
                     else // Anonymous
                     {

--- a/ShareX.UploadersLib/FileUploaders/ShareCX.cs
+++ b/ShareX.UploadersLib/FileUploaders/ShareCX.cs
@@ -32,11 +32,11 @@ namespace ShareX.UploadersLib.FileUploaders
     {
         public override UploadResult Upload(Stream stream, string fileName)
         {
-            UploadResult result = SendRequestFile("http://file1.share.cx/cgi-bin/upload.cgi", stream, fileName, "file_0");
+            UploadResult result = SendRequestFile("https://file1.share.cx/cgi-bin/upload.cgi", stream, fileName, "file_0");
 
             if (result.IsSuccess)
             {
-                MatchCollection matches = Regex.Matches(result.Response, "(?<=value=\")http:.+?(?=\".*></td>)");
+                MatchCollection matches = Regex.Matches(result.Response, "(?<=value=\")https:.+?(?=\".*></td>)");
 
                 if (matches.Count == 2)
                 {

--- a/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
+++ b/ShareX.UploadersLib/Forms/UploadersConfigForm.cs
@@ -1098,7 +1098,7 @@ namespace ShareX.UploadersLib
 
         private void llVgymeAccountDetailsPage_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            URLHelpers.OpenURL("http://vgy.me/account/details");
+            URLHelpers.OpenURL("https://vgy.me/account/details");
         }
 
         #endregion vgy.me
@@ -1121,7 +1121,7 @@ namespace ShareX.UploadersLib
 
         private void btnPastebinRegister_Click(object sender, EventArgs e)
         {
-            URLHelpers.OpenURL("http://pastebin.com/signup");
+            URLHelpers.OpenURL("https://pastebin.com/signup");
         }
 
         private void btnPastebinLogin_Click(object sender, EventArgs e)

--- a/ShareX.UploadersLib/ImageUploaders/ImageBin.cs
+++ b/ShareX.UploadersLib/ImageUploaders/ImageBin.cs
@@ -42,14 +42,14 @@ namespace ShareX.UploadersLib.ImageUploaders
             arguments.Add("sfile", "Upload");
             arguments.Add("url", "");
 
-            UploadResult result = SendRequestFile("http://imagebin.ca/upload.php", stream, fileName, "f", arguments);
+            UploadResult result = SendRequestFile("https://imagebin.ca/upload.php", stream, fileName, "f", arguments);
 
             if (result.IsSuccess)
             {
                 Match match = Regex.Match(result.Response, @"(?<=ca/view/).+(?=\.html'>)");
                 if (match != null)
                 {
-                    string url = "http://imagebin.ca/img/" + match.Value + Path.GetExtension(fileName);
+                    string url = "https://imagebin.ca/img/" + match.Value + Path.GetExtension(fileName);
                     result.URL = url;
                 }
             }

--- a/ShareX.UploadersLib/ImageUploaders/ImageShackUploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/ImageShackUploader.cs
@@ -118,8 +118,8 @@ namespace ShareX.UploadersLib.ImageUploaders
                         if (uploadResult != null && uploadResult.images.Count > 0)
                         {
                             ImageShackImage image = uploadResult.images[0];
-                            result.URL = string.Format("http://imageshack.com/a/img{0}/{1}/{2}", image.server, image.bucket, image.filename);
-                            result.ThumbnailURL = string.Format("http://imagizer.imageshack.us/v2/{0}x{1}q90/{2}/{3}",
+                            result.URL = string.Format("https://imageshack.com/a/img{0}/{1}/{2}", image.server, image.bucket, image.filename);
+                            result.ThumbnailURL = string.Format("https://imagizer.imageshack.us/v2/{0}x{1}q90/{2}/{3}",
                                 Config.ThumbnailWidth, Config.ThumbnailHeight, image.server, image.filename);
                         }
                     }

--- a/ShareX.UploadersLib/ImageUploaders/Img1Uploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/Img1Uploader.cs
@@ -29,7 +29,7 @@ namespace ShareX.UploadersLib.ImageUploaders
 {
     public sealed class Img1Uploader : ImageUploader
     {
-        private const string uploadURL = "http://img1.us/?app";
+        private const string uploadURL = "https://img1.us/?app";
 
         public override UploadResult Upload(Stream stream, string fileName)
         {

--- a/ShareX.UploadersLib/ImageUploaders/ImmioUploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/ImmioUploader.cs
@@ -32,7 +32,7 @@ namespace ShareX.UploadersLib.ImageUploaders
     {
         public override UploadResult Upload(Stream stream, string fileName)
         {
-            UploadResult result = SendRequestFile("http://imm.io/store/", stream, fileName, "image");
+            UploadResult result = SendRequestFile("https://imm.io/store/", stream, fileName, "image");
             if (result.IsSuccess)
             {
                 ImmioResponse response = JsonConvert.DeserializeObject<ImmioResponse>(result.Response);

--- a/ShareX.UploadersLib/ImageUploaders/Photobucket.cs
+++ b/ShareX.UploadersLib/ImageUploaders/Photobucket.cs
@@ -55,9 +55,9 @@ namespace ShareX.UploadersLib.ImageUploaders
 
     public sealed class Photobucket : ImageUploader, IOAuth
     {
-        private const string URLRequestToken = "http://api.photobucket.com/login/request";
-        private const string URLAuthorize = "http://photobucket.com/apilogin/login";
-        private const string URLAccessToken = "http://api.photobucket.com/login/access";
+        private const string URLRequestToken = "https://api.photobucket.com/login/request";
+        private const string URLAuthorize = "https://photobucket.com/apilogin/login";
+        private const string URLAccessToken = "https://api.photobucket.com/login/access";
 
         public OAuthInfo AuthInfo { get; set; }
         public PhotobucketAccountInfo AccountInfo { get; set; }
@@ -120,7 +120,7 @@ namespace ShareX.UploadersLib.ImageUploaders
             args.Add("size", ""); // Size to resize an image to. (Images can only be made smaller.)
             */
 
-            string url = "http://api.photobucket.com/album/!/upload";
+            string url = "https://api.photobucket.com/album/!/upload";
             string query = OAuthManager.GenerateQuery(url, args, HttpMethod.POST, AuthInfo);
             query = FixURL(query);
 
@@ -147,7 +147,7 @@ namespace ShareX.UploadersLib.ImageUploaders
             args.Add("id", albumID); // Album identifier.
             args.Add("name", albumName); // Name of result. Must be between 2 and 50 characters. Valid characters are letters, numbers, underscore ( _ ), hyphen (-), and space.
 
-            string url = "http://api.photobucket.com/album/!";
+            string url = "https://api.photobucket.com/album/!";
             string query = OAuthManager.GenerateQuery(url, args, HttpMethod.POST, AuthInfo);
             query = FixURL(query);
 

--- a/ShareX.UploadersLib/ImageUploaders/TwitPicUploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/TwitPicUploader.cs
@@ -55,8 +55,8 @@ namespace ShareX.UploadersLib.ImageUploaders
         public bool ShowFull { get; set; }
         public TwitPicThumbnailType TwitPicThumbnailMode { get; set; }
 
-        private const string UploadLink = "http://api.twitpic.com/1/upload.json";
-        private const string UploadAndPostLink = "http://api.twitpic.com/1/uploadAndPost.json";
+        private const string UploadLink = "https://api.twitpic.com/1/upload.json";
+        private const string UploadAndPostLink = "https://api.twitpic.com/1/uploadAndPost.json";
 
         public TwitPicUploader(string key, OAuthInfo oauth)
         {
@@ -108,7 +108,7 @@ namespace ShareX.UploadersLib.ImageUploaders
             {
                 result.URL = response.URL;
                 if (ShowFull) result.URL += "/full";
-                result.ThumbnailURL = string.Format("http://twitpic.com/show/{0}/{1}.{2}", TwitPicThumbnailMode.ToString().ToLowerInvariant(), response.ID, response.Type);
+                result.ThumbnailURL = string.Format("https://twitpic.com/show/{0}/{1}.{2}", TwitPicThumbnailMode.ToString().ToLowerInvariant(), response.ID, response.Type);
             }
 
             return result;

--- a/ShareX.UploadersLib/ImageUploaders/TwitSnapsUploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/TwitSnapsUploader.cs
@@ -34,7 +34,7 @@ namespace ShareX.UploadersLib.ImageUploaders
     {
         public OAuthInfo AuthInfo { get; set; }
 
-        private const string APIURL = "http://twitsnaps.com/dev/image/upload.xml";
+        private const string APIURL = "https://twitsnaps.com/dev/image/upload.xml";
 
         private string APIKey;
 
@@ -83,8 +83,8 @@ namespace ShareX.UploadersLib.ImageUploaders
                 if (xe != null)
                 {
                     string id = xe.GetElementValue("id");
-                    result.URL = "http://twitsnaps.com/snap/" + id;
-                    result.ThumbnailURL = "http://twitsnaps.com/thumb/" + id;
+                    result.URL = "https://twitsnaps.com/snap/" + id;
+                    result.ThumbnailURL = "https://twitsnaps.com/thumb/" + id;
                 }
                 else
                 {

--- a/ShareX.UploadersLib/ImageUploaders/UploadScreenshot.cs
+++ b/ShareX.UploadersLib/ImageUploaders/UploadScreenshot.cs
@@ -46,7 +46,7 @@ namespace ShareX.UploadersLib.ImageUploaders
             arguments.Add("xmlOutput", "1");
             //arguments.Add("testMode", "1");
 
-            UploadResult result = SendRequestFile("http://img1.uploadscreenshot.com/api-upload.php", stream, fileName, "userfile", arguments);
+            UploadResult result = SendRequestFile("https://img1.uploadscreenshot.com/api-upload.php", stream, fileName, "userfile", arguments);
 
             return ParseResult(result);
         }

--- a/ShareX.UploadersLib/ImageUploaders/YfrogUploader.cs
+++ b/ShareX.UploadersLib/ImageUploaders/YfrogUploader.cs
@@ -69,8 +69,8 @@ namespace ShareX.UploadersLib.ImageUploaders
     {
         private YfrogOptions Options;
 
-        private const string UploadLink = "http://yfrog.com/api/upload";
-        private const string UploadAndPostLink = "http://yfrog.com/api/uploadAndPost";
+        private const string UploadLink = "https://yfrog.com/api/upload";
+        private const string UploadAndPostLink = "https://yfrog.com/api/uploadAndPost";
 
         public YfrogUploader(YfrogOptions options)
         {

--- a/ShareX.UploadersLib/SharingServices/PinterestSharingService.cs
+++ b/ShareX.UploadersLib/SharingServices/PinterestSharingService.cs
@@ -29,6 +29,6 @@ namespace ShareX.UploadersLib.SharingServices
     {
         public override URLSharingServices EnumValue { get; } = URLSharingServices.Pinterest;
 
-        protected override string URLFormatString { get; } = "http://pinterest.com/pin/create/button/?url={0}&media={0}";
+        protected override string URLFormatString { get; } = "https://pinterest.com/pin/create/button/?url={0}&media={0}";
     }
 }

--- a/ShareX.UploadersLib/SharingServices/RedditSharingService.cs
+++ b/ShareX.UploadersLib/SharingServices/RedditSharingService.cs
@@ -29,6 +29,6 @@ namespace ShareX.UploadersLib.SharingServices
     {
         public override URLSharingServices EnumValue { get; } = URLSharingServices.Reddit;
 
-        protected override string URLFormatString { get; } = "http://www.reddit.com/submit?url={0}";
+        protected override string URLFormatString { get; } = "https://www.reddit.com/submit?url={0}";
     }
 }

--- a/ShareX.UploadersLib/SharingServices/StumbleUponSharingService.cs
+++ b/ShareX.UploadersLib/SharingServices/StumbleUponSharingService.cs
@@ -29,6 +29,6 @@ namespace ShareX.UploadersLib.SharingServices
     {
         public override URLSharingServices EnumValue { get; } = URLSharingServices.StumbleUpon;
 
-        protected override string URLFormatString { get; } = "http://www.stumbleupon.com/submit?url={0}";
+        protected override string URLFormatString { get; } = "https://www.stumbleupon.com/submit?url={0}";
     }
 }

--- a/ShareX.UploadersLib/SharingServices/VkSharingService.cs
+++ b/ShareX.UploadersLib/SharingServices/VkSharingService.cs
@@ -29,6 +29,6 @@ namespace ShareX.UploadersLib.SharingServices
     {
         public override URLSharingServices EnumValue { get; } = URLSharingServices.VK;
 
-        protected override string URLFormatString { get; } = "http://vk.com/share.php?url={0}";
+        protected override string URLFormatString { get; } = "https://vk.com/share.php?url={0}";
     }
 }

--- a/ShareX.UploadersLib/TextUploaders/Pastebin_ca.cs
+++ b/ShareX.UploadersLib/TextUploaders/Pastebin_ca.cs
@@ -30,7 +30,7 @@ namespace ShareX.UploadersLib.TextUploaders
 {
     public sealed class Pastebin_ca : TextUploader
     {
-        private const string APIURL = "http://pastebin.ca/quiet-paste.php";
+        private const string APIURL = "https://pastebin.ca/quiet-paste.php";
 
         private string APIKey;
 
@@ -77,7 +77,7 @@ namespace ShareX.UploadersLib.TextUploaders
                 {
                     if (ur.Response.StartsWith("SUCCESS:"))
                     {
-                        ur.URL = "http://pastebin.ca/" + ur.Response.Substring(8);
+                        ur.URL = "https://pastebin.ca/" + ur.Response.Substring(8);
                     }
                     else if (ur.Response.StartsWith("FAIL:"))
                     {

--- a/ShareX.UploadersLib/TextUploaders/Pastie.cs
+++ b/ShareX.UploadersLib/TextUploaders/Pastie.cs
@@ -64,7 +64,7 @@ namespace ShareX.UploadersLib.TextUploaders
                 arguments.Add("paste[restricted]", IsPublic ? "0" : "1");
                 arguments.Add("paste[authorization]", "burger");
 
-                SendRequestURLEncoded(HttpMethod.POST, "http://pastie.org/pastes", arguments);
+                SendRequestURLEncoded(HttpMethod.POST, "https://pastie.org/pastes", arguments);
                 ur.URL = LastResponseInfo.ResponseURL;
             }
 

--- a/ShareX.UploadersLib/TextUploaders/Slexy.cs
+++ b/ShareX.UploadersLib/TextUploaders/Slexy.cs
@@ -47,7 +47,7 @@ namespace ShareX.UploadersLib.TextUploaders
 
     public sealed class Slexy : TextUploader
     {
-        private const string APIURL = "http://slexy.org/index.php/submit";
+        private const string APIURL = "https://slexy.org/index.php/submit";
 
         private SlexySettings settings;
 

--- a/ShareX.UploadersLib/TextUploaders/Upaste.cs
+++ b/ShareX.UploadersLib/TextUploaders/Upaste.cs
@@ -53,7 +53,7 @@ namespace ShareX.UploadersLib.TextUploaders
 
     public sealed class Upaste : TextUploader
     {
-        private const string APIURL = "http://upaste.me/api";
+        private const string APIURL = "https://upaste.me/api";
 
         public string UserKey { get; private set; }
         public bool IsPublic { get; set; }

--- a/ShareX.UploadersLib/URLShorteners/AdFlyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/AdFlyURLShortener.cs
@@ -69,7 +69,7 @@ namespace ShareX.UploadersLib.URLShorteners
             args.Add("domain", "adf.ly");
             args.Add("url", url);
 
-            string response = SendRequest(HttpMethod.GET, "http://api.adf.ly/api.php", args);
+            string response = SendRequest(HttpMethod.GET, "https://api.adf.ly/api.php", args);
 
             if (!string.IsNullOrEmpty(response) && response != "error")
             {

--- a/ShareX.UploadersLib/URLShorteners/IsgdURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/IsgdURLShortener.cs
@@ -42,7 +42,7 @@ namespace ShareX.UploadersLib.URLShorteners
 
     public class IsgdURLShortener : URLShortener
     {
-        protected virtual string APIURL { get { return "http://is.gd/create.php"; } }
+        protected virtual string APIURL { get { return "https://is.gd/create.php"; } }
 
         public override UploadResult ShortenURL(string url)
         {

--- a/ShareX.UploadersLib/URLShorteners/NlcmURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/NlcmURLShortener.cs
@@ -38,7 +38,7 @@ namespace ShareX.UploadersLib.URLShorteners
                 Dictionary<string, string> arguments = new Dictionary<string, string>();
                 arguments.Add("url", url);
 
-                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "http://nl.cm/api/", arguments);
+                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "https://nl.cm/api/", arguments);
             }
 
             return result;

--- a/ShareX.UploadersLib/URLShorteners/QRnetURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/QRnetURLShortener.cs
@@ -42,7 +42,7 @@ namespace ShareX.UploadersLib.URLShorteners
 
     public sealed class QRnetURLShortener : URLShortener
     {
-        private const string API_ENDPOINT = "http://qr.net/api/short";
+        private const string API_ENDPOINT = "https://qr.net/api/short";
 
         public override UploadResult ShortenURL(string url)
         {

--- a/ShareX.UploadersLib/URLShorteners/TinyURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/TinyURLShortener.cs
@@ -50,7 +50,7 @@ namespace ShareX.UploadersLib.URLShorteners
                 Dictionary<string, string> arguments = new Dictionary<string, string>();
                 arguments.Add("url", url);
 
-                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "http://tinyurl.com/api-create.php", arguments);
+                result.Response = result.ShortenedURL = SendRequest(HttpMethod.GET, "https://tinyurl.com/api-create.php", arguments);
             }
 
             return result;

--- a/ShareX.UploadersLib/URLShorteners/TurlURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/TurlURLShortener.cs
@@ -50,13 +50,13 @@ namespace ShareX.UploadersLib.URLShorteners
                 Dictionary<string, string> arguments = new Dictionary<string, string>();
                 arguments.Add("url", url);
 
-                result.Response = SendRequest(HttpMethod.GET, "http://turl.ca/api.php", arguments);
+                result.Response = SendRequest(HttpMethod.GET, "https://turl.ca/api.php", arguments);
 
                 if (!string.IsNullOrEmpty(result.Response))
                 {
                     if (result.Response.StartsWith("SUCCESS:"))
                     {
-                        result.ShortenedURL = "http://turl.ca/" + result.Response.Substring(8);
+                        result.ShortenedURL = "https://turl.ca/" + result.Response.Substring(8);
                     }
 
                     if (result.Response.StartsWith("ERROR:"))

--- a/ShareX.UploadersLib/URLShorteners/TwoGPURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/TwoGPURLShortener.cs
@@ -42,7 +42,7 @@ namespace ShareX.UploadersLib.URLShorteners
 
     public sealed class TwoGPURLShortener : URLShortener
     {
-        private const string API_ENDPOINT = "http://2.gp/api/short";
+        private const string API_ENDPOINT = "https://2.gp/api/short";
 
         public override UploadResult ShortenURL(string url)
         {

--- a/ShareX.UploadersLib/URLShorteners/VURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/VURLShortener.cs
@@ -41,7 +41,7 @@ namespace ShareX.UploadersLib.URLShorteners
 
     public sealed class VURLShortener : URLShortener
     {
-        private const string API_ENDPOINT = "http://vurl.com/api.php";
+        private const string API_ENDPOINT = "https://vurl.com/api.php";
 
         public override UploadResult ShortenURL(string url)
         {

--- a/ShareX.UploadersLib/URLShorteners/VgdURLShortener.cs
+++ b/ShareX.UploadersLib/URLShorteners/VgdURLShortener.cs
@@ -39,6 +39,6 @@ namespace ShareX.UploadersLib.URLShorteners
 
     public class VgdURLShortener : IsgdURLShortener
     {
-        protected override string APIURL { get { return "http://v.gd/create.php"; } }
+        protected override string APIURL { get { return "https://v.gd/create.php"; } }
     }
 }

--- a/ShareX.UploadersLib/UploadersConfig.cs
+++ b/ShareX.UploadersLib/UploadersConfig.cs
@@ -253,7 +253,7 @@ namespace ShareX.UploadersLib
 
         #region Jira
 
-        public string JiraHost { get; set; } = "http://";
+        public string JiraHost { get; set; } = "https://";
         public string JiraIssuePrefix { get; set; } = "PROJECT-";
         public OAuthInfo JiraOAuthInfo { get; set; } = null;
 
@@ -431,7 +431,7 @@ namespace ShareX.UploadersLib
 
         #region yourls.org
 
-        public string YourlsAPIURL { get; set; } = "http://yoursite.com/yourls-api.php";
+        public string YourlsAPIURL { get; set; } = "https://yoursite.com/yourls-api.php";
         [JsonEncrypt]
         public string YourlsSignature { get; set; } = "";
         public string YourlsUsername { get; set; } = "";


### PR DESCRIPTION
All API endpoints have transitioned from HTTP to HTTPS. This change is implemented to ensure the encryption of data in transit, thereby improving the overall security posture of ShareX.

Many services may redirect to https, but this is only an assumption. This change generally relies on secure data transmission.