### PR TITLE
Update to .NET 8

### DIFF
--- a/ShareX.HelpersLib/Cryptographic/HashChecker.cs
+++ b/ShareX.HelpersLib/Cryptographic/HashChecker.cs
@@ -132,15 +132,15 @@ namespace ShareX.HelpersLib
                 case HashType.CRC32:
                     return new Crc32();
                 case HashType.MD5:
-                    return new MD5CryptoServiceProvider();
+                    return MD5.Create();
                 case HashType.SHA1:
-                    return new SHA1CryptoServiceProvider();
+                    return SHA1.Create();
                 case HashType.SHA256:
-                    return new SHA256CryptoServiceProvider();
+                    return SHA256.Create();
                 case HashType.SHA384:
-                    return new SHA384CryptoServiceProvider();
+                    return SHA384.Create();
                 case HashType.SHA512:
-                    return new SHA512CryptoServiceProvider();
+                    return SHA512.Create();
             }
 
             return null;

--- a/ShareX.HelpersLib/FastDateTime.cs
+++ b/ShareX.HelpersLib/FastDateTime.cs
@@ -49,7 +49,7 @@ namespace ShareX.HelpersLib
 
         static FastDateTime()
         {
-            LocalUtcOffset = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now);
+            LocalUtcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
         }
 
         public static DateTime ToLocalTime(DateTime dateTime)

--- a/ShareX.HelpersLib/FileDownloader.cs
+++ b/ShareX.HelpersLib/FileDownloader.cs
@@ -166,11 +166,11 @@ namespace ShareX.HelpersLib
                     }
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 if (!IsCanceled)
                 {
-                    throw e;
+                    throw;
                 }
             }
             finally

--- a/ShareX.HelpersLib/Forms/MonitorTestForm.resx
+++ b/ShareX.HelpersLib/Forms/MonitorTestForm.resx
@@ -468,18 +468,6 @@
   <data name="btnScreenTearingTest.Text" xml:space="preserve">
     <value>Start test animation</value>
   </data>
-  <data name="&gt;&gt;btnScreenTearingTest.Name" xml:space="preserve">
-    <value>btnScreenTearingTest</value>
-  </data>
-  <data name="&gt;&gt;btnScreenTearingTest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnScreenTearingTest.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;btnScreenTearingTest.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnGradientColor2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -498,18 +486,6 @@
   <data name="btnGradientColor2.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
-  <data name="&gt;&gt;btnGradientColor2.Name" xml:space="preserve">
-    <value>btnGradientColor2</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor2.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ColorButton, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor2.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="btnGradientColor1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -527,18 +503,6 @@
   </data>
   <data name="btnGradientColor1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor1.Name" xml:space="preserve">
-    <value>btnGradientColor1</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor1.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.ColorButton, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor1.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;btnGradientColor1.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="lblTip.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 9.75pt</value>
@@ -561,18 +525,6 @@
   <data name="lblTip.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>
   </data>
-  <data name="&gt;&gt;lblTip.Name" xml:space="preserve">
-    <value>lblTip</value>
-  </data>
-  <data name="&gt;&gt;lblTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTip.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblTip.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="cbGradient.Location" type="System.Drawing.Point, System.Drawing">
     <value>120, 223</value>
   </data>
@@ -581,18 +533,6 @@
   </data>
   <data name="cbGradient.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
-  </data>
-  <data name="&gt;&gt;cbGradient.Name" xml:space="preserve">
-    <value>cbGradient</value>
-  </data>
-  <data name="&gt;&gt;cbGradient.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbGradient.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;cbGradient.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="rbGradient.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -612,18 +552,6 @@
   <data name="rbGradient.Text" xml:space="preserve">
     <value>Gradient:</value>
   </data>
-  <data name="&gt;&gt;rbGradient.Name" xml:space="preserve">
-    <value>rbGradient</value>
-  </data>
-  <data name="&gt;&gt;rbGradient.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbGradient.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;rbGradient.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="btnClose.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -638,18 +566,6 @@
   </data>
   <data name="btnClose.Text" xml:space="preserve">
     <value>Close</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Name" xml:space="preserve">
-    <value>btnClose</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;btnClose.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="lblShapeSize.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -668,18 +584,6 @@
   </data>
   <data name="lblShapeSize.Text" xml:space="preserve">
     <value>Size:</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSize.Name" xml:space="preserve">
-    <value>lblShapeSize</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSize.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSize.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="lblShapeSizeValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -702,18 +606,6 @@
   <data name="lblShapeSizeValue.Text" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;lblShapeSizeValue.Name" xml:space="preserve">
-    <value>lblShapeSizeValue</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSizeValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSizeValue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblShapeSizeValue.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="tbShapeSize.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -729,18 +621,6 @@
   <data name="tbShapeSize.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
   </data>
-  <data name="&gt;&gt;tbShapeSize.Name" xml:space="preserve">
-    <value>tbShapeSize</value>
-  </data>
-  <data name="&gt;&gt;tbShapeSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbShapeSize.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;tbShapeSize.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="btnColorDialog.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -755,18 +635,6 @@
   </data>
   <data name="btnColorDialog.Text" xml:space="preserve">
     <value>Color dialog...</value>
-  </data>
-  <data name="&gt;&gt;btnColorDialog.Name" xml:space="preserve">
-    <value>btnColorDialog</value>
-  </data>
-  <data name="&gt;&gt;btnColorDialog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnColorDialog.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;btnColorDialog.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="cbShapes.Items" xml:space="preserve">
     <value>Horizontal lines</value>
@@ -786,18 +654,6 @@
   <data name="cbShapes.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
-  <data name="&gt;&gt;cbShapes.Name" xml:space="preserve">
-    <value>cbShapes</value>
-  </data>
-  <data name="&gt;&gt;cbShapes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbShapes.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;cbShapes.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="rbShapes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -816,18 +672,6 @@
   <data name="rbShapes.Text" xml:space="preserve">
     <value>Shape:</value>
   </data>
-  <data name="&gt;&gt;rbShapes.Name" xml:space="preserve">
-    <value>rbShapes</value>
-  </data>
-  <data name="&gt;&gt;rbShapes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbShapes.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;rbShapes.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="lblBlue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -845,18 +689,6 @@
   </data>
   <data name="lblBlue.Text" xml:space="preserve">
     <value>B:</value>
-  </data>
-  <data name="&gt;&gt;lblBlue.Name" xml:space="preserve">
-    <value>lblBlue</value>
-  </data>
-  <data name="&gt;&gt;lblBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBlue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblBlue.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
   <data name="lblBlueValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -879,18 +711,6 @@
   <data name="lblBlueValue.Text" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lblBlueValue.Name" xml:space="preserve">
-    <value>lblBlueValue</value>
-  </data>
-  <data name="&gt;&gt;lblBlueValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBlueValue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblBlueValue.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="tbBlue.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -905,18 +725,6 @@
   </data>
   <data name="tbBlue.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
