### PR TITLE
Capture delay french translation fix

### DIFF
--- a/ShareX/Forms/MainForm.fr.resx
+++ b/ShareX/Forms/MainForm.fr.resx
@@ -688,7 +688,7 @@
     <value>2 secondes</value>
   </data>
   <data name="tsmiTrayScreenshotDelay3.Text" xml:space="preserve">
-    <value>2 secondes</value>
+    <value>3 secondes</value>
   </data>
   <data name="tsmiTrayScreenshotDelay4.Text" xml:space="preserve">
     <value>4 secondes</value>


### PR DESCRIPTION
TrayScreenshotDelay3 had "2 seconds" as value instead of "3 seconds" in french translation