### PR TITLE
Proposal: New config/behavior to enable 'Copy to Clipboard' to also run first (before other actions)

### DIFF
--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -229,6 +229,9 @@ namespace ShareX
         [Category("Clipboard"), DefaultValue(false), Description("Default .NET method can't get image with alpha channel from clipboard. When this setting is true, ShareX checks if clipboard contains \"PNG\" or 32 bit \"DIB\" in order to retain image transparency.")]
         public bool UseAlternativeClipboardGetImage { get; set; }
 
+        [Category("Clipboard"), DefaultValue(false), Description("Set to true to run the 'Copy to Clipboard' also as the first post capture action, so the original capture will be immediately copied to clipboard (and preserved even if other post actions are cancelled).")]
+        public bool CopyToClipboardFirst { get; set; }
+
         [Category("Image"), DefaultValue(true), Description("If JPEG exif contains orientation data then rotate image accordingly.")]
         public bool RotateImageByExifOrientationData { get; set; }
 

--- a/ShareX/WorkerTask.cs
+++ b/ShareX/WorkerTask.cs
@@ -614,6 +614,11 @@ namespace ShareX
                 return true;
             }
 
+            if (Program.Settings.CopyToClipboardFirst)
+            {
+                CopyToClipboardIfEnabled();
+            }
+
             if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.BeautifyImage))
             {
                 Image = TaskHelpers.BeautifyImage(Image, Info.TaskSettings);
@@ -645,11 +650,7 @@ namespace ShareX
                 }
             }
 
-            if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.CopyImageToClipboard))
-            {
-                ClipboardHelpers.CopyImage(Image, Info.FileName);
-                DebugHelper.WriteLine("Image copied to clipboard.");
-            }
+            CopyToClipboardIfEnabled();
 
             if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.PinToScreen))
             {
@@ -753,6 +754,15 @@ namespace ShareX
             }
 
             return true;
+        }
+
+        private void CopyToClipboardIfEnabled()
+        {
+            if (Info.TaskSettings.AfterCaptureJob.HasFlag(AfterCaptureTasks.CopyImageToClipboard))
+            {
+                ClipboardHelpers.CopyImage(Image, Info.FileName);
+                DebugHelper.WriteLine("Image copied to clipboard.");
+            }
         }
 
         private void DoFileJobs()


### PR DESCRIPTION
Added configuration to enable the 'Copy to Clipboard' to run also as first action, enabling user to preserve the captured image even if other post actions are cancelled.

This behavior must be enabled thru application configuration ('Advanced' tab).

Addresses #7052

![Issue7052](https://github.com/user-attachments/assets/726af2fb-b52b-45eb-9e63-8e325b24b8b3)