-  </data>
-  <data name="&gt;&gt;tbBlue.Name" xml:space="preserve">
-    <value>tbBlue</value>
-  </data>
-  <data name="&gt;&gt;tbBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbBlue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;tbBlue.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="lblGreen.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -935,18 +743,6 @@
   </data>
   <data name="lblGreen.Text" xml:space="preserve">
     <value>G:</value>
-  </data>
-  <data name="&gt;&gt;lblGreen.Name" xml:space="preserve">
-    <value>lblGreen</value>
-  </data>
-  <data name="&gt;&gt;lblGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGreen.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblGreen.ZOrder" xml:space="preserve">
-    <value>16</value>
   </data>
   <data name="lblGreenValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -969,18 +765,6 @@
   <data name="lblGreenValue.Text" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lblGreenValue.Name" xml:space="preserve">
-    <value>lblGreenValue</value>
-  </data>
-  <data name="&gt;&gt;lblGreenValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGreenValue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblGreenValue.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
   <data name="tbGreen.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -995,18 +779,6 @@
   </data>
   <data name="tbGreen.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
-  </data>
-  <data name="&gt;&gt;tbGreen.Name" xml:space="preserve">
-    <value>tbGreen</value>
-  </data>
-  <data name="&gt;&gt;tbGreen.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbGreen.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;tbGreen.ZOrder" xml:space="preserve">
-    <value>18</value>
   </data>
   <data name="lblRed.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1025,18 +797,6 @@
   </data>
   <data name="lblRed.Text" xml:space="preserve">
     <value>R:</value>
-  </data>
-  <data name="&gt;&gt;lblRed.Name" xml:space="preserve">
-    <value>lblRed</value>
-  </data>
-  <data name="&gt;&gt;lblRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRed.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblRed.ZOrder" xml:space="preserve">
-    <value>19</value>
   </data>
   <data name="lblRedValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1059,18 +819,6 @@
   <data name="lblRedValue.Text" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lblRedValue.Name" xml:space="preserve">
-    <value>lblRedValue</value>
-  </data>
-  <data name="&gt;&gt;lblRedValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRedValue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblRedValue.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
   <data name="tbRed.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1085,18 +833,6 @@
   </data>
   <data name="tbRed.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;tbRed.Name" xml:space="preserve">
-    <value>tbRed</value>
-  </data>
-  <data name="&gt;&gt;tbRed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbRed.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;tbRed.ZOrder" xml:space="preserve">
-    <value>21</value>
   </data>
   <data name="rbRedGreenBlue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1115,18 +851,6 @@
   </data>
   <data name="rbRedGreenBlue.Text" xml:space="preserve">
     <value>Red, Green, Blue:</value>
-  </data>
-  <data name="&gt;&gt;rbRedGreenBlue.Name" xml:space="preserve">
-    <value>rbRedGreenBlue</value>
-  </data>
-  <data name="&gt;&gt;rbRedGreenBlue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbRedGreenBlue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;rbRedGreenBlue.ZOrder" xml:space="preserve">
-    <value>22</value>
   </data>
   <data name="lblBlackWhiteValue.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1149,18 +873,6 @@
   <data name="lblBlackWhiteValue.Text" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;lblBlackWhiteValue.Name" xml:space="preserve">
-    <value>lblBlackWhiteValue</value>
-  </data>
-  <data name="&gt;&gt;lblBlackWhiteValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblBlackWhiteValue.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;lblBlackWhiteValue.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
   <data name="tbBlackWhite.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1175,18 +887,6 @@
   </data>
   <data name="tbBlackWhite.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;tbBlackWhite.Name" xml:space="preserve">
-    <value>tbBlackWhite</value>
-  </data>
-  <data name="&gt;&gt;tbBlackWhite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbBlackWhite.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;tbBlackWhite.ZOrder" xml:space="preserve">
-    <value>24</value>
   </data>
   <data name="rbBlackWhite.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1205,18 +905,6 @@
   </data>
   <data name="rbBlackWhite.Text" xml:space="preserve">
     <value>Black, White:</value>
