### PR TITLE
Choosable FTP Account List (Before Upload)

### DIFF
--- a/ShareX/Forms/AfterCaptureForm.cs
+++ b/ShareX/Forms/AfterCaptureForm.cs
@@ -50,7 +50,7 @@ namespace ShareX
             lvAfterCaptureTasks.SmallImageList = imageList;
             lvAfterUploadTasks.SmallImageList = imageList;
 
-            ucBeforeUpload.InitCapture(TaskSettings);
+            ucBeforeUpload.InitCapture(TaskSettings, EDataType.Image);
 
             AddAfterCaptureItems(TaskSettings.AfterCaptureJob);
             AddAfterUploadItems(TaskSettings.AfterUploadJob);

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -431,6 +431,12 @@ namespace ShareX
 
                 if (!cancelUpload)
                 {
+                    if (Info.TaskSettings.OverrideFTP)
+                    {
+                        taskReferenceHelper.OverrideFTP = true;
+                        taskReferenceHelper.FTPIndex = Info.TaskSettings.FTPIndex;
+                    }
+
                     OnUploadStarted();
 
                     bool isError = DoUpload(Data, Info.FileName);


### PR DESCRIPTION
So I gave ShareX a shot yesterday and was grateful it gave me a one-click solution to upload all kinds of files to FTP.
Unfortunately I was missing the Option to select an FTP Account in the 'before upload' window, so I added it. :)
![image](https://github.com/ShareX/ShareX/assets/7689370/93101395-ec0f-464b-83f3-8039f00b8ad5)

It selects the FTP Account you selected for the current filetype by default.
It 'abuses' the `TaskSettings.OverrideFTP` setting but allowed for very few lines of code required for implementation.
Also this mechanic could be made toggleable with a new `TaskSetting` but I'd assume most people prefer this by default over having only one FTP option and an hidden `OverrideFTP` setting.
I started with creating `RadioButton`s per Account but migrated to a ComboBox for scalability, I tried putting it next to the `RadioButton` but it messed with the `FlowLayoutPanel `and/or `RadioButton` Grouping.

I've seen a few people wish for a feature like this so I thought I'd Share.
_Originally posted by @bartico6 in https://github.com/ShareX/ShareX/issues/3992#issuecomment-519340569_
> Bump, this would be great for SFTP/FTP uploads too - where I'd like to upload certain files to one FTP profile, and others to another profile - this is currently not possible in a generic way w/o tricking ShareX with the "text goes to X, images go to Y" setting. 
Ideally, the user (if there are multiple profiles for the upload destination) is prompted which profile should be used - or each profile has an optional selection of files it accepts.
A workaround is to use workloads, yeah, but this could be simpler IMO.