### PR TITLE
Add the option to copy the normalized RGBA colors in the color picker

### DIFF
--- a/ShareX.HelpersLib/Forms/ColorPickerForm.Designer.cs
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.Designer.cs
@@ -78,6 +78,7 @@
             this.tsmiCopyCMYK = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCopyHSB = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCopyDecimal = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiCopyNormalized = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCopyPosition = new System.Windows.Forms.ToolStripMenuItem();
             this.pCursorPosition = new System.Windows.Forms.Panel();
             this.txtY = new System.Windows.Forms.TextBox();
@@ -456,6 +457,7 @@
             this.tsmiCopyCMYK,
             this.tsmiCopyHSB,
             this.tsmiCopyDecimal,
+            this.tsmiCopyNormalized,
             this.tsmiCopyPosition});
             this.cmsCopy.Name = "cmsCopy";
             this.cmsCopy.ShowImageMargin = false;
@@ -496,6 +498,12 @@
             this.tsmiCopyDecimal.Name = "tsmiCopyDecimal";
             resources.ApplyResources(this.tsmiCopyDecimal, "tsmiCopyDecimal");
             this.tsmiCopyDecimal.Click += new System.EventHandler(this.tsmiCopyDecimal_Click);
+            // 
+            // tsmiCopyNormalized
+            // 
+            this.tsmiCopyNormalized.Name = "tsmiCopyNormalized";
+            resources.ApplyResources(this.tsmiCopyNormalized, "tsmiCopyNormalized");
+            this.tsmiCopyNormalized.Click += new System.EventHandler(this.tsmiCopyNormalized_Click);
             // 
             // tsmiCopyPosition
             // 
@@ -747,6 +755,7 @@
         private System.Windows.Forms.ToolStripMenuItem tsmiCopyCMYK;
         private System.Windows.Forms.ToolStripMenuItem tsmiCopyHSB;
         private System.Windows.Forms.ToolStripMenuItem tsmiCopyDecimal;
+        private System.Windows.Forms.ToolStripMenuItem tsmiCopyNormalized;
         private System.Windows.Forms.ToolStripMenuItem tsmiCopyPosition;
         private System.Windows.Forms.Panel pCursorPosition;
         private System.Windows.Forms.Label lblCursorPosition;

--- a/ShareX.HelpersLib/Forms/ColorPickerForm.cs
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.cs
@@ -476,13 +476,12 @@ namespace ShareX.HelpersLib
         private void tsmiCopyNormalized_Click(object sender, EventArgs e)
         {
             RGBA rgba = colorPicker.SelectedColor.RGBA;
-            String formatted = string.Format("{0:0.0}, {1:0.0}, {2:0.0}, {3:0.0}",
-                Convert.ToSingle(rgba.Red) / 255f,
-                Convert.ToSingle(rgba.Green) / 255f,
-                Convert.ToSingle(rgba.Blue) / 255f,
-                Convert.ToSingle(rgba.Alpha) / 255f
-                );
+            float red = rgba.Red / 255f;
+            float green = rgba.Green / 255f;
+            float blue = rgba.Blue / 255f;
+            float alpha = rgba.Alpha / 255f;
 
+            string formatted = $"{ColorHelpers.FormatNormalizedRGBA(red)}, {ColorHelpers.FormatNormalizedRGBA(green)}, {ColorHelpers.FormatNormalizedRGBA(blue)}, {ColorHelpers.FormatNormalizedRGBA(alpha)}";
             ClipboardHelpers.CopyText(formatted);
         }
 

--- a/ShareX.HelpersLib/Forms/ColorPickerForm.cs
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.cs
@@ -473,6 +473,19 @@ namespace ShareX.HelpersLib
             ClipboardHelpers.CopyText(dec.ToString());
         }
 
+        private void tsmiCopyNormalized_Click(object sender, EventArgs e)
+        {
+            RGBA rgba = colorPicker.SelectedColor.RGBA;
+            String formatted = string.Format("{0:0.0}, {1:0.0}, {2:0.0}, {3:0.0}",
+                Convert.ToSingle(rgba.Red) / 255f,
+                Convert.ToSingle(rgba.Green) / 255f,
+                Convert.ToSingle(rgba.Blue) / 255f,
+                Convert.ToSingle(rgba.Alpha) / 255f
+                );
+
+            ClipboardHelpers.CopyText(formatted);
+        }
+
         private void tsmiCopyPosition_Click(object sender, EventArgs e)
         {
             ClipboardHelpers.CopyText($"{txtX.Text}, {txtY.Text}");

--- a/ShareX.HelpersLib/Forms/ColorPickerForm.resx
+++ b/ShareX.HelpersLib/Forms/ColorPickerForm.resx
@@ -1302,6 +1302,12 @@
   <data name="tsmiCopyDecimal.Text" xml:space="preserve">
     <value>Copy decimal</value>
   </data>
+  <data name="tsmiCopyNormalized.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 22</value>
+  </data>
+  <data name="tsmiCopyNormalized.Text" xml:space="preserve">
+    <value>Copy Normalized RGBA</value>
+  </data>
   <data name="tsmiCopyPosition.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 22</value>
   </data>
@@ -1846,6 +1852,12 @@
     <value>tsmiCopyDecimal</value>
   </data>
   <data name="&gt;&gt;tsmiCopyDecimal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsmiCopyNormalized.Name" xml:space="preserve">
+    <value>tsmiCopyNormalized</value>
+  </data>
+  <data name="&gt;&gt;tsmiCopyNormalized.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tsmiCopyPosition.Name" xml:space="preserve">

--- a/ShareX.HelpersLib/Helpers/ColorHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ColorHelpers.cs
@@ -462,5 +462,10 @@ namespace ShareX.HelpersLib
             Color knownColor = FindClosestKnownColor(color);
             return Helpers.GetProperName(knownColor.Name);
         }
+
+        public static string FormatNormalizedRGBA(float value)
+        {
+            return value == Math.Round(value) ? $"{value:0.0}" : value.ToString();
+        }
     }
 }


### PR DESCRIPTION
Hello,
I use the color picker tool frequently, I primarily work on graphics related applications that usually accept normalized colors, between 0 and 1. It would be great to have this functionality in ShareX, it would help my workflow quite a bit (having the colors as constants instead of dividing by 255 every time)

I implemented another `ToolStripMenuItem` in the color picker's `Copy` button. I followed the conventions of the other copy menu items. I formatted the output to include a single zero after the dot in case the number is whole (TIL C# omits all zeros even in floating point types)

The only thing left is to localize the new string I added for the button text.
I hope it is accepable 