-  </data>
-  <data name="&gt;&gt;rbBlackWhite.Name" xml:space="preserve">
-    <value>rbBlackWhite</value>
-  </data>
-  <data name="&gt;&gt;rbBlackWhite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbBlackWhite.Parent" xml:space="preserve">
-    <value>pSettings</value>
-  </data>
-  <data name="&gt;&gt;rbBlackWhite.ZOrder" xml:space="preserve">
-    <value>25</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/ShareX.HelpersLib/Helpers/FileHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/FileHelpers.cs
@@ -260,7 +260,8 @@ namespace ShareX.HelpersLib
                     {
                         ProcessStartInfo psi = new ProcessStartInfo()
                         {
-                            FileName = filePath
+                            FileName = filePath,
+                            UseShellExecute = true,
                         };
 
                         process.StartInfo = psi;
@@ -300,7 +301,8 @@ namespace ShareX.HelpersLib
                     {
                         ProcessStartInfo psi = new ProcessStartInfo()
                         {
-                            FileName = folderPath
+                            FileName = folderPath,
+                            UseShellExecute = true,
                         };
 
                         process.StartInfo = psi;

--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -708,20 +708,14 @@ namespace ShareX.HelpersLib
 
         public static byte[] ComputeSHA256(byte[] data)
         {
-            using (SHA256Managed hashAlgorithm = new SHA256Managed())
-            {
-                return hashAlgorithm.ComputeHash(data);
-            }
+            return SHA256.HashData(data);
         }
 
         public static byte[] ComputeSHA256(Stream stream, int bufferSize = 1024 * 32)
         {
             BufferedStream bufferedStream = new BufferedStream(stream, bufferSize);
 
-            using (SHA256Managed hashAlgorithm = new SHA256Managed())
-            {
-                return hashAlgorithm.ComputeHash(bufferedStream);
-            }
+            return SHA256.HashData(bufferedStream);
         }
 
         public static byte[] ComputeSHA256(string data)
@@ -731,10 +725,7 @@ namespace ShareX.HelpersLib
 
         public static byte[] ComputeHMACSHA256(byte[] data, byte[] key)
         {
-            using (HMACSHA256 hashAlgorithm = new HMACSHA256(key))
-            {
-                return hashAlgorithm.ComputeHash(data);
-            }
+            return HMACSHA256.HashData(key, data);
         }
 
         public static byte[] ComputeHMACSHA256(string data, string key)
@@ -913,7 +904,7 @@ namespace ShareX.HelpersLib
 
         public static string GetChecksum(string filePath)
         {
-            using (SHA256Managed hashAlgorithm = new SHA256Managed())
+            using (var hashAlgorithm = SHA256.Create())
             {
                 return GetChecksum(filePath, hashAlgorithm);
             }

--- a/ShareX.HelpersLib/Helpers/Helpers.cs
+++ b/ShareX.HelpersLib/Helpers/Helpers.cs
@@ -817,24 +817,6 @@ namespace ShareX.HelpersLib
             return result;
         }
 
-        [ReflectionPermission(SecurityAction.Assert, MemberAccess = true)]
-        public static bool TryFixHandCursor()
-        {
-            try
-            {
-                // https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Cursors.cs,423
-                typeof(Cursors).GetField("hand", BindingFlags.NonPublic | BindingFlags.Static)
-                    .SetValue(null, new Cursor(NativeMethods.LoadCursor(IntPtr.Zero, NativeConstants.IDC_HAND)));
-
-                return true;
-            }
-            catch
-            {
-                // If it fails, we'll just have to live with the old hand.
-                return false;
-            }
-        }
-
         public static bool IsTabletMode()
         {
             //int state = NativeMethods.GetSystemMetrics(SystemMetric.SM_CONVERTIBLESLATEMODE);

--- a/ShareX.HelpersLib/Helpers/URLHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/URLHelpers.cs
@@ -57,7 +57,10 @@ namespace ShareX.HelpersLib
                     {
                         using (Process process = new Process())
                         {
-                            ProcessStartInfo psi = new ProcessStartInfo();
+                            ProcessStartInfo psi = new ProcessStartInfo
+                            {
+                                UseShellExecute = true,
+                            };
 
                             if (!string.IsNullOrEmpty(HelpersOptions.BrowserPath))
                             {

--- a/ShareX.HelpersLib/Native/NativeConstants.cs
+++ b/ShareX.HelpersLib/Native/NativeConstants.cs
@@ -109,7 +109,6 @@ namespace ShareX.HelpersLib
 
         public const uint ECM_FIRST = 0x1500;
         public const uint EM_SETCUEBANNER = ECM_FIRST + 1;
-        public const int IDC_HAND = 32649;
         public const uint MA_ACTIVATE = 1;
         public const uint MA_ACTIVATEANDEAT = 2;
         public const uint MA_NOACTIVATE = 3;

--- a/ShareX.HelpersLib/Random/RandomCrypto.cs
+++ b/ShareX.HelpersLib/Random/RandomCrypto.cs
@@ -33,7 +33,7 @@ namespace ShareX.HelpersLib
     public static class RandomCrypto
     {
         private static readonly object randomLock = new object();
-        private static readonly RNGCryptoServiceProvider random = new RNGCryptoServiceProvider();
+        private static readonly RandomNumberGenerator random = RandomNumberGenerator.Create();
         private static byte[] uint32Buffer = new byte[4];
 
         /// <summary>Returns a non-negative random integer.</summary>

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -1,23 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="IWshRuntimeLibrary">

--- a/ShareX.HistoryLib/Forms/HistoryForm.cs
+++ b/ShareX.HistoryLib/Forms/HistoryForm.cs
@@ -73,8 +73,7 @@ namespace ShareX.HistoryLib
             il.Images.Add(Resources.globe);
             lvHistory.SmallImageList = il;
 
-            him = new HistoryItemManager(uploadFile, editImage, pinToScreen, true);
-            him.GetHistoryItems += him_GetHistoryItems;
+            him = new HistoryItemManager(uploadFile, editImage, pinToScreen, him_GetHistoryItems, true);
             lvHistory.ContextMenuStrip = him.cmsHistory;
 
             pbThumbnail.Reset();

--- a/ShareX.HistoryLib/Forms/HistoryForm.resx
+++ b/ShareX.HistoryLib/Forms/HistoryForm.resx
@@ -564,18 +564,6 @@
   <data name="btnAdvancedSearchClose.Text" xml:space="preserve">
     <value>Close</value>
   </data>
-  <data name="&gt;&gt;btnAdvancedSearchClose.Name" xml:space="preserve">
-    <value>btnAdvancedSearchClose</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchClose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchClose.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchClose.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnAdvancedSearchReset.Location" type="System.Drawing.Point, System.Drawing">
     <value>144, 176</value>
   </data>
@@ -587,18 +575,6 @@
   </data>
   <data name="btnAdvancedSearchReset.Text" xml:space="preserve">
     <value>Reset</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchReset.Name" xml:space="preserve">
-    <value>btnAdvancedSearchReset</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchReset.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;btnAdvancedSearchReset.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="lblURLFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -618,18 +594,6 @@
   <data name="lblURLFilter.Text" xml:space="preserve">
     <value>URL:</value>
   </data>
-  <data name="&gt;&gt;lblURLFilter.Name" xml:space="preserve">
-    <value>lblURLFilter</value>
-  </data>
-  <data name="&gt;&gt;lblURLFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblURLFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;lblURLFilter.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="txtURLFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>96, 44</value>
   </data>
@@ -637,18 +601,6 @@
     <value>296, 20</value>
   </data>
   <data name="txtURLFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtURLFilter.Name" xml:space="preserve">
-    <value>txtURLFilter</value>
-  </data>
-  <data name="&gt;&gt;txtURLFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtURLFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;txtURLFilter.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="lblFilenameFilter.AutoSize" type="System.Boolean, mscorlib">
@@ -669,18 +621,6 @@
   <data name="lblFilenameFilter.Text" xml:space="preserve">
     <value>Filename:</value>
   </data>
-  <data name="&gt;&gt;lblFilenameFilter.Name" xml:space="preserve">
-    <value>lblFilenameFilter</value>
-  </data>
-  <data name="&gt;&gt;lblFilenameFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFilenameFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;lblFilenameFilter.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="cbHostFilterSelection.Location" type="System.Drawing.Point, System.Drawing">
     <value>152, 142</value>
   </data>
@@ -690,18 +630,6 @@
   <data name="cbHostFilterSelection.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
-  <data name="&gt;&gt;cbHostFilterSelection.Name" xml:space="preserve">
-    <value>cbHostFilterSelection</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilterSelection.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilterSelection.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilterSelection.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="cbTypeFilterSelection.Location" type="System.Drawing.Point, System.Drawing">
     <value>152, 118</value>
   </data>
@@ -710,18 +638,6 @@
   </data>
   <data name="cbTypeFilterSelection.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilterSelection.Name" xml:space="preserve">
-    <value>cbTypeFilterSelection</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilterSelection.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilterSelection.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilterSelection.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="cbHostFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -741,18 +657,6 @@
   <data name="cbHostFilter.Text" xml:space="preserve">
     <value>Host:</value>
   </data>
-  <data name="&gt;&gt;cbHostFilter.Name" xml:space="preserve">
-    <value>cbHostFilter</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;cbHostFilter.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="cbTypeFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -771,18 +675,6 @@
   <data name="cbTypeFilter.Text" xml:space="preserve">
     <value>Type:</value>
   </data>
-  <data name="&gt;&gt;cbTypeFilter.Name" xml:space="preserve">
-    <value>cbTypeFilter</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;cbTypeFilter.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="dtpFilterFrom.Location" type="System.Drawing.Point, System.Drawing">
     <value>152, 70</value>
   </data>
@@ -791,18 +683,6 @@
   </data>
   <data name="dtpFilterFrom.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterFrom.Name" xml:space="preserve">
-    <value>dtpFilterFrom</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DateTimePicker, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterFrom.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterFrom.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="lblFilterFrom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -822,18 +702,6 @@
   <data name="lblFilterFrom.Text" xml:space="preserve">
     <value>From:</value>
   </data>
-  <data name="&gt;&gt;lblFilterFrom.Name" xml:space="preserve">
-    <value>lblFilterFrom</value>
-  </data>
-  <data name="&gt;&gt;lblFilterFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFilterFrom.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;lblFilterFrom.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="lblFilterTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -851,18 +719,6 @@
   </data>
   <data name="lblFilterTo.Text" xml:space="preserve">
     <value>To:</value>
-  </data>
-  <data name="&gt;&gt;lblFilterTo.Name" xml:space="preserve">
-    <value>lblFilterTo</value>
-  </data>
-  <data name="&gt;&gt;lblFilterTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFilterTo.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;lblFilterTo.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="cbDateFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -882,18 +738,6 @@
   <data name="cbDateFilter.Text" xml:space="preserve">
     <value>Date:</value>
   </data>
-  <data name="&gt;&gt;cbDateFilter.Name" xml:space="preserve">
-    <value>cbDateFilter</value>
-  </data>
-  <data name="&gt;&gt;cbDateFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDateFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;cbDateFilter.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="dtpFilterTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>152, 94</value>
   </data>
@@ -903,18 +747,6 @@
   <data name="dtpFilterTo.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="&gt;&gt;dtpFilterTo.Name" xml:space="preserve">
-    <value>dtpFilterTo</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DateTimePicker, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterTo.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;dtpFilterTo.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="txtFilenameFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>96, 20</value>
   </data>
@@ -923,18 +755,6 @@
   </data>
   <data name="txtFilenameFilter.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtFilenameFilter.Name" xml:space="preserve">
-    <value>txtFilenameFilter</value>
-  </data>
-  <data name="&gt;&gt;txtFilenameFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFilenameFilter.Parent" xml:space="preserve">
-    <value>gbAdvancedSearch</value>
-  </data>
-  <data name="&gt;&gt;txtFilenameFilter.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="scMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/ShareX.HistoryLib/Forms/ImageHistoryForm.cs
+++ b/ShareX.HistoryLib/Forms/ImageHistoryForm.cs
@@ -176,7 +176,15 @@ namespace ShareX.HistoryLib
 
         private HistoryItem[] him_GetHistoryItems()
         {
-            return ilvImages.SelectedItems.Select(x => x.Tag as HistoryItem).ToArray();
+            // We have to do this manually as ImageListViewSelectedItemCollection doesn't support several methods it claims to implement
+            // and some of those methods are used by modern LINQ.
+            // Would be fixed by https://github.com/oozcitak/imagelistview/pull/234
+            var result = new List<HistoryItem>();
+            foreach (var item in ilvImages.SelectedItems)
+            {
+                result.Add(item.Tag as HistoryItem);
+            }
+            return result.ToArray();
         }
 
         #region Form events

--- a/ShareX.HistoryLib/Forms/ImageHistoryForm.cs
+++ b/ShareX.HistoryLib/Forms/ImageHistoryForm.cs
@@ -63,8 +63,7 @@ namespace ShareX.HistoryLib
                 ilvImages.BorderStyle = BorderStyle.None;
             }
 
-            him = new HistoryItemManager(uploadFile, editImage, pinToScreen);
-            him.GetHistoryItems += him_GetHistoryItems;
+            him = new HistoryItemManager(uploadFile, editImage, pinToScreen, him_GetHistoryItems);
             ilvImages.ContextMenuStrip = him.cmsHistory;
 
             defaultTitle = Text;

--- a/ShareX.HistoryLib/HistoryItemManager.cs
+++ b/ShareX.HistoryLib/HistoryItemManager.cs
@@ -33,9 +33,7 @@ namespace ShareX.HistoryLib
 {
     public partial class HistoryItemManager
     {
-        public delegate HistoryItem[] GetHistoryItemsEventHandler();
-
-        public event GetHistoryItemsEventHandler GetHistoryItems;
+        private readonly Func<HistoryItem[]> getHistoryItems;
 
         public HistoryItem HistoryItem { get; private set; }
 
@@ -52,11 +50,12 @@ namespace ShareX.HistoryLib
 
         private Action<string> uploadFile, editImage, pinToScreen;
 
-        public HistoryItemManager(Action<string> uploadFile, Action<string> editImage, Action<string> pinToScreen, bool hideShowMoreInfoButton = false)
+        public HistoryItemManager(Action<string> uploadFile, Action<string> editImage, Action<string> pinToScreen, Func<HistoryItem[]> getHistoryItems, bool hideShowMoreInfoButton = false)
         {
             this.uploadFile = uploadFile;
             this.editImage = editImage;
             this.pinToScreen = pinToScreen;
+            this.getHistoryItems = getHistoryItems;
 
             InitializeComponent();
 
@@ -70,7 +69,7 @@ namespace ShareX.HistoryLib
 
         public HistoryItem UpdateSelectedHistoryItem()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
 
             if (historyItems != null && historyItems.Length > 0)
             {
@@ -102,16 +101,6 @@ namespace ShareX.HistoryLib
             }
 
             return HistoryItem;
-        }
-
-        public HistoryItem[] OnGetHistoryItems()
-        {
-            if (GetHistoryItems != null)
-            {
-                return GetHistoryItems();
-            }
-
-            return null;
         }
 
         public bool HandleKeyInput(KeyEventArgs e)
@@ -206,7 +195,7 @@ namespace ShareX.HistoryLib
 
         public void CopyURL()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => x.URL).ToArray();
@@ -225,7 +214,7 @@ namespace ShareX.HistoryLib
 
         public void CopyShortenedURL()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.ShortenedURL)).Select(x => x.ShortenedURL).ToArray();
@@ -244,7 +233,7 @@ namespace ShareX.HistoryLib
 
         public void CopyThumbnailURL()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.ThumbnailURL)).Select(x => x.ThumbnailURL).ToArray();
@@ -263,7 +252,7 @@ namespace ShareX.HistoryLib
 
         public void CopyDeletionURL()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.DeletionURL)).Select(x => x.DeletionURL).ToArray();
@@ -282,7 +271,7 @@ namespace ShareX.HistoryLib
 
         public void CopyFile()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.FilePath) && Path.HasExtension(x.FilePath) &&
