### PR TITLE
MainWindowFont Option for Themes

### DIFF
--- a/ShareX.HelpersLib/ShareXTheme.cs
+++ b/ShareX.HelpersLib/ShareXTheme.cs
@@ -81,6 +81,8 @@ namespace ShareX.HelpersLib
 
         private Color textColor;
 
+        public Font MainWindowFont { get; set; } = new Font("Segoe UI", 9.75f);
+
         [Editor(typeof(MyColorEditor), typeof(UITypeEditor)), TypeConverter(typeof(MyColorConverter))]
         public Color TextColor
         {

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -797,6 +797,7 @@ namespace ShareX
                 ShareXResources.ApplyCustomThemeToContextMenuStrip(cmsTaskInfo);
                 ttMain.BackColor = ShareXResources.Theme.BackgroundColor;
                 ttMain.ForeColor = ShareXResources.Theme.TextColor;
+                lvUploads.Font = ShareXResources.Theme.MainWindowFont;
                 lvUploads.BackColor = ShareXResources.Theme.BackgroundColor;
                 lvUploads.ForeColor = ShareXResources.Theme.TextColor;
                 scMain.SplitterColor = ShareXResources.Theme.BackgroundColor;


### PR DESCRIPTION
## New Setting Option for Custom Themes: `MainWindowFont`

Hey, as I was changing my theme settings and increased the font size of the Menu and ContextMenu, I discovered that the Tasks in the Task List in the MainWindow were unaffected by that.

It doesn't really look good, if everything is bigger but the tasks remains so small, so I've decided to add a new setting to solve that problem.

<table>
<tr>
 <td><b>Before</b>
 <td><b>After</b>
<tr>
 <td><img src="https://github.com/ShareX/ShareX/assets/18190639/06956a82-6f1d-4f15-9ed5-0f7671bf1da2"></td>
 <td><img src="https://github.com/ShareX/ShareX/assets/18190639/a5a5778b-dfe8-440a-abfb-754c9ad2ac00"></td>
</table>

I was a bit unsure about how to name the option and if other windows should have some changes as well, but I'm pretty happy with this. Let me know what you think! ❤️ 




