### PR TITLE
Fix toast notification settings not being respected in OCR

### DIFF
--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -1312,7 +1312,7 @@ namespace ShareX
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
-            bool notificationsEnabled = taskSettings.GeneralSettings.ShowToastNotificationAfterTaskComplete;
+            bool notificationsEnabled = taskSettings.GeneralSettings.ShowToastNotificationAfterTaskCompleted;
             await OCRImage(bmp, taskSettings.CaptureSettingsReference.OCROptions, filePath, notificationsEnabled);
         }
 

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -1312,10 +1312,11 @@ namespace ShareX
         {
             if (taskSettings == null) taskSettings = TaskSettings.GetDefaultTaskSettings();
 
-            await OCRImage(bmp, taskSettings.CaptureSettingsReference.OCROptions, filePath);
+            bool notificationsEnabled = taskSettings.GeneralSettings.ShowToastNotificationAfterTaskComplete;
+            await OCRImage(bmp, taskSettings.CaptureSettingsReference.OCROptions, filePath, notificationsEnabled);
         }
 
-        private static async Task OCRImage(Bitmap bmp, OCROptions options, string filePath = null)
+        private static async Task OCRImage(Bitmap bmp, OCROptions options, string filePath = null, bool notificationsEnabled = true)
         {
             try
             {
@@ -1325,7 +1326,7 @@ namespace ShareX
                 {
                     if (options.Silent)
                     {
-                        await AsyncOCRImage(bmp, options, filePath);
+                        await AsyncOCRImage(bmp, options, filePath, notificationsEnabled);
                     }
                     else
                     {
@@ -1348,9 +1349,9 @@ namespace ShareX
             }
         }
 
-        private static async Task AsyncOCRImage(Bitmap bmp, OCROptions options, string filePath = null)
+        private static async Task AsyncOCRImage(Bitmap bmp, OCROptions options, string filePath = null, bool notificationsEnabled = true)
         {
-            ShowNotificationTip(Resources.OCRForm_AutoProcessing);
+            if (notificationsEnabled) ShowNotificationTip(Resources.OCRForm_AutoProcessing);
 
             string result = null;
 
@@ -1372,11 +1373,11 @@ namespace ShareX
                     File.WriteAllText(textFilePath, result, Encoding.UTF8);
                 }
 
-                ShowNotificationTip(Resources.OCRForm_AutoComplete);
+                if (notificationsEnabled) ShowNotificationTip(Resources.OCRForm_AutoComplete);
             }
             else
             {
-                ShowNotificationTip(Resources.OCRForm_AutoCompleteFail);
+                if (notificationsEnabled) ShowNotificationTip(Resources.OCRForm_AutoCompleteFail);
             }
         }
 


### PR DESCRIPTION
This should fix https://github.com/ShareX/ShareX/issues/7073

I wasn't sure if there was a code style to adhere to w.r.t. if statements being in a single line. I saw it done in certain places so I just followed that. I also admit to not testing this but the change set seemed simple enough. I edited this file using GitHub's editor (sorry) so it looks like it added an extraneous newline to the end of the file.