### PR TITLE
Add wasd and `delete` keyboard controls for PinToScreenForm

### DIFF
--- a/ShareX/Tools/PinToScreen/PinToScreenForm.cs
+++ b/ShareX/Tools/PinToScreen/PinToScreenForm.cs
@@ -535,9 +535,33 @@ namespace ShareX
         {
             switch (e.KeyData)
             {
+                case Keys.W:
+                case Keys.Up:
+                    Location = new Point(Location.X, Location.Y - 1);
+                    Update();
+                    break;
+                case Keys.A:
+                case Keys.Left:
+                    Location = new Point(Location.X - 1, Location.Y);
+                    Update();
+                    break;
+                case Keys.S:
+                case Keys.Down:
+                    Location = new Point(Location.X, Location.Y + 1);
+                    Update();
+                    break;
+                case Keys.D:
+                case Keys.Right:
+                    Location = new Point(Location.X + 1, Location.Y);
+                    Update();
+                    break;
                 case Keys.Control | Keys.C:
                     ClipboardHelpers.CopyImage(Image);
                     break;
+                case Keys.R: // Remove
+                case Keys.Delete:
+                    Close();
+                    return;
             }
 
             if (!Minimized)


### PR DESCRIPTION
Add the ability to precisely control the position of the image by pressing arrow keys or wasd keys, and the ability to delete the pinned image by pressing delete or r.

As someone that likes to align my pinned images, I see this as a useful feature. the delete key is for images being too small that the toolbar cannot display.