### PR TITLE
Replace ImageListView with ImageListViewCore.

### DIFF
--- a/ShareX.HistoryLib/Forms/ImageHistoryForm.resx
+++ b/ShareX.HistoryLib/Forms/ImageHistoryForm.resx
@@ -148,7 +148,7 @@
     <value>ilvImages</value>
   </data>
   <data name="&gt;&gt;ilvImages.Type" xml:space="preserve">
-    <value>Manina.Windows.Forms.ImageListView, ImageListView, Version=13.8.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Manina.Windows.Forms.ImageListView, ImageListViewCore, Version=0.0.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ilvImages.Parent" xml:space="preserve">
     <value>tscMain.ContentPanel</value>

--- a/ShareX.HistoryLib/ShareX.HistoryLib.csproj
+++ b/ShareX.HistoryLib/ShareX.HistoryLib.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ImageListView" Version="13.8.2" />
+    <PackageReference Include="ImageListViewCore" Version="0.0.2" />
   </ItemGroup>
 </Project>

--- a/ShareX.ScreenCaptureLib/Forms/StickerForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/StickerForm.resx
@@ -148,7 +148,7 @@
     <value>ilvStickers</value>
   </data>
   <data name="&gt;&gt;ilvStickers.Type" xml:space="preserve">
-    <value>Manina.Windows.Forms.ImageListView, ImageListView, Version=13.7.2.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Manina.Windows.Forms.ImageListView, ImageListViewCore, Version=0.0.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ilvStickers.Parent" xml:space="preserve">
     <value>tscMain.ContentPanel</value>

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -13,6 +13,6 @@
     <ProjectReference Include="..\ShareX.MediaLib\ShareX.MediaLib.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ImageListView" Version="13.8.2" />
+    <PackageReference Include="ImageListViewCore" Version="0.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The `ImageListView` package has been replaced with [`ImageListViewCore`][1] which is my fork of the same project.

**Changes in `ImageListViewCore`:**
- New target frameworks has been added (`net4.8` and `net6.0`).
- The `SourceLink` has been enabled which may help with debugging.
- The packages are deterministic and released via build scripts which helps releasing bug fixes faster.
- The assembly name has been changed to `ImageListViewCore.dll` (from `ImageListView.dll`), hopefully this doesn't break anything.

[1]: https://github.com/imagelistview-core/imagelistview-core