### PR TITLE
Disable upload by default

### DIFF
--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -236,7 +236,7 @@ namespace ShareX
         [Category("Image"), DefaultValue(false), Description("Strip color space information chunks from PNG image.")]
         public bool PNGStripColorSpaceInformation { get; set; }
 
-        [Category("Upload"), DefaultValue(false), Description("Can be used to disable uploading application wide.")]
+        [Category("Upload"), DefaultValue(true), Description("Can be used to disable uploading application wide.")]
         public bool DisableUpload { get; set; }
 
         [Category("Upload"), DefaultValue(false), Description("Accept invalid SSL certificates when uploading.")]


### PR DESCRIPTION
Resolves #7535.

This PR simply makes `Program.Settings.DisableUpload` default to true.

If this is not desired, let's discuss about alternative solutions in #7535.