@@ -307,7 +296,7 @@ namespace ShareX.HistoryLib
 
         public void CopyHTMLLink()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).
@@ -327,7 +316,7 @@ namespace ShareX.HistoryLib
 
         public void CopyHTMLImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL)).
@@ -347,7 +336,7 @@ namespace ShareX.HistoryLib
 
         public void CopyHTMLLinkedImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL) &&
@@ -367,7 +356,7 @@ namespace ShareX.HistoryLib
 
         public void CopyForumLink()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).Select(x => string.Format("[url]{0}[/url]", x.URL)).ToArray();
@@ -386,7 +375,7 @@ namespace ShareX.HistoryLib
 
         public void CopyForumImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL)).
@@ -406,7 +395,7 @@ namespace ShareX.HistoryLib
 
         public void CopyForumLinkedImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL) &&
@@ -426,7 +415,7 @@ namespace ShareX.HistoryLib
 
         public void CopyMarkdownLink()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL)).
@@ -446,7 +435,7 @@ namespace ShareX.HistoryLib
 
         public void CopyMarkdownImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL)).
@@ -466,7 +455,7 @@ namespace ShareX.HistoryLib
 
         public void CopyMarkdownLinkedImage()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.URL) && FileHelpers.IsImageFile(x.URL) &&
