### PR TITLE
Fix cursor offset for multi-monitor configurations

### DIFF
--- a/ShareX.HelpersLib/CursorData.cs
+++ b/ShareX.HelpersLib/CursorData.cs
@@ -131,7 +131,6 @@ namespace ShareX.HelpersLib
             if (IsVisible)
             {
                 Point drawPosition = new Point(DrawPosition.X - offset.X, DrawPosition.Y - offset.Y);
-                drawPosition = CaptureHelpers.ScreenToClient(drawPosition);
 
                 NativeMethods.DrawIconEx(hdcDest, drawPosition.X, drawPosition.Y, Handle, Size.Width, Size.Height, 0, IntPtr.Zero, NativeConstants.DI_NORMAL);
             }


### PR DESCRIPTION
This fixes an issue when capturing on certain multi-monitor configurations when using the "Show cursor" option. The cursor would be drawn at the incorrect location on the screen.

Here is a showcase of the problem:
In this example, a hotkey was bound to the "Capture entire screen" action.
The monitor on the right is Display 1, and the monitor on the left is Display 2.
![cursor](https://github.com/user-attachments/assets/d677fe72-3a9c-4b84-9e0f-70d6ad31ee30)

Explanation:
In all usages of the `DrawCursor` method, the coordinates to draw the cursor are already correct relative to the screen.
This issue could only be seen in multi-monitor configurations where Desktop 1 is not the top-left most monitor. In these configurations, the offset from the real screen to [the virtual screen](https://learn.microsoft.com/en-us/windows/win32/gdi/the-virtual-screen) would have a negative value, and the cursor was being shifted by this value. Likewise, when Desktop 1 is the top-left most monitor, this issue would not appear as the offset from the real screen to the virtual screen is (0, 0).

This issue was only affecting captures that draw a cursor on the screen, such as "Capture region (Light)", or "Capture entire screen".
This issue does not apply to cursors that are added via the toolbar and handled by the ShapeManager.

Similar to: #5709