### PR TITLE
add border to a highlighter tool

### DIFF
--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -1423,27 +1423,55 @@ namespace ShareX.HelpersLib
 
         public static void HighlightImage(Bitmap bmp, Color highlightColor)
         {
-            HighlightImage(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height), highlightColor);
+            HighlightImage(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height), highlightColor, Color.Red, 0);
         }
 
+        public static void HighlightImage(Bitmap bmp, Color highlightColor, Color borderColor, int borderSize)
+        {
+            HighlightImage(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height), highlightColor, borderColor, borderSize);
+        }
         public static void HighlightImage(Bitmap bmp, Rectangle rect)
         {
-            HighlightImage(bmp, rect, Color.Yellow);
+            HighlightImage(bmp, rect, Color.Yellow, Color.Red, 0);
         }
 
-        public static void HighlightImage(Bitmap bmp, Rectangle rect, Color highlightColor)
+
+        public static void HighlightImage(Bitmap bmp, Rectangle rect, Color highlightColor, Color borderColor, int borderSize)
         {
             using (UnsafeBitmap unsafeBitmap = new UnsafeBitmap(bmp, true))
             {
-                for (int y = rect.Y; y < rect.Height; y++)
+                for (int y = rect.Y + borderSize; y < (rect.Height - borderSize); y++)
                 {
-                    for (int x = rect.X; x < rect.Width; x++)
+                    for (int x = rect.X + borderSize; x < (rect.Width - borderSize); x++)
                     {
                         ColorBgra color = unsafeBitmap.GetPixel(x, y);
                         color.Red = Math.Min(color.Red, highlightColor.R);
                         color.Green = Math.Min(color.Green, highlightColor.G);
                         color.Blue = Math.Min(color.Blue, highlightColor.B);
                         unsafeBitmap.SetPixel(x, y, color);
+                    }
+                }
+                ColorBgra _borderColor = new ColorBgra(borderColor.B, borderColor.G, borderColor.R, borderColor.A);
+                for (int y = rect.Y; y < rect.Height; y++)
+                {
+                    for (int x = rect.X; x < rect.X + borderSize; x++)
+                    {
+                        unsafeBitmap.SetPixel(x, y, _borderColor);
+                    }
+                    for (int x = rect.Width - borderSize; x < rect.Width; x++)
+                    {
+                        unsafeBitmap.SetPixel(x, y, _borderColor);
+                    }
+                }
+                for (int x = rect.X; x < rect.Width; x++)
+                {
+                    for (int y = rect.Y; y < rect.Y + borderSize; y++)
+                    {
+                        unsafeBitmap.SetPixel(x, y, _borderColor);
+                    }
+                    for (int y = rect.Height - borderSize; y < rect.Height; y++)
+                    {
+                        unsafeBitmap.SetPixel(x, y, _borderColor);
                     }
                 }
             }

--- a/ShareX.ScreenCaptureLib/Shapes/Effect/HighlightEffectShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Effect/HighlightEffectShape.cs
@@ -35,21 +35,29 @@ namespace ShareX.ScreenCaptureLib
 
         public override string OverlayText => Resources.Highlight;
 
+        public Color BorderColor { get; set; }
+
+        public int BorderSize { get; set; }
+
         public Color HighlightColor { get; set; }
 
         public override void OnConfigLoad()
         {
+            BorderSize = AnnotationOptions.BorderSize;
+            BorderColor = AnnotationOptions.BorderColor;
             HighlightColor = AnnotationOptions.HighlightColor;
         }
 
         public override void OnConfigSave()
         {
+            AnnotationOptions.BorderSize = BorderSize;
+            AnnotationOptions.BorderColor = BorderColor;
             AnnotationOptions.HighlightColor = HighlightColor;
         }
 
         public override void ApplyEffect(Bitmap bmp)
         {
-            ImageHelpers.HighlightImage(bmp, HighlightColor);
+            ImageHelpers.HighlightImage(bmp, HighlightColor, BorderColor, BorderSize);
         }
     }
 }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -1536,6 +1536,7 @@ namespace ShareX.ScreenCaptureLib
                 case ShapeType.DrawingCursor:
                 case ShapeType.EffectBlur:
                 case ShapeType.EffectPixelate:
+                case ShapeType.EffectHighlight:
                 case ShapeType.ToolCutOut:
                     tsddbShapeOptions.Visible = true;
                     break;
@@ -1569,6 +1570,18 @@ namespace ShareX.ScreenCaptureLib
                     tslnudBorderSize.Visible = true;
                     tsmiShadow.Visible = true;
                     tsmiShadowColor.Visible = true;
+                    break;
+            }
+
+            switch (shapeType)
+            {
+                default:
+                    tsbBorderColor.Visible = false;
+                    tslnudBorderSize.Visible = false;
+                    break;
+                case ShapeType.EffectHighlight:
+                    tsbBorderColor.Visible = true;
+                    tslnudBorderSize.Visible = true;
                     break;
             }
 

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -1550,8 +1550,6 @@ namespace ShareX.ScreenCaptureLib
             switch (shapeType)
             {
                 default:
-                    tsbBorderColor.Visible = false;
-                    tslnudBorderSize.Visible = false;
                     tsmiShadow.Visible = false;
                     tsmiShadowColor.Visible = false;
                     break;
@@ -1566,8 +1564,6 @@ namespace ShareX.ScreenCaptureLib
                 case ShapeType.DrawingSpeechBalloon:
                 case ShapeType.DrawingStep:
                 case ShapeType.DrawingMagnify:
-                    tsbBorderColor.Visible = true;
-                    tslnudBorderSize.Visible = true;
                     tsmiShadow.Visible = true;
                     tsmiShadowColor.Visible = true;
                     break;
@@ -1579,6 +1575,17 @@ namespace ShareX.ScreenCaptureLib
                     tsbBorderColor.Visible = false;
                     tslnudBorderSize.Visible = false;
                     break;
+                case ShapeType.DrawingRectangle:
+                case ShapeType.DrawingEllipse:
+                case ShapeType.DrawingFreehand:
+                case ShapeType.DrawingFreehandArrow:
+                case ShapeType.DrawingLine:
+                case ShapeType.DrawingArrow:
+                case ShapeType.DrawingTextOutline:
+                case ShapeType.DrawingTextBackground:
+                case ShapeType.DrawingSpeechBalloon:
+                case ShapeType.DrawingStep:
+                case ShapeType.DrawingMagnify:
                 case ShapeType.EffectHighlight:
                     tsbBorderColor.Visible = true;
                     tslnudBorderSize.Visible = true;


### PR DESCRIPTION
For my use case, highlighting construction drawings, rectangle with fill doesn't look great.
I prefer the way highlighter works. The only problem was the lack of visual pop.
This patch adds a border to a highlighter tool.