### PR TITLE
Add ClearClipboardAfterCapture option for screenshots

### DIFF
--- a/ShareX.HelpersLib/HelpersOptions.cs
+++ b/ShareX.HelpersLib/HelpersOptions.cs
@@ -44,5 +44,6 @@ namespace ShareX.HelpersLib
         public static bool URLEncodeIgnoreEmoji { get; set; } = false;
         public static Dictionary<string, string> ShareXSpecialFolders { get; set; } = new Dictionary<string, string>();
         public static bool DevMode { get; set; } = false;
+        public static bool ClearClipboardAfterCapture { get; set; } = false;
     }
 }

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -281,6 +281,9 @@ namespace ShareX
         [Category("Drag and drop window"), DefaultValue(255), Description("When you drag file to drop window then opacity will change to this.")]
         public int DropHoverOpacity { get; set; }
 
+        [Category("Clipboard"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
+        public bool ClearClipboardAfterCapture { get; set; }
+
         #endregion Advanced
 
         #endregion Settings Form

--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -230,6 +230,9 @@ namespace ShareX
         [Category("Clipboard"), DefaultValue(false), Description("Default .NET method can't get image with alpha channel from clipboard. When this setting is true, ShareX checks if clipboard contains \"PNG\" or 32 bit \"DIB\" in order to retain image transparency.")]
         public bool UseAlternativeClipboardGetImage { get; set; }
 
+        [Category("Clipboard"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
+        public bool ClearClipboardAfterCapture { get; set; }
+
         [Category("Image"), DefaultValue(true), Description("If JPEG exif contains orientation data then rotate image accordingly.")]
         public bool RotateImageByExifOrientationData { get; set; }
 
@@ -280,9 +283,6 @@ namespace ShareX
 
         [Category("Drag and drop window"), DefaultValue(255), Description("When you drag file to drop window then opacity will change to this.")]
         public int DropHoverOpacity { get; set; }
-
-        [Category("Clipboard"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
-        public bool ClearClipboardAfterCapture { get; set; }
 
         #endregion Advanced
 

--- a/ShareX/CaptureHelpers/CaptureBase.cs
+++ b/ShareX/CaptureHelpers/CaptureBase.cs
@@ -28,6 +28,7 @@ using System;
 using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace ShareX
 {

--- a/ShareX/CaptureHelpers/CaptureBase.cs
+++ b/ShareX/CaptureHelpers/CaptureBase.cs
@@ -101,6 +101,11 @@ namespace ShareX
         {
             if (metadata != null && metadata.Image != null)
             {
+                if (taskSettings.AdvancedSettings.ClearClipboardAfterCapture)
+                {
+                    Clipboard.Clear();
+                }
+
                 TaskHelpers.PlayNotificationSoundAsync(NotificationSound.Capture, taskSettings);
 
                 if (taskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.AnnotateImage) && !AllowAnnotation)

--- a/ShareX/CaptureHelpers/CaptureBase.cs
+++ b/ShareX/CaptureHelpers/CaptureBase.cs
@@ -102,7 +102,7 @@ namespace ShareX
         {
             if (metadata != null && metadata.Image != null)
             {
-                if (taskSettings.AdvancedSettings.ClearClipboardAfterCapture)
+                if (HelpersOptions.ClearClipboardAfterCapture)
                 {
                     Clipboard.Clear();
                 }

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -951,6 +951,7 @@ namespace ShareX
             HelpersOptions.BrowserPath = Program.Settings.BrowserPath;
             HelpersOptions.RecentColors = Program.Settings.RecentColors;
             HelpersOptions.DevMode = Program.Settings.DevMode;
+            HelpersOptions.ClearClipboardAfterCapture = Program.Settings.ClearClipboardAfterCapture;
             Program.UpdateHelpersSpecialFolders();
 
             TaskManager.RecentManager.MaxCount = Program.Settings.RecentTasksMaxCount;

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -487,9 +487,6 @@ namespace ShareX
         [Category("Capture"), DefaultValue(false), Description("Disable annotation support in region capture.")]
         public bool RegionCaptureDisableAnnotation { get; set; }
 
-        [Category("Capture"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
-        public bool ClearClipboardAfterCapture { get; set; }
-
         [Category("Upload"), Description("Files with these file extensions will be uploaded using image uploader."),
         Editor("System.Windows.Forms.Design.StringCollectionEditor,System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
         public List<string> ImageExtensions { get; set; }

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -487,6 +487,9 @@ namespace ShareX
         [Category("Capture"), DefaultValue(false), Description("Disable annotation support in region capture.")]
         public bool RegionCaptureDisableAnnotation { get; set; }
 
+        [Category("Capture"), DefaultValue(false), Description("When you enable this option your clipboard will be cleared directly after you capture a screenshot.")]
+        public bool ClearClipboardAfterCapture { get; set; }
+
         [Category("Upload"), Description("Files with these file extensions will be uploaded using image uploader."),
         Editor("System.Windows.Forms.Design.StringCollectionEditor,System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(UITypeEditor))]
         public List<string> ImageExtensions { get; set; }


### PR DESCRIPTION
Introduce a new boolean property `ClearClipboardAfterCapture` in `ApplicationConfig.cs` and `TaskSettings.cs` to allow users to clear the clipboard after capturing a screenshot. Update `CaptureInternal` in `CaptureBase.cs` to implement this functionality.