@@ -486,7 +475,7 @@ namespace ShareX.HistoryLib
 
         public void CopyFilePath()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.FilePath) && Path.HasExtension(x.FilePath) &&
@@ -506,7 +495,7 @@ namespace ShareX.HistoryLib
 
         public void CopyFileName()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.FilePath) && Path.HasExtension(x.FilePath)).
@@ -526,7 +515,7 @@ namespace ShareX.HistoryLib
 
         public void CopyFileNameWithExtension()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.FilePath) && Path.HasExtension(x.FilePath)).
@@ -546,7 +535,7 @@ namespace ShareX.HistoryLib
 
         public void CopyFolder()
         {
-            HistoryItem[] historyItems = OnGetHistoryItems();
+            HistoryItem[] historyItems = getHistoryItems();
             if (historyItems != null)
             {
                 string[] array = historyItems.Where(x => x != null && !string.IsNullOrEmpty(x.FilePath) && Path.HasExtension(x.FilePath)).

--- a/ShareX.HistoryLib/ShareX.HistoryLib.csproj
+++ b/ShareX.HistoryLib/ShareX.HistoryLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
+++ b/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Design" />
-    <Reference Include="System.IO.Compression" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>

--- a/ShareX.IndexerLib/Forms/DirectoryIndexerForm.resx
+++ b/ShareX.IndexerLib/Forms/DirectoryIndexerForm.resx
@@ -315,18 +315,6 @@
   <data name="tpPreview.Text" xml:space="preserve">
     <value>Preview</value>
   </data>
-  <data name="&gt;&gt;tpPreview.Name" xml:space="preserve">
-    <value>tpPreview</value>
-  </data>
-  <data name="&gt;&gt;tpPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpPreview.Parent" xml:space="preserve">
-    <value>tcMain</value>
-  </data>
-  <data name="&gt;&gt;tpPreview.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="txtPreview.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -343,18 +331,6 @@
     <value>860, 564</value>
   </data>
   <data name="txtPreview.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtPreview.Name" xml:space="preserve">
-    <value>txtPreview</value>
-  </data>
-  <data name="&gt;&gt;txtPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPreview.Parent" xml:space="preserve">
-    <value>tpPreview</value>
-  </data>
-  <data name="&gt;&gt;txtPreview.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="&gt;&gt;pgSettings.Name" xml:space="preserve">
@@ -381,18 +357,6 @@
   <data name="tpSettings.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="&gt;&gt;tpSettings.Name" xml:space="preserve">
-    <value>tpSettings</value>
-  </data>
-  <data name="&gt;&gt;tpSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpSettings.Parent" xml:space="preserve">
-    <value>tcMain</value>
-  </data>
-  <data name="&gt;&gt;tpSettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="pgSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -403,18 +367,6 @@
     <value>860, 564</value>
   </data>
   <data name="pgSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;pgSettings.Name" xml:space="preserve">
-    <value>pgSettings</value>
-  </data>
-  <data name="&gt;&gt;pgSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PropertyGrid, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pgSettings.Parent" xml:space="preserve">
-    <value>tpSettings</value>
-  </data>
-  <data name="&gt;&gt;pgSettings.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="btnSaveAs.Enabled" type="System.Boolean, mscorlib">
@@ -461,18 +413,6 @@
   </data>
   <data name="wbPreview.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;wbPreview.Name" xml:space="preserve">
-    <value>wbPreview</value>
-  </data>
-  <data name="&gt;&gt;wbPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.WebBrowser, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;wbPreview.Parent" xml:space="preserve">
-    <value>tpPreview</value>
-  </data>
-  <data name="&gt;&gt;wbPreview.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/ShareX.IndexerLib/ShareX.IndexerLib.csproj
+++ b/ShareX.IndexerLib/ShareX.IndexerLib.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Design" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>

--- a/ShareX.MediaLib/Forms/ImageCombinerForm.resx
+++ b/ShareX.MediaLib/Forms/ImageCombinerForm.resx
@@ -513,18 +513,6 @@
   <data name="rbOrientationHorizontal.Text" xml:space="preserve">
     <value>Horizontal</value>
   </data>
-  <data name="&gt;&gt;rbOrientationHorizontal.Name" xml:space="preserve">
-    <value>rbOrientationHorizontal</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationHorizontal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationHorizontal.Parent" xml:space="preserve">
-    <value>flpOrientation</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationHorizontal.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="rbOrientationVertical.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -539,18 +527,6 @@
   </data>
   <data name="rbOrientationVertical.Text" xml:space="preserve">
     <value>Vertical</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationVertical.Name" xml:space="preserve">
-    <value>rbOrientationVertical</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationVertical.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationVertical.Parent" xml:space="preserve">
-    <value>flpOrientation</value>
-  </data>
-  <data name="&gt;&gt;rbOrientationVertical.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="cbAutoFillBackground.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>

--- a/ShareX.MediaLib/ShareX.MediaLib.csproj
+++ b/ShareX.MediaLib/ShareX.MediaLib.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.IO.Compression" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>

--- a/ShareX.NativeMessagingHost/ShareX.NativeMessagingHost.csproj
+++ b/ShareX.NativeMessagingHost/ShareX.NativeMessagingHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>ShareX_NativeMessagingHost</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
@@ -1357,18 +1357,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpX264.Text" xml:space="preserve">
     <value>x264 / x265</value>
   </data>
-  <data name="&gt;&gt;tpX264.Name" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpX264.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblx264BitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1386,18 +1374,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblx264BitrateK.Text" xml:space="preserve">
     <value>kbps</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Name" xml:space="preserve">
-    <value>lblx264BitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="cbx264UseBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1417,18 +1393,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="cbx264UseBitrate.Text" xml:space="preserve">
     <value>Use bitrate</value>
   </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Name" xml:space="preserve">
-    <value>cbx264UseBitrate</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="lblx264CRF.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1446,18 +1410,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblx264CRF.Text" xml:space="preserve">
     <value>CRF:</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Name" xml:space="preserve">
-    <value>lblx264CRF</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="lblx264Preset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1477,18 +1429,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblx264Preset.Text" xml:space="preserve">
     <value>Preset:</value>
   </data>
-  <data name="&gt;&gt;lblx264Preset.Name" xml:space="preserve">
-    <value>lblx264Preset</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="nudx264Bitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
   </data>
@@ -1500,18 +1440,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="nudx264Bitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Name" xml:space="preserve">
-    <value>nudx264Bitrate</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="&gt;&gt;lblVP8BitrateK.Name" xml:space="preserve">
     <value>lblVP8BitrateK</value>
@@ -1561,18 +1489,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpVpx.Text" xml:space="preserve">
     <value>VP8</value>
   </data>
-  <data name="&gt;&gt;tpVpx.Name" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="lblVP8BitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1591,18 +1507,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblVP8BitrateK.Text" xml:space="preserve">
     <value>kbps</value>
   </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Name" xml:space="preserve">
-    <value>lblVP8BitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="nudVP8Bitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
   </data>
@@ -1614,18 +1518,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="nudVP8Bitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Name" xml:space="preserve">
-    <value>nudVP8Bitrate</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="lblVP8Bitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1644,18 +1536,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblVP8Bitrate.Text" xml:space="preserve">
     <value>Bitrate:</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Name" xml:space="preserve">
-    <value>lblVP8Bitrate</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;lblXvidQscale.Name" xml:space="preserve">
     <value>lblXvidQscale</value>
@@ -1681,18 +1561,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpXvid.Text" xml:space="preserve">
     <value>Xvid</value>
   </data>
-  <data name="&gt;&gt;tpXvid.Name" xml:space="preserve">
-    <value>tpXvid</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lblXvidQscale.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1710,18 +1578,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblXvidQscale.Text" xml:space="preserve">
     <value>Variable bitrate:</value>
-  </data>
-  <data name="&gt;&gt;lblXvidQscale.Name" xml:space="preserve">
-    <value>lblXvidQscale</value>
-  </data>
-  <data name="&gt;&gt;lblXvidQscale.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblXvidQscale.Parent" xml:space="preserve">
-    <value>tpXvid</value>
-  </data>
-  <data name="&gt;&gt;lblXvidQscale.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;cbNVENCTune.Name" xml:space="preserve">
     <value>cbNVENCTune</value>
@@ -1822,18 +1678,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpNVENC.Text" xml:space="preserve">
     <value>NVENC</value>
   </data>
-  <data name="&gt;&gt;tpNVENC.Name" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="cbNVENCTune.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 52</value>
   </data>
@@ -1842,18 +1686,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="cbNVENCTune.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Name" xml:space="preserve">
-    <value>cbNVENCTune</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblNVENCTune.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1873,18 +1705,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblNVENCTune.Text" xml:space="preserve">
     <value>Tune:</value>
   </data>
-  <data name="&gt;&gt;lblNVENCTune.Name" xml:space="preserve">
-    <value>lblNVENCTune</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="lblNVENCBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1903,18 +1723,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblNVENCBitrateK.Text" xml:space="preserve">
     <value>kbps</value>
   </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Name" xml:space="preserve">
-    <value>lblNVENCBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="cbNVENCPreset.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
   </data>
@@ -1923,18 +1731,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="cbNVENCPreset.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Name" xml:space="preserve">
-    <value>cbNVENCPreset</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="lblNVENCPreset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1954,18 +1750,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblNVENCPreset.Text" xml:space="preserve">
     <value>Preset:</value>
   </data>
-  <data name="&gt;&gt;lblNVENCPreset.Name" xml:space="preserve">
-    <value>lblNVENCPreset</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="nudNVENCBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
   </data>
@@ -1977,18 +1761,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="nudNVENCBitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Name" xml:space="preserve">
-    <value>nudNVENCBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="lblNVENCBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2007,18 +1779,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblNVENCBitrate.Text" xml:space="preserve">
     <value>Bitrate:</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Name" xml:space="preserve">
-    <value>lblNVENCBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;lblGIFDither.Name" xml:space="preserve">
     <value>lblGIFDither</value>
@@ -2059,18 +1819,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpGIF.Text" xml:space="preserve">
     <value>GIF</value>
   </data>
-  <data name="&gt;&gt;tpGIF.Name" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="lblGIFDither.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2089,18 +1837,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblGIFDither.Text" xml:space="preserve">
     <value>Dithering mode:</value>
   </data>
-  <data name="&gt;&gt;lblGIFDither.Name" xml:space="preserve">
-    <value>lblGIFDither</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.Parent" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lblGIFStatsMode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2118,18 +1854,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblGIFStatsMode.Text" xml:space="preserve">
     <value>Palette mode:</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Name" xml:space="preserve">
-    <value>lblGIFStatsMode</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Parent" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;lblAMFBitrateK.Name" xml:space="preserve">
     <value>lblAMFBitrateK</value>
@@ -2230,18 +1954,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpAMF.Text" xml:space="preserve">
     <value>AMF</value>
   </data>
-  <data name="&gt;&gt;tpAMF.Name" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="lblAMFBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2260,18 +1972,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblAMFBitrateK.Text" xml:space="preserve">
     <value>kbps</value>
   </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Name" xml:space="preserve">
-    <value>lblAMFBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="nudAMFBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
   </data>
@@ -2283,18 +1983,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="nudAMFBitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Name" xml:space="preserve">
-    <value>nudAMFBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="lblAMFBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2314,18 +2002,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblAMFBitrate.Text" xml:space="preserve">
     <value>Bitrate:</value>
   </data>
-  <data name="&gt;&gt;lblAMFBitrate.Name" xml:space="preserve">
-    <value>lblAMFBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="cbAMFQuality.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 52</value>
   </data>
@@ -2334,18 +2010,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="cbAMFQuality.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Name" xml:space="preserve">
-    <value>cbAMFQuality</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="lblAMFQuality.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2365,18 +2029,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblAMFQuality.Text" xml:space="preserve">
     <value>Quality:</value>
   </data>
-  <data name="&gt;&gt;lblAMFQuality.Name" xml:space="preserve">
-    <value>lblAMFQuality</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="cbAMFUsage.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
   </data>
@@ -2385,18 +2037,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="cbAMFUsage.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Name" xml:space="preserve">
-    <value>cbAMFUsage</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="lblAMFUsage.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2415,18 +2055,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblAMFUsage.Text" xml:space="preserve">
     <value>Usage:</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Name" xml:space="preserve">
-    <value>lblAMFUsage</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;lblQSVBitrateK.Name" xml:space="preserve">
     <value>lblQSVBitrateK</value>
@@ -2503,18 +2131,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="tpQSV.Text" xml:space="preserve">
     <value>QuickSync</value>
   </data>
-  <data name="&gt;&gt;tpQSV.Name" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="lblQSVBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2533,18 +2149,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblQSVBitrateK.Text" xml:space="preserve">
     <value>kbps</value>
   </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Name" xml:space="preserve">
-    <value>lblQSVBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="cbQSVPreset.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
   </data>
@@ -2553,18 +2157,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="cbQSVPreset.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Name" xml:space="preserve">
-    <value>cbQSVPreset</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="lblQSVPreset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2584,18 +2176,6 @@ A higher value means bad quality, but a low file size.</value>
   <data name="lblQSVPreset.Text" xml:space="preserve">
     <value>Preset:</value>
   </data>
-  <data name="&gt;&gt;lblQSVPreset.Name" xml:space="preserve">
-    <value>lblQSVPreset</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="nudQSVBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
   </data>
@@ -2607,18 +2187,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="nudQSVBitrate.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Center</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Name" xml:space="preserve">
-    <value>nudQSVBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="lblQSVBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2637,18 +2205,6 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="lblQSVBitrate.Text" xml:space="preserve">
     <value>Bitrate:</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Name" xml:space="preserve">
-    <value>lblQSVBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="btnResetOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>504, 416</value>

--- a/ShareX.ScreenCaptureLib/Forms/ScreenRecordForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/ScreenRecordForm.resx
@@ -285,18 +285,6 @@
   <data name="btnPause.Text" xml:space="preserve">
     <value>Pause</value>
   </data>
-  <data name="&gt;&gt;btnPause.Name" xml:space="preserve">
-    <value>btnPause</value>
-  </data>
-  <data name="&gt;&gt;btnPause.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.NoFocusBorderButton, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;btnPause.Parent" xml:space="preserve">
-    <value>pInfo</value>
-  </data>
-  <data name="&gt;&gt;btnPause.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <metadata name="cmsMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>138, 17</value>
   </metadata>

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Design" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
     <ProjectReference Include="..\ShareX.ImageEffectsLib\ShareX.ImageEffectsLib.csproj" />

--- a/ShareX.Setup/ShareX.Setup.csproj
+++ b/ShareX.Setup/ShareX.Setup.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.IO.Compression" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>

--- a/ShareX.Steam/ShareX.Steam.csproj
+++ b/ShareX.Steam/ShareX.Steam.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <PlatformTarget>x86</PlatformTarget>
     <AssemblyName>ShareX_Launcher</AssemblyName>
@@ -8,7 +8,7 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Management" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="steam_appid.txt">

--- a/ShareX.UploadersLib/FileUploaders/BackblazeB2.cs
+++ b/ShareX.UploadersLib/FileUploaders/BackblazeB2.cs
@@ -397,13 +397,10 @@ namespace ShareX.UploadersLib.FileUploaders
 
             // compute SHA1 hash without loading the file fully into memory
             string sha1Hash;
-            using (SHA1CryptoServiceProvider cryptoProvider = new SHA1CryptoServiceProvider())
-            {
-                file.Seek(0, SeekOrigin.Begin);
-                byte[] bytes = cryptoProvider.ComputeHash(file);
-                sha1Hash = BitConverter.ToString(bytes).Replace("-", "").ToLower();
-                file.Seek(0, SeekOrigin.Begin);
-            }
+            file.Seek(0, SeekOrigin.Begin);
+            byte[] bytes = SHA1.HashData(file);
+            sha1Hash = BitConverter.ToString(bytes).Replace("-", "").ToLower();
+            file.Seek(0, SeekOrigin.Begin);
             DebugHelper.WriteLine($"B2 uploader: SHA1 hash is '{sha1Hash}'.");
 
             // it's showtime

--- a/ShareX.UploadersLib/FileUploaders/FTP.cs
+++ b/ShareX.UploadersLib/FileUploaders/FTP.cs
@@ -246,7 +246,7 @@ namespace ShareX.UploadersLib.FileUploaders
                         return UploadDataInternal(localStream, remotePath);
                     }
 
-                    throw e;
+                    throw;
                 }
             }
 

