### PR TITLE
Added iOS tagging for 265 video

### DIFF
--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -252,6 +252,7 @@ namespace ShareX.ScreenCaptureLib
                                 args.Append($"-crf {FFmpeg.x264_CRF} ");
                             }
                             args.Append("-pix_fmt yuv420p "); // -pix_fmt yuv420p required otherwise can't stream in Chrome
+                            args.Append("-tag:v hvc1 "); // tagging HEVC stream to be compatible with iOS devices
                             args.Append("-movflags +faststart "); // This will move some information to the beginning of your file and allow the video to begin playing before it is completely downloaded by the viewer
                             break;
                         case FFmpegVideoCodec.libvpx: // https://trac.ffmpeg.org/wiki/Encode/VP8
@@ -268,6 +269,7 @@ namespace ShareX.ScreenCaptureLib
                             args.Append($"-preset {FFmpeg.NVENC_Preset} ");
                             args.Append($"-tune {FFmpeg.NVENC_Tune} ");
                             args.Append($"-b:v {FFmpeg.NVENC_Bitrate}k ");
+                            args.Append("-tag:v hvc1 "); // tagging HEVC stream to be compatible with iOS devices
                             args.Append("-movflags +faststart "); // This will move some information to the beginning of your file and allow the video to begin playing before it is completely downloaded by the viewer
                             break;
                         case FFmpegVideoCodec.h264_amf:

--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -278,11 +278,13 @@ namespace ShareX.ScreenCaptureLib
                             args.Append($"-quality {FFmpeg.AMF_Quality} ");
                             args.Append($"-b:v {FFmpeg.AMF_Bitrate}k ");
                             args.Append("-pix_fmt yuv420p ");
+                            args.Append("-tag:v hvc1 "); // tagging HEVC stream to be compatible with iOS devices
                             break;
                         case FFmpegVideoCodec.h264_qsv: // https://trac.ffmpeg.org/wiki/Hardware/QuickSync
                         case FFmpegVideoCodec.hevc_qsv:
                             args.Append($"-preset {FFmpeg.QSV_Preset} ");
                             args.Append($"-b:v {FFmpeg.QSV_Bitrate}k ");
+                            args.Append("-tag:v hvc1 "); // tagging HEVC stream to be compatible with iOS devices
                             break;
                         case FFmpegVideoCodec.libwebp: // https://www.ffmpeg.org/ffmpeg-codecs.html#libwebp
                             args.Append("-lossless 0 ");


### PR DESCRIPTION
My first pull request, so please be kind.

Adding "-tag:v hvc1" to the h265/HEVC video codec preset args for ffmpeg. This is something that other ffmpeg wrappers like Handbrake do by default, and is because playback of HEVC video on Apple devices fails using the default hev1 tag.

See here for the differences between the tags: https://community.bitmovin.com/t/whats-the-difference-between-hvc1-and-hev1-hevc-codec-tags-for-fmp4/101

See requirement 1.10 here: https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices#2969487

This change should have no other effects in terms of compatibility.