### PR TITLE
Added a way to finally change the proportional fixed aspect ratio size

### DIFF
--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1928,6 +1928,15 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fixed Aspect Ratio (width:height).
+        /// </summary>
+        internal static string ShapeManager_CreateToolbar_FixedAspectRatio {
+            get {
+                return ResourceManager.GetString("ShapeManager_CreateToolbar_FixedAspectRatio", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Flip horizontal.
         /// </summary>
         internal static string ShapeManager_CreateToolbar_FlipHorizontal {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -833,4 +833,7 @@ Would you like to save the changes before closing the image editor?</value>
   <data name="CutOutBackgroundColor" xml:space="preserve">
     <value>Cut out background color...</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_FixedAspectRatio" xml:space="preserve">
+    <value>Fixed Aspect Ratio (width:height)</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
+++ b/ShareX.ScreenCaptureLib/RegionCaptureOptions.cs
@@ -40,7 +40,7 @@ namespace ShareX.ScreenCaptureLib
         public const int SnapDistance = 30;
         public const int MoveSpeedMinimum = 1;
         public const int MoveSpeedMaximum = 10;
-
+        public Size AspectRatio = new Size(1,1); // Initially set to square or 1:1 fixed aspect ratio.
         public bool QuickCrop = true;
         public int MinimumSize = DefaultMinimumSize;
         public RegionCaptureAction RegionCaptureActionRightClick = RegionCaptureAction.RemoveShapeCancelCapture;

--- a/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/BaseShape.cs
@@ -279,20 +279,19 @@ namespace ShareX.ScreenCaptureLib
 
                 if (Manager.IsProportionalResizing || ForceProportionalResizing)
                 {
-                    float degree, startDegree;
+                    float aspectRatio = (float)Manager.Options.AspectRatio.Width / (float)Manager.Options.AspectRatio.Height;
 
-                    if (ShapeType == ShapeType.DrawingLine || ShapeType == ShapeType.DrawingArrow)
+                    float width = Math.Abs(pos.X - StartPosition.X);
+                    float height = Math.Abs(pos.Y - StartPosition.Y);
+
+                    if (width / height > aspectRatio)
                     {
-                        degree = 45;
-                        startDegree = 0;
+                        pos.X = StartPosition.X + (height * aspectRatio) * Math.Sign(pos.X - StartPosition.X);
                     }
                     else
                     {
-                        degree = 90;
-                        startDegree = 45;
+                        pos.Y = StartPosition.Y + (width / aspectRatio) * Math.Sign(pos.Y - StartPosition.Y);
                     }
-
-                    pos = CaptureHelpers.SnapPositionToDegree(StartPosition, pos, degree, startDegree).Round();
                 }
                 else if (Manager.IsSnapResizing)
                 {

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -1033,6 +1033,8 @@ namespace ShareX.ScreenCaptureLib
                 tsddbOptions.DropDownItems.Add(tslnudFixedSize);
             }
 
+
+
             ToolStripMenuItem tsmiShowFPS = new ToolStripMenuItem(Resources.ShapeManager_CreateContextMenu_Show_FPS);
             tsmiShowFPS.Checked = Options.ShowFPS;
             tsmiShowFPS.CheckOnClick = true;
@@ -1113,6 +1115,19 @@ namespace ShareX.ScreenCaptureLib
                 };
                 tsddbOptions.DropDownItems.Add(tsmiRememberMenuState);
             }
+
+            ToolStripLabel lblAspectRatio = new ToolStripLabel(Resources.ShapeManager_CreateToolbar_FixedAspectRatio);
+            tsddbOptions.DropDownItems.Add(lblAspectRatio);
+            ToolStripDoubleLabeledNumericUpDown tslnudAspectRatio = new ToolStripDoubleLabeledNumericUpDown(Resources.ShapeManager_CreateContextMenu_Width_,
+                   Resources.ShapeManager_CreateContextMenu_Height_);
+            tslnudAspectRatio.Content.Minimum = 1;
+            tslnudAspectRatio.Content.Maximum = 50;
+            tslnudAspectRatio.Content.Increment = 1;
+            tslnudAspectRatio.Content.Value = Options.AspectRatio.Width;
+            tslnudAspectRatio.Content.Value2 = Options.AspectRatio.Height;
+            tslnudAspectRatio.Content.ValueChanged = (sender, e) => Options.AspectRatio = new Size((int)tslnudAspectRatio.Content.Value, (int)tslnudAspectRatio.Content.Value2);
+
+            tsddbOptions.DropDownItems.Add(tslnudAspectRatio);
 
             tsddbOptions.DropDownItems.Add(new ToolStripSeparator());
 


### PR DESCRIPTION
Added a way to finally change the proportional fixed aspect ratio size from 1:1 to a custom value. Previously people could only draw a square region using shift, now they can more easily select 4:3 and 16:9 images. A long awaited feature that went stale several times.