--- a/ShareX.UploadersLib/FileUploaders/Vault_ooo.cs
+++ b/ShareX.UploadersLib/FileUploaders/Vault_ooo.cs
@@ -225,7 +225,7 @@ namespace ShareX.UploadersLib.FileUploaders
 
         private static byte[] EncryptBytes(Vault_oooCryptoData crypto, byte[] bytes)
         {
-            using (AesManaged aes = new AesManaged())
+            using (var aes = Aes.Create())
             {
                 aes.Mode = CipherMode.CBC;
                 aes.KeySize = AES_KEY_SIZE;

--- a/ShareX.UploadersLib/OAuth/OAuth2ProofKey.cs
+++ b/ShareX.UploadersLib/OAuth/OAuth2ProofKey.cs
@@ -56,22 +56,15 @@ namespace ShareX.UploadersLib
         {
             Method = method;
 
-            byte[] buffer = new byte[32];
+            byte[] buffer = RandomNumberGenerator.GetBytes(32);
 
-            using (RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider())
-            {
-                rng.GetBytes(buffer);
-            }
             CodeVerifier = CleanBase64(buffer);
             CodeChallenge = CodeVerifier;
 
             if (Method == OAuth2ChallengeMethod.SHA256)
             {
-                using (SHA256 sha = SHA256.Create())
-                {
-                    sha.ComputeHash(Encoding.UTF8.GetBytes(CodeVerifier));
-                    CodeChallenge = CleanBase64(sha.Hash);
-                }
+                var hash = SHA256.HashData(Encoding.UTF8.GetBytes(CodeVerifier));
+                CodeChallenge = CleanBase64(hash);
             }
         }
 

--- a/ShareX.UploadersLib/OAuth/OAuthManager.cs
+++ b/ShareX.UploadersLib/OAuth/OAuthManager.cs
@@ -202,7 +202,7 @@ namespace ShareX.UploadersLib
         {
             byte[] dataBuffer = Encoding.ASCII.GetBytes(signatureBase);
 
-            using (SHA1CryptoServiceProvider sha1 = GenerateSha1Hash(dataBuffer))
+            using (var sha1 = GenerateSha1Hash(dataBuffer))
             using (AsymmetricAlgorithm algorithm = new RSACryptoServiceProvider())
             {
                 algorithm.FromXmlString(privateKey);
@@ -212,9 +212,9 @@ namespace ShareX.UploadersLib
             }
         }
 
-        private static SHA1CryptoServiceProvider GenerateSha1Hash(byte[] dataBuffer)
+        private static SHA1 GenerateSha1Hash(byte[] dataBuffer)
         {
-            SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider();
+            var sha1 = SHA1.Create();
 
             using (CryptoStream cs = new CryptoStream(Stream.Null, sha1, CryptoStreamMode.Write))
             {

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -1,14 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Design" />
-    <Reference Include="System.ServiceModel.Web" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>

--- a/ShareX/Forms/AfterCaptureForm.resx
+++ b/ShareX/Forms/AfterCaptureForm.resx
@@ -300,18 +300,6 @@
   <data name="tpAfterCapture.Text" xml:space="preserve">
     <value>After capture</value>
   </data>
-  <data name="&gt;&gt;tpAfterCapture.Name" xml:space="preserve">
-    <value>tpAfterCapture</value>
-  </data>
-  <data name="&gt;&gt;tpAfterCapture.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAfterCapture.Parent" xml:space="preserve">
-    <value>tcTasks</value>
-  </data>
-  <data name="&gt;&gt;tpAfterCapture.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lvAfterCaptureTasks.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -326,18 +314,6 @@
   </data>
   <data name="lvAfterCaptureTasks.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;lvAfterCaptureTasks.Name" xml:space="preserve">
-    <value>lvAfterCaptureTasks</value>
-  </data>
-  <data name="&gt;&gt;lvAfterCaptureTasks.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvAfterCaptureTasks.Parent" xml:space="preserve">
-    <value>tpAfterCapture</value>
-  </data>
-  <data name="&gt;&gt;lvAfterCaptureTasks.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="&gt;&gt;ucBeforeUpload.Name" xml:space="preserve">
     <value>ucBeforeUpload</value>
@@ -366,18 +342,6 @@
   <data name="tpBeforeUpload.Text" xml:space="preserve">
     <value>Destinations</value>
   </data>
-  <data name="&gt;&gt;tpBeforeUpload.Name" xml:space="preserve">
-    <value>tpBeforeUpload</value>
-  </data>
-  <data name="&gt;&gt;tpBeforeUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpBeforeUpload.Parent" xml:space="preserve">
-    <value>tcTasks</value>
-  </data>
-  <data name="&gt;&gt;tpBeforeUpload.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="ucBeforeUpload.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -388,18 +352,6 @@
     <value>290, 307</value>
   </data>
   <data name="ucBeforeUpload.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucBeforeUpload.Name" xml:space="preserve">
-    <value>ucBeforeUpload</value>
-  </data>
-  <data name="&gt;&gt;ucBeforeUpload.Type" xml:space="preserve">
-    <value>ShareX.BeforeUploadControl, ShareX, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucBeforeUpload.Parent" xml:space="preserve">
-    <value>tpBeforeUpload</value>
-  </data>
-  <data name="&gt;&gt;ucBeforeUpload.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="&gt;&gt;lvAfterUploadTasks.Name" xml:space="preserve">
@@ -429,18 +381,6 @@
   <data name="tpAfterUpload.Text" xml:space="preserve">
     <value>After upload</value>
   </data>
-  <data name="&gt;&gt;tpAfterUpload.Name" xml:space="preserve">
-    <value>tpAfterUpload</value>
-  </data>
-  <data name="&gt;&gt;tpAfterUpload.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAfterUpload.Parent" xml:space="preserve">
-    <value>tcTasks</value>
-  </data>
-  <data name="&gt;&gt;tpAfterUpload.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lvAfterUploadTasks.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -455,18 +395,6 @@
   </data>
   <data name="lvAfterUploadTasks.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;lvAfterUploadTasks.Name" xml:space="preserve">
-    <value>lvAfterUploadTasks</value>
-  </data>
-  <data name="&gt;&gt;lvAfterUploadTasks.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.MyListView, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lvAfterUploadTasks.Parent" xml:space="preserve">
-    <value>tpAfterUpload</value>
-  </data>
-  <data name="&gt;&gt;lvAfterUploadTasks.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblFileName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>

--- a/ShareX/Forms/MainForm.resx
+++ b/ShareX/Forms/MainForm.resx
@@ -1968,18 +1968,6 @@
   <data name="pHotkeys.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;pHotkeys.Name" xml:space="preserve">
-    <value>pHotkeys</value>
-  </data>
-  <data name="&gt;&gt;pHotkeys.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pHotkeys.Parent" xml:space="preserve">
-    <value>pMain</value>
-  </data>
-  <data name="&gt;&gt;pHotkeys.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="ucTaskThumbnailView.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1994,18 +1982,6 @@
   </data>
   <data name="ucTaskThumbnailView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;ucTaskThumbnailView.Name" xml:space="preserve">
-    <value>ucTaskThumbnailView</value>
-  </data>
-  <data name="&gt;&gt;ucTaskThumbnailView.Type" xml:space="preserve">
-    <value>ShareX.TaskThumbnailView, ShareX, Version=16.1.2.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ucTaskThumbnailView.Parent" xml:space="preserve">
-    <value>pMain</value>
-  </data>
-  <data name="&gt;&gt;ucTaskThumbnailView.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/ShareX/Program.cs
+++ b/ShareX/Program.cs
@@ -355,7 +355,6 @@ namespace ShareX
             UpdateManager = new ShareXUpdateManager();
             LanguageHelper.ChangeLanguage(Settings.Language);
             CleanupManager.CleanupAsync();
-            Helpers.TryFixHandCursor();
 
             DebugHelper.WriteLine("MainForm init started.");
             MainForm = new MainForm();
@@ -668,7 +667,6 @@ namespace ShareX
             {
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                Helpers.TryFixHandCursor();
                 Application.Run(new DNSChangerForm());
                 return true;
             }

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -1,17 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net80-windows10.0.26100.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <ApplicationIcon>ShareX_Icon.ico</ApplicationIcon>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Description>Screen capture, file sharing and productivity tool</Description>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System.Design" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HistoryLib\ShareX.HistoryLib.csproj" />
     <ProjectReference Include="..\ShareX.ImageEffectsLib\ShareX.ImageEffectsLib.csproj" />
@@ -22,9 +17,9 @@
     <ProjectReference Include="..\ShareX.UploadersLib\ShareX.UploadersLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ZXing.Net" Version="0.16.9" />
+    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host-manifest-chrome.json">

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -46,7 +46,7 @@ using System.Windows.Forms;
 using ZXing;
 using ZXing.Common;
 using ZXing.QrCode;
-using ZXing.Rendering;
+using ZXing.Windows.Compatibility;
 
 namespace ShareX
 {


### PR DESCRIPTION
I tried updating to .NET 8 and fixed what was broken. Very little needed to be fixed to get it working, but a bunch of new warnings showed up so I fixed the ones that were trivial.

Since there aren't any tests in code and I only just stumbled onto this tool, I haven't exactly tested it thoroughly. I opened every window/section in the UI and poked around for a while and made sure every test under the debug menu worked.

If you don't want to go to .NET 8 yet, every commit before `Update to .NET 8` should be completely fine for .NET Framework as well.

The `ImageListView` dependency is still on .NET Framework and has some shortcomings that cause problems with the optimisations to LINQ in modern .NET. There's an [old PR there](https://github.com/oozcitak/imagelistview/pull/234) to fix it, but I've worked around the problem for now.

It still won't be possible to use the `dotnet` CLI tool for building (and maybe other things) due to the COM reference in `ShareX.HelpersLib` (used for creating & checking shortcuts). I'm pretty sure that could be replaced with something more modern, but I've never dealt with that stuff and didn't want to risk messing it up.