### PR TITLE
Added MainWindowFont Theme Font Option

### DIFF
--- a/ShareX.HelpersLib/ShareXTheme.cs
+++ b/ShareX.HelpersLib/ShareXTheme.cs
@@ -81,6 +81,8 @@ namespace ShareX.HelpersLib
 
         private Color textColor;
 
+        public Font MainWindowFont { get; set; } = new Font("Segoe UI", 9.75f);
+
         [Editor(typeof(MyColorEditor), typeof(UITypeEditor)), TypeConverter(typeof(MyColorConverter))]
         public Color TextColor
         {

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -797,6 +797,7 @@ namespace ShareX
                 ShareXResources.ApplyCustomThemeToContextMenuStrip(cmsTaskInfo);
                 ttMain.BackColor = ShareXResources.Theme.BackgroundColor;
                 ttMain.ForeColor = ShareXResources.Theme.TextColor;
+                lvUploads.Font = ShareXResources.Theme.MainWindowFont;
                 lvUploads.BackColor = ShareXResources.Theme.BackgroundColor;
                 lvUploads.ForeColor = ShareXResources.Theme.TextColor;
                 scMain.SplitterColor = ShareXResources.Theme.BackgroundColor;


### PR DESCRIPTION
## New Setting Option for Custom Themes: `MainWindowFont`

Hey, as I was changing my theme settings and increased the font size of the Menu and ContextMenu, I discovered that the Tasks in the Task List in the MainWindow were unaffected by that.

It doesn't really look good, if everything is bigger but the tasks remain so small, so I've decided to add a new setting to solve that problem.

<table>
<tr>
 <td><b>Before</b>
 <td><b>After</b>
<tr>
 <td><img src="https://github.com/ShareX/ShareX/assets/18190639/31cf1760-34f8-427d-9897-9d2f47c8dad5"></td>
 <td><img src="https://github.com/ShareX/ShareX/assets/18190639/4f8589f4-8c48-44de-9c94-d63e104785cc"></td>
</table>

I was a bit unsure about how to name the option and if other windows should have some changes as well, but I'm pretty happy with this. Let me know what you think! ❤️ 




