### PR TITLE
fixed #7794: fixed AzureStorages return-url when using custom domains

### DIFF
--- a/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
+++ b/ShareX.UploadersLib/FileUploaders/AzureStorage.cs
@@ -192,7 +192,14 @@ namespace ShareX.UploadersLib.FileUploaders
 
             if (!isRequest && !string.IsNullOrEmpty(AzureStorageCustomDomain))
             {
-                url = URLHelpers.CombineURL(AzureStorageCustomDomain, uploadPath);
+                if (AzureStorageContainer == "$root")
+                {
+                    url = URLHelpers.CombineURL(AzureStorageCustomDomain, uploadPath);
+                }
+                else
+                {
+                    url = URLHelpers.CombineURL(AzureStorageCustomDomain, AzureStorageContainer, uploadPath);
+                }
                 url = URLHelpers.FixPrefix(url);
             }
             else if (!isRequest && AzureStorageContainer == "$root")


### PR DESCRIPTION
The returned url now contains the azure-storage-container when using custom domains.
The behvior for configs **without** custom domains is unchanged

## Custom Domain
![image](https://github.com/user-attachments/assets/d6f8870f-8ca2-424f-bf50-926bc7eefd55)

## Custom Domain with additional upload path

![image](https://github.com/user-attachments/assets/d1258477-c8d2-4838-a077-1eb528e708cd)


## No Custom Domain 
![image](https://github.com/user-attachments/assets/49c87e30-93a9-4bd5-9649-caca3758d4d0)

## No Custom Domain with upload path

![image](https://github.com/user-attachments/assets/55e39695-b274-4a3b-97a6-e120b97b262b)


