### PR TITLE
Add CQP options to screen recorder hardware encoders

### DIFF
--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.Designer.cs
@@ -38,6 +38,9 @@
             this.nudGIFBayerScale = new System.Windows.Forms.NumericUpDown();
             this.cbGIFDither = new System.Windows.Forms.ComboBox();
             this.cbGIFStatsMode = new System.Windows.Forms.ComboBox();
+            this.nudQSVQP = new System.Windows.Forms.NumericUpDown();
+            this.nudAMFQP = new System.Windows.Forms.NumericUpDown();
+            this.nudNVENCQP = new System.Windows.Forms.NumericUpDown();
             this.cbVideoCodec = new System.Windows.Forms.ComboBox();
             this.btnFFmpegBrowse = new System.Windows.Forms.Button();
             this.txtFFmpegPath = new System.Windows.Forms.TextBox();
@@ -69,6 +72,7 @@
             this.cbVorbisQuality = new System.Windows.Forms.ComboBox();
             this.lblVorbisQuality = new System.Windows.Forms.Label();
             this.tpMP3 = new System.Windows.Forms.TabPage();
+            this.cbMP3Quality = new System.Windows.Forms.ComboBox();
             this.lblMP3Quality = new System.Windows.Forms.Label();
             this.tcFFmpegVideoCodecs = new ShareX.HelpersLib.TablessControl();
             this.tpX264 = new System.Windows.Forms.TabPage();
@@ -84,6 +88,7 @@
             this.tpXvid = new System.Windows.Forms.TabPage();
             this.lblXvidQscale = new System.Windows.Forms.Label();
             this.tpNVENC = new System.Windows.Forms.TabPage();
+            this.cbNVENCUseBitrate = new System.Windows.Forms.CheckBox();
             this.cbNVENCTune = new System.Windows.Forms.ComboBox();
             this.lblNVENCTune = new System.Windows.Forms.Label();
             this.lblNVENCBitrateK = new System.Windows.Forms.Label();
@@ -95,6 +100,7 @@
             this.lblGIFDither = new System.Windows.Forms.Label();
             this.lblGIFStatsMode = new System.Windows.Forms.Label();
             this.tpAMF = new System.Windows.Forms.TabPage();
+            this.cbAMFUseBitrate = new System.Windows.Forms.CheckBox();
             this.lblAMFBitrateK = new System.Windows.Forms.Label();
             this.nudAMFBitrate = new System.Windows.Forms.NumericUpDown();
             this.lblAMFBitrate = new System.Windows.Forms.Label();
@@ -103,17 +109,20 @@
             this.cbAMFUsage = new System.Windows.Forms.ComboBox();
             this.lblAMFUsage = new System.Windows.Forms.Label();
             this.tpQSV = new System.Windows.Forms.TabPage();
+            this.cbQSVUseBitrate = new System.Windows.Forms.CheckBox();
             this.lblQSVBitrateK = new System.Windows.Forms.Label();
             this.cbQSVPreset = new System.Windows.Forms.ComboBox();
             this.lblQSVPreset = new System.Windows.Forms.Label();
             this.nudQSVBitrate = new System.Windows.Forms.NumericUpDown();
             this.lblQSVBitrate = new System.Windows.Forms.Label();
             this.btnResetOptions = new System.Windows.Forms.Button();
-            this.cbMP3Quality = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.pbx264PresetWarning)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudx264CRF)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudXvidQscale)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudGIFBayerScale)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQSVQP)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAMFQP)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudNVENCQP)).BeginInit();
             this.tcFFmpegAudioCodecs.SuspendLayout();
             this.tpAAC.SuspendLayout();
             this.tpOpus.SuspendLayout();
@@ -234,6 +243,57 @@
             this.cbGIFStatsMode.Name = "cbGIFStatsMode";
             this.ttHelpTip.SetToolTip(this.cbGIFStatsMode, resources.GetString("cbGIFStatsMode.ToolTip"));
             this.cbGIFStatsMode.SelectedIndexChanged += new System.EventHandler(this.cbGIFStatsMode_SelectedIndexChanged);
+            // 
+            // nudQSVQP
+            // 
+            resources.ApplyResources(this.nudQSVQP, "nudQSVQP");
+            this.nudQSVQP.Maximum = new decimal(new int[] {
+            51,
+            0,
+            0,
+            0});
+            this.nudQSVQP.Name = "nudQSVQP";
+            this.ttHelpTip.SetToolTip(this.nudQSVQP, resources.GetString("nudQSVQP.ToolTip"));
+            this.nudQSVQP.Value = new decimal(new int[] {
+            23,
+            0,
+            0,
+            0});
+            this.nudQSVQP.ValueChanged += new System.EventHandler(this.nudQSVQP_ValueChanged);
+            // 
+            // nudAMFQP
+            // 
+            resources.ApplyResources(this.nudAMFQP, "nudAMFQP");
+            this.nudAMFQP.Maximum = new decimal(new int[] {
+            51,
+            0,
+            0,
+            0});
+            this.nudAMFQP.Name = "nudAMFQP";
+            this.ttHelpTip.SetToolTip(this.nudAMFQP, resources.GetString("nudAMFQP.ToolTip"));
+            this.nudAMFQP.Value = new decimal(new int[] {
+            23,
+            0,
+            0,
+            0});
+            this.nudAMFQP.ValueChanged += new System.EventHandler(this.nudAMFQP_ValueChanged);
+            // 
+            // nudNVENCQP
+            // 
+            resources.ApplyResources(this.nudNVENCQP, "nudNVENCQP");
+            this.nudNVENCQP.Maximum = new decimal(new int[] {
+            51,
+            0,
+            0,
+            0});
+            this.nudNVENCQP.Name = "nudNVENCQP";
+            this.ttHelpTip.SetToolTip(this.nudNVENCQP, resources.GetString("nudNVENCQP.ToolTip"));
+            this.nudNVENCQP.Value = new decimal(new int[] {
+            23,
+            0,
+            0,
+            0});
+            this.nudNVENCQP.ValueChanged += new System.EventHandler(this.nudNVENCQP_ValueChanged);
             // 
             // cbVideoCodec
             // 
@@ -447,6 +507,14 @@
             resources.ApplyResources(this.tpMP3, "tpMP3");
             this.tpMP3.Name = "tpMP3";
             // 
+            // cbMP3Quality
+            // 
+            this.cbMP3Quality.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbMP3Quality.FormattingEnabled = true;
+            resources.ApplyResources(this.cbMP3Quality, "cbMP3Quality");
+            this.cbMP3Quality.Name = "cbMP3Quality";
+            this.cbMP3Quality.SelectedIndexChanged += new System.EventHandler(this.cbMP3Quality_SelectedIndexChanged);
+            // 
             // lblMP3Quality
             // 
             resources.ApplyResources(this.lblMP3Quality, "lblMP3Quality");
@@ -584,6 +652,8 @@
             // tpNVENC
             // 
             this.tpNVENC.BackColor = System.Drawing.SystemColors.Window;
+            this.tpNVENC.Controls.Add(this.nudNVENCQP);
+            this.tpNVENC.Controls.Add(this.cbNVENCUseBitrate);
             this.tpNVENC.Controls.Add(this.cbNVENCTune);
             this.tpNVENC.Controls.Add(this.lblNVENCTune);
             this.tpNVENC.Controls.Add(this.lblNVENCBitrateK);
@@ -593,6 +663,13 @@
             this.tpNVENC.Controls.Add(this.lblNVENCBitrate);
             resources.ApplyResources(this.tpNVENC, "tpNVENC");
             this.tpNVENC.Name = "tpNVENC";
+            // 
+            // cbNVENCUseBitrate
+            // 
+            resources.ApplyResources(this.cbNVENCUseBitrate, "cbNVENCUseBitrate");
+            this.cbNVENCUseBitrate.Name = "cbNVENCUseBitrate";
+            this.cbNVENCUseBitrate.UseVisualStyleBackColor = true;
+            this.cbNVENCUseBitrate.CheckedChanged += new System.EventHandler(this.cbNVENCUseBitrate_CheckedChanged);
             // 
             // cbNVENCTune
             // 
@@ -674,6 +751,8 @@
             // 
             // tpAMF
             // 
+            this.tpAMF.Controls.Add(this.cbAMFUseBitrate);
+            this.tpAMF.Controls.Add(this.nudAMFQP);
             this.tpAMF.Controls.Add(this.lblAMFBitrateK);
             this.tpAMF.Controls.Add(this.nudAMFBitrate);
             this.tpAMF.Controls.Add(this.lblAMFBitrate);
@@ -684,6 +763,13 @@
             resources.ApplyResources(this.tpAMF, "tpAMF");
             this.tpAMF.Name = "tpAMF";
             this.tpAMF.UseVisualStyleBackColor = true;
+            // 
+            // cbAMFUseBitrate
+            // 
+            resources.ApplyResources(this.cbAMFUseBitrate, "cbAMFUseBitrate");
+            this.cbAMFUseBitrate.Name = "cbAMFUseBitrate";
+            this.cbAMFUseBitrate.UseVisualStyleBackColor = true;
+            this.cbAMFUseBitrate.CheckedChanged += new System.EventHandler(this.cbAMFUseBitrate_CheckedChanged);
             // 
             // lblAMFBitrateK
             // 
@@ -744,6 +830,8 @@
             // 
             // tpQSV
             // 
+            this.tpQSV.Controls.Add(this.nudQSVQP);
+            this.tpQSV.Controls.Add(this.cbQSVUseBitrate);
             this.tpQSV.Controls.Add(this.lblQSVBitrateK);
             this.tpQSV.Controls.Add(this.cbQSVPreset);
             this.tpQSV.Controls.Add(this.lblQSVPreset);
@@ -752,6 +840,13 @@
             resources.ApplyResources(this.tpQSV, "tpQSV");
             this.tpQSV.Name = "tpQSV";
             this.tpQSV.UseVisualStyleBackColor = true;
+            // 
+            // cbQSVUseBitrate
+            // 
+            resources.ApplyResources(this.cbQSVUseBitrate, "cbQSVUseBitrate");
+            this.cbQSVUseBitrate.Name = "cbQSVUseBitrate";
+            this.cbQSVUseBitrate.UseVisualStyleBackColor = true;
+            this.cbQSVUseBitrate.CheckedChanged += new System.EventHandler(this.cbQSVUseBitrate_CheckedChanged);
             // 
             // lblQSVBitrateK
             // 
@@ -804,14 +899,6 @@
             this.btnResetOptions.UseVisualStyleBackColor = true;
             this.btnResetOptions.Click += new System.EventHandler(this.btnResetOptions_Click);
             // 
-            // cbMP3Quality
-            // 
-            this.cbMP3Quality.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cbMP3Quality.FormattingEnabled = true;
-            resources.ApplyResources(this.cbMP3Quality, "cbMP3Quality");
-            this.cbMP3Quality.Name = "cbMP3Quality";
-            this.cbMP3Quality.SelectedIndexChanged += new System.EventHandler(this.cbMP3Quality_SelectedIndexChanged);
-            // 
             // FFmpegOptionsForm
             // 
             resources.ApplyResources(this, "$this");
@@ -848,6 +935,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.nudx264CRF)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudXvidQscale)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudGIFBayerScale)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQSVQP)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAMFQP)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudNVENCQP)).EndInit();
             this.tcFFmpegAudioCodecs.ResumeLayout(false);
             this.tpAAC.ResumeLayout(false);
             this.tpAAC.PerformLayout();
@@ -964,5 +1054,11 @@
         private System.Windows.Forms.Label lblOpusBitrateK;
         private System.Windows.Forms.ComboBox cbVorbisQuality;
         private System.Windows.Forms.ComboBox cbMP3Quality;
+        private System.Windows.Forms.CheckBox cbQSVUseBitrate;
+        private System.Windows.Forms.NumericUpDown nudAMFQP;
+        private System.Windows.Forms.NumericUpDown nudQSVQP;
+        private System.Windows.Forms.NumericUpDown nudNVENCQP;
+        private System.Windows.Forms.CheckBox cbNVENCUseBitrate;
+        private System.Windows.Forms.CheckBox cbAMFUseBitrate;
     }
 }

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.cs
@@ -103,6 +103,8 @@ namespace ShareX.ScreenCaptureLib
             nudNVENCBitrate.SetValue(Options.FFmpeg.NVENC_Bitrate);
             cbNVENCPreset.SelectedIndex = (int)Options.FFmpeg.NVENC_Preset;
             cbNVENCTune.SelectedIndex = (int)Options.FFmpeg.NVENC_Tune;
+            nudNVENCQP.SetValue(Options.FFmpeg.NVENC_QP);
+            cbNVENCUseBitrate.Checked = Options.FFmpeg.NVENC_Use_Bitrate;
 
             // GIF
             cbGIFStatsMode.SelectedIndex = (int)Options.FFmpeg.GIFStatsMode;
@@ -113,10 +115,14 @@ namespace ShareX.ScreenCaptureLib
             cbAMFUsage.SelectedIndex = (int)Options.FFmpeg.AMF_Usage;
             cbAMFQuality.SelectedIndex = (int)Options.FFmpeg.AMF_Quality;
             nudAMFBitrate.SetValue(Options.FFmpeg.AMF_Bitrate);
+            nudAMFQP.SetValue(Options.FFmpeg.AMF_QP);
+            cbAMFUseBitrate.Checked = Options.FFmpeg.AMF_Use_Bitrate;
 
             // QuickSync
             cbQSVPreset.SelectedIndex = (int)Options.FFmpeg.QSV_Preset;
             nudQSVBitrate.SetValue(Options.FFmpeg.QSV_Bitrate);
+            nudQSVQP.SetValue(Options.FFmpeg.QSV_QP);
+            cbQSVUseBitrate.Checked = Options.FFmpeg.QSV_Use_Bitrate;
 
             // AAC
             int indexAACBitrate = cbAACBitrate.Items.IndexOf(Options.FFmpeg.AAC_Bitrate);
@@ -261,6 +267,18 @@ namespace ShareX.ScreenCaptureLib
                 nudx264CRF.Visible = !Options.FFmpeg.x264_Use_Bitrate;
                 nudx264Bitrate.Visible = lblx264BitrateK.Visible = Options.FFmpeg.x264_Use_Bitrate;
                 pbx264PresetWarning.Visible = (FFmpegPreset)cbx264Preset.SelectedIndex > FFmpegPreset.fast;
+
+                lblNVENCBitrate.Text = Options.FFmpeg.NVENC_Use_Bitrate ? Resources.Bitrate : Resources.QP;
+                nudNVENCQP.Visible = !Options.FFmpeg.NVENC_Use_Bitrate;
+                nudNVENCBitrate.Visible = lblNVENCBitrateK.Visible = Options.FFmpeg.NVENC_Use_Bitrate;
+
+                lblAMFBitrate.Text = Options.FFmpeg.AMF_Use_Bitrate ? Resources.Bitrate : Resources.QP;
+                nudAMFQP.Visible = !Options.FFmpeg.AMF_Use_Bitrate;
+                nudAMFBitrate.Visible = lblAMFBitrateK.Visible = Options.FFmpeg.AMF_Use_Bitrate;
+
+                lblQSVBitrate.Text = Options.FFmpeg.QSV_Use_Bitrate ? Resources.Bitrate : Resources.QP;
+                nudQSVQP.Visible = !Options.FFmpeg.QSV_Use_Bitrate;
+                nudQSVBitrate.Visible = lblQSVBitrateK.Visible = Options.FFmpeg.QSV_Use_Bitrate;
 
                 if (!Options.FFmpeg.UseCustomCommands)
                 {
@@ -463,6 +481,18 @@ namespace ShareX.ScreenCaptureLib
             UpdateUI();
         }
 
+        private void nudNVENCQP_ValueChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.NVENC_QP = (int)nudNVENCQP.Value;
+            UpdateUI();
+        }
+
+        private void cbNVENCUseBitrate_CheckedChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.NVENC_Use_Bitrate = cbNVENCUseBitrate.Checked;
+            UpdateUI();
+        }
+
         private void cbNVENCPreset_SelectedIndexChanged(object sender, EventArgs e)
         {
             Options.FFmpeg.NVENC_Preset = (FFmpegNVENCPreset)cbNVENCPreset.SelectedIndex;
@@ -510,6 +540,17 @@ namespace ShareX.ScreenCaptureLib
             Options.FFmpeg.AMF_Bitrate = (int)nudAMFBitrate.Value;
             UpdateUI();
         }
+        private void nudAMFQP_ValueChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.AMF_QP = (int)nudAMFQP.Value;
+            UpdateUI();
+        }
+
+        private void cbAMFUseBitrate_CheckedChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.AMF_Use_Bitrate = cbAMFUseBitrate.Checked;
+            UpdateUI();
+        }
 
         private void cbQSVPreset_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -520,6 +561,17 @@ namespace ShareX.ScreenCaptureLib
         private void nudQSVBitrate_ValueChanged(object sender, EventArgs e)
         {
             Options.FFmpeg.QSV_Bitrate = (int)nudQSVBitrate.Value;
+            UpdateUI();
+        }
+        private void nudQSVQP_ValueChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.QSV_QP = (int)nudQSVQP.Value;
+            UpdateUI();
+        }
+
+        private void cbQSVUseBitrate_CheckedChanged(object sender, EventArgs e)
+        {
+            Options.FFmpeg.QSV_Use_Bitrate = cbQSVUseBitrate.Checked;
             UpdateUI();
         }
 

--- a/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
+++ b/ShareX.ScreenCaptureLib/Forms/FFmpegOptionsForm.resx
@@ -117,14 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ttHelpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ttHelpTip.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>17, 17</value>
-  </metadata>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="pbx264PresetWarning.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pbx264PresetWarning.Location" type="System.Drawing.Point, System.Drawing">
     <value>224, 30</value>
   </data>
@@ -312,6 +312,90 @@ A higher value means bad quality, but a low file size.</value>
   </data>
   <data name="&gt;&gt;cbGIFStatsMode.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="nudQSVQP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>72, 4</value>
+  </data>
+  <data name="nudQSVQP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 20</value>
+  </data>
+  <data name="nudQSVQP.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="nudQSVQP.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="nudQSVQP.ToolTip" xml:space="preserve">
+    <value>Quantization Parameter (QP): The value can be between 0-51, where 0 is lossless, 30 is default, and 51 is the worst possible.
+A higher value means bad quality, but a low file size.</value>
+  </data>
+  <data name="&gt;&gt;nudQSVQP.Name" xml:space="preserve">
+    <value>nudQSVQP</value>
+  </data>
+  <data name="&gt;&gt;nudQSVQP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudQSVQP.Parent" xml:space="preserve">
+    <value>tpQSV</value>
+  </data>
+  <data name="&gt;&gt;nudQSVQP.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="nudAMFQP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>72, 4</value>
+  </data>
+  <data name="nudAMFQP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 20</value>
+  </data>
+  <data name="nudAMFQP.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="nudAMFQP.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="nudAMFQP.ToolTip" xml:space="preserve">
+    <value>Quantization Parameter (QP): The value can be between 0-51, where 0 is lossless, 30 is default, and 51 is the worst possible.
+A higher value means bad quality, but a low file size.</value>
+  </data>
+  <data name="&gt;&gt;nudAMFQP.Name" xml:space="preserve">
+    <value>nudAMFQP</value>
+  </data>
+  <data name="&gt;&gt;nudAMFQP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudAMFQP.Parent" xml:space="preserve">
+    <value>tpAMF</value>
+  </data>
+  <data name="&gt;&gt;nudAMFQP.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="nudNVENCQP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>72, 4</value>
+  </data>
+  <data name="nudNVENCQP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 20</value>
+  </data>
+  <data name="nudNVENCQP.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="nudNVENCQP.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="nudNVENCQP.ToolTip" xml:space="preserve">
+    <value>Quantization Parameter (QP): The value can be between 0-51, where 0 is lossless, 30 is default, and 51 is the worst possible.
+A higher value means bad quality, but a low file size.</value>
+  </data>
+  <data name="&gt;&gt;nudNVENCQP.Name" xml:space="preserve">
+    <value>nudNVENCQP</value>
+  </data>
+  <data name="&gt;&gt;nudNVENCQP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudNVENCQP.Parent" xml:space="preserve">
+    <value>tpNVENC</value>
+  </data>
+  <data name="&gt;&gt;nudNVENCQP.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="cbVideoCodec.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 160</value>
@@ -1169,205 +1253,13 @@ A higher value means bad quality, but a low file size.</value>
     <value>tcFFmpegAudioCodecs</value>
   </data>
   <data name="&gt;&gt;tcFFmpegAudioCodecs.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.TablessControl, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>ShareX.HelpersLib.TablessControl, ShareX.HelpersLib, Version=17.1.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tcFFmpegAudioCodecs.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tcFFmpegAudioCodecs.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Name" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpX264.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.Name" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpVpx.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.Name" xml:space="preserve">
-    <value>tpXvid</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpXvid.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Name" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.Name" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpGIF.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.Name" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpAMF.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.Name" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpQSV.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tcFFmpegVideoCodecs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 184</value>
-  </data>
-  <data name="tcFFmpegVideoCodecs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>312, 80</value>
-  </data>
-  <data name="tcFFmpegVideoCodecs.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;tcFFmpegVideoCodecs.Name" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tcFFmpegVideoCodecs.Type" xml:space="preserve">
-    <value>ShareX.HelpersLib.TablessControl, ShareX.HelpersLib, Version=15.0.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;tcFFmpegVideoCodecs.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tcFFmpegVideoCodecs.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Name" xml:space="preserve">
-    <value>lblx264BitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264BitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Name" xml:space="preserve">
-    <value>cbx264UseBitrate</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;cbx264UseBitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Name" xml:space="preserve">
-    <value>lblx264CRF</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264CRF.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.Name" xml:space="preserve">
-    <value>lblx264Preset</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;lblx264Preset.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Name" xml:space="preserve">
-    <value>nudx264Bitrate</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.Parent" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;nudx264Bitrate.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tpX264.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpX264.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpX264.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 36</value>
-  </data>
-  <data name="tpX264.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpX264.Text" xml:space="preserve">
-    <value>x264 / x265</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Name" xml:space="preserve">
-    <value>tpX264</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpX264.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpX264.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblx264BitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1513,65 +1405,32 @@ A higher value means bad quality, but a low file size.</value>
   <data name="&gt;&gt;nudx264Bitrate.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Name" xml:space="preserve">
-    <value>lblVP8BitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;lblVP8BitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Name" xml:space="preserve">
-    <value>nudVP8Bitrate</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;nudVP8Bitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Name" xml:space="preserve">
-    <value>lblVP8Bitrate</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.Parent" xml:space="preserve">
-    <value>tpVpx</value>
-  </data>
-  <data name="&gt;&gt;lblVP8Bitrate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tpVpx.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpX264.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 40</value>
   </data>
-  <data name="tpVpx.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpX264.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpX264.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 36</value>
   </data>
-  <data name="tpVpx.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="tpX264.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="tpVpx.Text" xml:space="preserve">
-    <value>VP8</value>
+  <data name="tpX264.Text" xml:space="preserve">
+    <value>x264 / x265</value>
   </data>
-  <data name="&gt;&gt;tpVpx.Name" xml:space="preserve">
-    <value>tpVpx</value>
+  <data name="&gt;&gt;tpX264.Name" xml:space="preserve">
+    <value>tpX264</value>
   </data>
-  <data name="&gt;&gt;tpVpx.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpX264.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpVpx.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpX264.Parent" xml:space="preserve">
     <value>tcFFmpegVideoCodecs</value>
   </data>
-  <data name="&gt;&gt;tpVpx.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tpX264.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblVP8BitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1657,6 +1516,48 @@ A higher value means bad quality, but a low file size.</value>
   <data name="&gt;&gt;lblVP8Bitrate.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="tpVpx.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpVpx.Size" type="System.Drawing.Size, System.Drawing">
+    <value>304, 36</value>
+  </data>
+  <data name="tpVpx.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tpVpx.Text" xml:space="preserve">
+    <value>VP8</value>
+  </data>
+  <data name="&gt;&gt;tpVpx.Name" xml:space="preserve">
+    <value>tpVpx</value>
+  </data>
+  <data name="&gt;&gt;tpVpx.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpVpx.Parent" xml:space="preserve">
+    <value>tcFFmpegVideoCodecs</value>
+  </data>
+  <data name="&gt;&gt;tpVpx.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblXvidQscale.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblXvidQscale.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblXvidQscale.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 8</value>
+  </data>
+  <data name="lblXvidQscale.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 13</value>
+  </data>
+  <data name="lblXvidQscale.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblXvidQscale.Text" xml:space="preserve">
+    <value>Variable bitrate:</value>
+  </data>
   <data name="&gt;&gt;lblXvidQscale.Name" xml:space="preserve">
     <value>lblXvidQscale</value>
   </data>
@@ -1693,146 +1594,35 @@ A higher value means bad quality, but a low file size.</value>
   <data name="&gt;&gt;tpXvid.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="lblXvidQscale.AutoSize" type="System.Boolean, mscorlib">
+  <data name="cbNVENCUseBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblXvidQscale.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="cbNVENCUseBitrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblXvidQscale.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 8</value>
+  <data name="cbNVENCUseBitrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 6</value>
   </data>
-  <data name="lblXvidQscale.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 13</value>
+  <data name="cbNVENCUseBitrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 17</value>
   </data>
-  <data name="lblXvidQscale.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="cbNVENCUseBitrate.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
   </data>
-  <data name="lblXvidQscale.Text" xml:space="preserve">
-    <value>Variable bitrate:</value>
+  <data name="cbNVENCUseBitrate.Text" xml:space="preserve">
+    <value>Use bitrate</value>
   </data>
-  <data name="&gt;&gt;lblXvidQscale.Name" xml:space="preserve">
-    <value>lblXvidQscale</value>
+  <data name="&gt;&gt;cbNVENCUseBitrate.Name" xml:space="preserve">
+    <value>cbNVENCUseBitrate</value>
   </data>
-  <data name="&gt;&gt;lblXvidQscale.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cbNVENCUseBitrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblXvidQscale.Parent" xml:space="preserve">
-    <value>tpXvid</value>
+  <data name="&gt;&gt;cbNVENCUseBitrate.Parent" xml:space="preserve">
+    <value>tpNVENC</value>
   </data>
-  <data name="&gt;&gt;lblXvidQscale.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;cbNVENCUseBitrate.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Name" xml:space="preserve">
-    <value>cbNVENCTune</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCTune.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.Name" xml:space="preserve">
-    <value>lblNVENCTune</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCTune.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Name" xml:space="preserve">
-    <value>lblNVENCBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrateK.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Name" xml:space="preserve">
-    <value>cbNVENCPreset</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;cbNVENCPreset.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.Name" xml:space="preserve">
-    <value>lblNVENCPreset</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCPreset.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Name" xml:space="preserve">
-    <value>nudNVENCBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;nudNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Name" xml:space="preserve">
-    <value>lblNVENCBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.Parent" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;lblNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpNVENC.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 40</value>
-  </data>
-  <data name="tpNVENC.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpNVENC.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 36</value>
-  </data>
-  <data name="tpNVENC.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="tpNVENC.Text" xml:space="preserve">
-    <value>NVENC</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Name" xml:space="preserve">
-    <value>tpNVENC</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.Parent" xml:space="preserve">
-    <value>tcFFmpegVideoCodecs</value>
-  </data>
-  <data name="&gt;&gt;tpNVENC.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="cbNVENCTune.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 52</value>
@@ -1853,7 +1643,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;cbNVENCTune.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="lblNVENCTune.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1883,7 +1673,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;lblNVENCTune.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblNVENCBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1913,7 +1703,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;lblNVENCBitrateK.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="cbNVENCPreset.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
@@ -1934,7 +1724,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;cbNVENCPreset.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblNVENCPreset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1964,7 +1754,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;lblNVENCPreset.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="nudNVENCBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
@@ -1988,7 +1778,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;nudNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblNVENCBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2018,58 +1808,34 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpNVENC</value>
   </data>
   <data name="&gt;&gt;lblNVENCBitrate.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;lblGIFDither.Name" xml:space="preserve">
-    <value>lblGIFDither</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.Parent" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;lblGIFDither.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Name" xml:space="preserve">
-    <value>lblGIFStatsMode</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.Parent" xml:space="preserve">
-    <value>tpGIF</value>
-  </data>
-  <data name="&gt;&gt;lblGIFStatsMode.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpGIF.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpNVENC.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 40</value>
   </data>
-  <data name="tpGIF.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpNVENC.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpGIF.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpNVENC.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 36</value>
   </data>
-  <data name="tpGIF.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="tpNVENC.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="tpGIF.Text" xml:space="preserve">
-    <value>GIF</value>
+  <data name="tpNVENC.Text" xml:space="preserve">
+    <value>NVENC</value>
   </data>
-  <data name="&gt;&gt;tpGIF.Name" xml:space="preserve">
-    <value>tpGIF</value>
+  <data name="&gt;&gt;tpNVENC.Name" xml:space="preserve">
+    <value>tpNVENC</value>
   </data>
-  <data name="&gt;&gt;tpGIF.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpNVENC.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpGIF.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpNVENC.Parent" xml:space="preserve">
     <value>tcFFmpegVideoCodecs</value>
   </data>
-  <data name="&gt;&gt;tpGIF.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;tpNVENC.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lblGIFDither.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2131,116 +1897,62 @@ A higher value means bad quality, but a low file size.</value>
   <data name="&gt;&gt;lblGIFStatsMode.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Name" xml:space="preserve">
-    <value>lblAMFBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Name" xml:space="preserve">
-    <value>nudAMFBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;nudAMFBitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.Name" xml:space="preserve">
-    <value>lblAMFBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFBitrate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Name" xml:space="preserve">
-    <value>cbAMFQuality</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;cbAMFQuality.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.Name" xml:space="preserve">
-    <value>lblAMFQuality</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFQuality.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Name" xml:space="preserve">
-    <value>cbAMFUsage</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;cbAMFUsage.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Name" xml:space="preserve">
-    <value>lblAMFUsage</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.Parent" xml:space="preserve">
-    <value>tpAMF</value>
-  </data>
-  <data name="&gt;&gt;lblAMFUsage.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpAMF.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpGIF.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 40</value>
   </data>
-  <data name="tpAMF.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpGIF.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpAMF.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpGIF.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 36</value>
   </data>
-  <data name="tpAMF.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="tpGIF.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
-  <data name="tpAMF.Text" xml:space="preserve">
-    <value>AMF</value>
+  <data name="tpGIF.Text" xml:space="preserve">
+    <value>GIF</value>
   </data>
-  <data name="&gt;&gt;tpAMF.Name" xml:space="preserve">
-    <value>tpAMF</value>
+  <data name="&gt;&gt;tpGIF.Name" xml:space="preserve">
+    <value>tpGIF</value>
   </data>
-  <data name="&gt;&gt;tpAMF.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpGIF.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpAMF.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpGIF.Parent" xml:space="preserve">
     <value>tcFFmpegVideoCodecs</value>
   </data>
-  <data name="&gt;&gt;tpAMF.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;tpGIF.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="cbAMFUseBitrate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAMFUseBitrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbAMFUseBitrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 6</value>
+  </data>
+  <data name="cbAMFUseBitrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 17</value>
+  </data>
+  <data name="cbAMFUseBitrate.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="cbAMFUseBitrate.Text" xml:space="preserve">
+    <value>Use bitrate</value>
+  </data>
+  <data name="&gt;&gt;cbAMFUseBitrate.Name" xml:space="preserve">
+    <value>cbAMFUseBitrate</value>
+  </data>
+  <data name="&gt;&gt;cbAMFUseBitrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAMFUseBitrate.Parent" xml:space="preserve">
+    <value>tpAMF</value>
+  </data>
+  <data name="&gt;&gt;cbAMFUseBitrate.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblAMFBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2270,7 +1982,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;lblAMFBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="nudAMFBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
@@ -2294,7 +2006,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;nudAMFBitrate.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblAMFBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2324,7 +2036,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;lblAMFBitrate.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="cbAMFQuality.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 52</value>
@@ -2345,7 +2057,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;cbAMFQuality.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblAMFQuality.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2375,7 +2087,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;lblAMFQuality.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="cbAMFUsage.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
@@ -2396,7 +2108,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;cbAMFUsage.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblAMFUsage.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2426,94 +2138,64 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpAMF</value>
   </data>
   <data name="&gt;&gt;lblAMFUsage.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Name" xml:space="preserve">
-    <value>lblQSVBitrateK</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Name" xml:space="preserve">
-    <value>cbQSVPreset</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;cbQSVPreset.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.Name" xml:space="preserve">
-    <value>lblQSVPreset</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVPreset.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Name" xml:space="preserve">
-    <value>nudQSVBitrate</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;nudQSVBitrate.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Name" xml:space="preserve">
-    <value>lblQSVBitrate</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.Parent" xml:space="preserve">
-    <value>tpQSV</value>
-  </data>
-  <data name="&gt;&gt;lblQSVBitrate.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tpQSV.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tpAMF.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 40</value>
   </data>
-  <data name="tpQSV.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tpAMF.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
-  <data name="tpQSV.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tpAMF.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 36</value>
   </data>
-  <data name="tpQSV.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+  <data name="tpAMF.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
-  <data name="tpQSV.Text" xml:space="preserve">
-    <value>QuickSync</value>
+  <data name="tpAMF.Text" xml:space="preserve">
+    <value>AMF</value>
   </data>
-  <data name="&gt;&gt;tpQSV.Name" xml:space="preserve">
-    <value>tpQSV</value>
+  <data name="&gt;&gt;tpAMF.Name" xml:space="preserve">
+    <value>tpAMF</value>
   </data>
-  <data name="&gt;&gt;tpQSV.Type" xml:space="preserve">
+  <data name="&gt;&gt;tpAMF.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tpQSV.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tpAMF.Parent" xml:space="preserve">
     <value>tcFFmpegVideoCodecs</value>
   </data>
-  <data name="&gt;&gt;tpQSV.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;tpAMF.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="cbQSVUseBitrate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbQSVUseBitrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbQSVUseBitrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 6</value>
+  </data>
+  <data name="cbQSVUseBitrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 17</value>
+  </data>
+  <data name="cbQSVUseBitrate.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="cbQSVUseBitrate.Text" xml:space="preserve">
+    <value>Use bitrate</value>
+  </data>
+  <data name="&gt;&gt;cbQSVUseBitrate.Name" xml:space="preserve">
+    <value>cbQSVUseBitrate</value>
+  </data>
+  <data name="&gt;&gt;cbQSVUseBitrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbQSVUseBitrate.Parent" xml:space="preserve">
+    <value>tpQSV</value>
+  </data>
+  <data name="&gt;&gt;cbQSVUseBitrate.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="lblQSVBitrateK.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2543,7 +2225,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpQSV</value>
   </data>
   <data name="&gt;&gt;lblQSVBitrateK.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="cbQSVPreset.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 28</value>
@@ -2564,7 +2246,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpQSV</value>
   </data>
   <data name="&gt;&gt;cbQSVPreset.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblQSVPreset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2594,7 +2276,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpQSV</value>
   </data>
   <data name="&gt;&gt;lblQSVPreset.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="nudQSVBitrate.Location" type="System.Drawing.Point, System.Drawing">
     <value>72, 4</value>
@@ -2618,7 +2300,7 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpQSV</value>
   </data>
   <data name="&gt;&gt;nudQSVBitrate.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblQSVBitrate.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2648,7 +2330,55 @@ A higher value means bad quality, but a low file size.</value>
     <value>tpQSV</value>
   </data>
   <data name="&gt;&gt;lblQSVBitrate.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
+  </data>
+  <data name="tpQSV.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 40</value>
+  </data>
+  <data name="tpQSV.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpQSV.Size" type="System.Drawing.Size, System.Drawing">
+    <value>304, 36</value>
+  </data>
+  <data name="tpQSV.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tpQSV.Text" xml:space="preserve">
+    <value>QuickSync</value>
+  </data>
+  <data name="&gt;&gt;tpQSV.Name" xml:space="preserve">
+    <value>tpQSV</value>
+  </data>
+  <data name="&gt;&gt;tpQSV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpQSV.Parent" xml:space="preserve">
+    <value>tcFFmpegVideoCodecs</value>
+  </data>
+  <data name="&gt;&gt;tpQSV.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tcFFmpegVideoCodecs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 184</value>
+  </data>
+  <data name="tcFFmpegVideoCodecs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>312, 80</value>
+  </data>
+  <data name="tcFFmpegVideoCodecs.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;tcFFmpegVideoCodecs.Name" xml:space="preserve">
+    <value>tcFFmpegVideoCodecs</value>
+  </data>
+  <data name="&gt;&gt;tcFFmpegVideoCodecs.Type" xml:space="preserve">
+    <value>ShareX.HelpersLib.TablessControl, ShareX.HelpersLib, Version=17.1.1.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;tcFFmpegVideoCodecs.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tcFFmpegVideoCodecs.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="btnResetOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>504, 416</value>
@@ -2674,12 +2404,12 @@ A higher value means bad quality, but a low file size.</value>
   <data name="&gt;&gt;btnResetOptions.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  </data>
+  <data name="$this.TrayHeight" type="System.Int32, mscorlib">
     <value>60</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>96, 96</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1339,6 +1339,15 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to QP:.
+        /// </summary>
+        internal static string QP {
+            get {
+                return ResourceManager.GetString("QP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rectangle capture light.
         /// </summary>
         internal static string RectangleLight_InitializeComponent_Rectangle_capture_light {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ar-YE.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ar-YE.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,92 +117,47 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>العرض:</value>
-  </data>
-  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
-    <value>هل تريد إعادة ضبط الخيارات؟</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>انتظار...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>قيمة الخطوة الأولى:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>تكبير حتى الملائمة عند الفتح</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>إلغاء المهمة (ESC)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>حجم الصفحة...</value>
+  <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
+    <value>رفع الصورة  (Ctrl+U)</value>
   </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>لقطة شاشة</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>لون التمييز...</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>لقطة شاشة</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>التقاط الشاشة النشطة</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>التقاط الشاشة كاملة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>التقاط المنطقة السابقة</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>التقاط الشاشة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>التقاط مساحات</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>نقاط المركز:</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>إضافة مؤثرات للصورة...</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>إغلاق (Esc)</value>
-  </data>
-  <data name="Confirmation" xml:space="preserve">
-    <value>التأكيد</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>استئناف المهمة (المسطرة أو نقرة بالزر الأيمن)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>نسخ الصورة إلى الحافظة (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>نصف قطر الزاوية:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>اقتصاص الصورة...</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>نوع المؤشّر:</value>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>تبديل إلى أداة الرسم بعد تحديد الشكل</value>
   </data>
   <data name="CutOutEffectSize" xml:space="preserve">
     <value>حجم مؤثرات الاقتطاع:</value>
   </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>مؤثرات الاقتطاع:</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>إضافة مؤثرات للصورة...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>انعكاس أفقي</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>وضع تعدد المناطق</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>حجم البكسل:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>حجم الصورة...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
     <value>حذف</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>حذف الكل</value>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>تطبيق التغييرات ومتابعة المهمة (Enter)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>التظليل</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>لون التظليل...</value>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>فتح صفحة وٍب اختصارات لوحة المفاتيح...</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
     <value>تكرار</value>
@@ -210,294 +165,339 @@
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>تعديل</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>قائمة المحرّر</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>أسلوب البدء الخاص بالمحرّر:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>تفعيل مؤثرات الحركة</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>جارٍ الترميز...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>لون التعبئة...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>وضع منطقة التسجيل الثابتة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>انعكاس أفقي</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>انعكاس عمودي</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>استخدام نقاط بيضاء لحواف مربع تغيير الحجم</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>تذكّر حالة القائمة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
-    <value>إعادة</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>جارٍ المعالجة...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>طباعة الصورة... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>اتجاه رأس السهم:</value>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>تم حفظ الصورة</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>إغلاق المحرّر بشكل تلقائي عند بدء مهمة</value>
   </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>نسخ الصورة تلقائيًا إلى الحافظة</value>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>تراجع</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>اقتصاص تلقائي لصورة...</value>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>إعادة</value>
   </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>معدل البِت:</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>تشويش</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>شدة التمويه:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>لون الحدود...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>حجم الحدود:</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>مظهر الحدود:</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>قفل القائمة</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>عدد بكسلات العدسة المكبرة:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>حجم بكسلات العدسة المكبرة:</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>قوة التكبير:</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>حجم أيقونات القائمة:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>وضع تعدد المناطق</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>صورة جديدة...</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>سطر جديد: Ctrl + Enter, موافق: Enter</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>سطر جديد: Ctrl + Enter, موافق: Enter</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>فتح ملف صورة...</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>فتح صفحة وٍب اختصارات لوحة المفاتيح...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>الخيارات</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>لصق الصورة/النص</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>إيقاف مؤقت</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>حجم البكسل:</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>تشويش</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>لقطة مستطيلة فاتحة</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>لقطة مستطيلة شفافة</value>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>محرّر الصور</value>
   </data>
   <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
     <value>التقاط منطقة</value>
   </data>
-  <data name="Resume" xml:space="preserve">
-    <value>متابعة</value>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>وضع منطقة التسجيل الثابتة</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>تدوير 180°</value>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>الحافظة لا تحتوي على صورة.</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>تدوير 90°</value>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>سطر جديد: Ctrl + Enter, موافق: Enter</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>تدوير 90° معاكس</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>تشغيل مهام ما بعد الالتقاط (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>حفظ  الصورة (Ctrl+S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>حفظ الصورة باسم... (Ctrl+Shift+S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>تحريك إلى الخلف</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>التقاط الشاشة</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
     <value>إرسال إلى الخلف</value>
   </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - محرّر الصور</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>التقاط الشاشة النشطة</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>عرض معدل الإطارات FPS</value>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>تحريك إلى الأمام</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>عرض العدسة المكبرة</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>عرض معلومات الموضع و الحجم</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>عدسة تكبير مربعة</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>بدء</value>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>تدوير 90° معاكس</value>
   </data>
   <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
     <value>بدء الالتقاط</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>نوع الخطوة:</value>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>وضع التوليد:</value>
   </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>إيقاف</value>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>العرض:</value>
   </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>إيقاف</value>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>انقر لإيقاف تسجيل الشاشة.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>نقاط المركز:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>الخيارات</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>مظهر الحدود:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>لقطة شاشة</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>سيتم إلغاء التسجيل، هل أنت متأكد؟</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>فتح ملف صورة...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>جارٍ المعالجة...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>انتظار...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>تدوير 90°</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>إغلاق (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>قيمة الخطوة الأولى:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>لقطة شاشة</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>تمييز</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>قوة التكبير:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>نصف قطر الزاوية:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>معدل البِت:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>طباعة الصورة... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>عرض معدل الإطارات FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>سطر جديد: Ctrl + Enter, موافق: Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>نوع المؤشّر:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>تحديد الملف ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>التظليل</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>عدسة تكبير مربعة</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>متابعة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>أسلوب البدء الخاص بالمحرّر:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>تم حفظ الصورة</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>اتجاه رأس السهم:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>التقاط الشاشة كاملة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>التقاط مساحات</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>لقطة مستطيلة فاتحة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>حفظ  الصورة (Ctrl+S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>صورة جديدة...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>تشويش</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>جارٍ الترميز...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>شدة التمويه:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>رفع الصورة</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>تفعيل مؤثرات الحركة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>تحريك إلى الخلف</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>الارتفاع:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>تم نسخ الصورة</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>لون التعبئة...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>حفظ الصورة باسم... (Ctrl+Shift+S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>استئناف المهمة (المسطرة أو نقرة بالزر الأيمن)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>حجم الخط:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>حجم الصفحة...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>حجم أيقونات القائمة:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>انعكاس عمودي</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>اقتصاص تلقائي لصورة...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>تشويش</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>قفل القائمة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>إرسال إلى المقدمة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>تدوير 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>استخدام نقاط بيضاء لحواف مربع تغيير الحجم</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>التقاط المنطقة السابقة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>إدراج لقطة من الشاشة...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>حذف الكل</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>نسخ الصورة تلقائيًا إلى الحافظة</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>حجم الحدود:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>قائمة المحرّر</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>لصق الصورة/النص</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>اقتصاص الصورة...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>لون الحدود...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>عرض العدسة المكبرة</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>إيقاف مؤقت</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - محرّر الصور</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>لون التظليل...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>تبديل إلى أداة التحديد بعد رسم شكل</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>لقطة مستطيلة شفافة</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>عرض معلومات الموضع و الحجم</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>بدء</value>
   </data>
   <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
     <value>إيقاف الالتقاط</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>تبديل إلى أداة الرسم بعد تحديد الشكل</value>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>نوع الخطوة:</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>تبديل إلى أداة التحديد بعد رسم شكل</value>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>نسخ الصورة إلى الحافظة (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>إظهار علامة التقاطع على الشاشة</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>الصورة</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>عدد بكسلات العدسة المكبرة:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>سيتم إغلاق النافذة قبل فتح صفحة وب اختصارات لوحة المفاتيح، هل تريد المتابعة؟</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>تقييد معدل الإطارات FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>إدراج ملف صورة...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>تكبير حتى الملائمة عند الفتح</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>تلميح: يمكنك تحريك الصورة بواسطة النقر باستمرار على زر الفأرة الأوسط والتحريك.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>تشغيل مهام ما بعد الالتقاط (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>تذكّر حالة القائمة</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>مؤثرات الاقتطاع:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>حجم بكسلات العدسة المكبرة:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>خيارات الأدوات</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>انقر لبدء تسجيل الشاشة.</value>
+  </data>
+  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
+    <value>هل تريد إعادة ضبط الخيارات؟</value>
+  </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>التأكيد</value>
+  </data>
+  <data name="ImageURL" xml:space="preserve">
+    <value>عنوان URL للصورة</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>هناك تعديلات غير محفوظة.
 
 هل تريد حفظ التغييرات وإغلاق محرّر الصور؟</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>سيتم إغلاق النافذة قبل فتح صفحة وب اختصارات لوحة المفاتيح، هل تريد المتابعة؟</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>تلميح: يمكنك تحريك الصورة بواسطة النقر باستمرار على زر الفأرة الأوسط والتحريك.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>خيارات الأدوات</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>تراجع</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
-    <value>رفع الصورة  (Ctrl+U)</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>انقر لبدء تسجيل الشاشة.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>انقر لإيقاف تسجيل الشاشة.</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>الحافظة لا تحتوي على صورة.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>حجم الخط:</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>تقييد معدل الإطارات FPS:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>الارتفاع:</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>تمييز</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>لون التمييز...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>تطبيق التغييرات ومتابعة المهمة (Enter)</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>سيتم إلغاء التسجيل، هل أنت متأكد؟</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>تحريك إلى الأمام</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>إرسال إلى المقدمة</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>تحديد الملف ffmpeg.exe</value>
-  </data>
   <data name="CutOutBackgroundColor" xml:space="preserve">
     <value>تخلص من لون الخلفية...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>الصورة</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>تم نسخ الصورة</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>محرّر الصور</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>تم حفظ الصورة</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>تم حفظ الصورة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>حجم الصورة...</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>رفع الصورة</value>
-  </data>
-  <data name="ImageURL" xml:space="preserve">
-    <value>عنوان URL للصورة</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>إدراج ملف صورة...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>إدراج لقطة من الشاشة...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>وضع التوليد:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>إظهار علامة التقاطع على الشاشة</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.de.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.de.resx
@@ -117,176 +117,38 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Nach ffmpeg.exe suchen</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Bereichsaufnahme</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Rechteckaufnahme einfach</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Aufnahme</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Aufnahme Stoppen</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Aufnahme Starten</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Rechteckaufnahme Transparent</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Rahmenfarbe...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Rahmengröße:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Füllfarbe...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Eckenradius:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Pixelgröße:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Hervorhebungsfarbe...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Optionen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Positions- und Größeninformation anzeigen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Lupe anzeigen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Breite:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Höhe:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>FPS anzeigen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Animationen aktivieren</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Bearbeiten</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Rückgängig</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Löschen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Alles löschen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Eine Ebene nach vorne</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Eine Ebene nach hinten</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>In den Vordergrund</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>In den Hintergrund</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Bild speichern</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Bild speichern unter... (Strg + Umschalt + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Bild in Zwischenablage kopieren</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Aufgabe abbrechen (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Bild hochladen</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Bild drucken... (Strg + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Letzten Bereich aufnehmen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Aufnehmen</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Bildeditor</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Bild</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Bildgröße...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Um 90° im Uhrzeigersinn drehen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Um 90° gegen den Uhrzeigersinn drehen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Um 180° drehen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Horizontal spiegeln</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Vertikal spiegeln</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Bild/Text einfügen</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Lupenpixelanzahl:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Lupenpixelgröße:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Bildschirmweites Steuerkreuz anzeigen</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Einfache Größenänderungspunkte verwenden</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Menüzustand merken</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Aufgaben nach der Aufnahme ausführen (Eingabe)</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Bildeffekte hinzufügen...</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Bildeditor</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Mehrbereichs-Modus</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Aufgabe abbrechen (Esc)</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Hervorhebungsfarbe...</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Wechsel zum Zeichenwerkzeug nach der Formauswahl</value>
   </data>
   <data name="CutOutEffectSize" xml:space="preserve">
     <value>Effektgröße ausschneiden:</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Bildeffekte hinzufügen...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Horizontal spiegeln</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Mehrbereichs-Modus</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Pixelgröße:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Bildgröße...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Löschen</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
     <value>Änderungen übernehmen &amp; Aufgabe fortsetzen (Enter)</value>
@@ -297,14 +159,26 @@
   <data name="Duplicate" xml:space="preserve">
     <value>Duplikat</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Bearbeiten</value>
+  </data>
   <data name="ImageSaved" xml:space="preserve">
     <value>Bild gespeichert</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>Editor bei Aufgabe automatisch schließen</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Rückgängig</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
     <value>Wiederherstellen</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Bildeditor</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Bereichsaufnahme</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
     <value>Modus Bereich mit fester Größe</value>
@@ -318,11 +192,26 @@
   <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
     <value>Monitor aufnehmen</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>In den Hintergrund</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
     <value>Aktiven Monitor aufnehmen</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Eine Ebene nach vorne</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Um 90° gegen den Uhrzeigersinn drehen</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Aufnahme Starten</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>Interpolationsmodus:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Breite:</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
     <value>Klicken Sie, um die Aufnahme zu beenden.</value>
@@ -330,8 +219,17 @@
   <data name="ShapeManager_CenterPoints" xml:space="preserve">
     <value>Punkte zentrieren:</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Optionen</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>Randstil:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Aufnehmen</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
   </data>
   <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
     <value>Sind Sie sicher, dass Sie diese Aufnahme abbrechen möchten?</value>
@@ -345,11 +243,17 @@
   <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
     <value>Warten...</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Um 90° im Uhrzeigersinn drehen</value>
+  </data>
   <data name="CloseEsc" xml:space="preserve">
     <value>Schließen (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
     <value>Wert des ersten Schritts:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Aufnahme</value>
   </data>
   <data name="Highlight" xml:space="preserve">
     <value>Hervorheben</value>
@@ -357,11 +261,23 @@
   <data name="MagnifyStrength" xml:space="preserve">
     <value>Stärke vergrößern:</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Eckenradius:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Bild drucken... (Strg + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>FPS anzeigen</value>
+  </data>
   <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
     <value>Neue Zeile: Enter, OK: Strg + Enter</value>
   </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>Cursor-Typ:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Nach ffmpeg.exe suchen</value>
   </data>
   <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
     <value>Schlagschatten</value>
@@ -387,6 +303,12 @@
   <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
     <value>Bereiche aufnehmen</value>
   </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Rechteckaufnahme einfach</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Bild speichern</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
     <value>Neues Bild...</value>
   </data>
@@ -402,8 +324,23 @@
   <data name="ImageUploading" xml:space="preserve">
     <value>Bild hochladen</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Animationen aktivieren</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Eine Ebene nach hinten</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Höhe:</value>
+  </data>
   <data name="ImageCopied" xml:space="preserve">
     <value>Bild kopiert</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Füllfarbe...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Bild speichern unter... (Strg + Umschalt + S)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
     <value>Aufgabe fortsetzen (Leertaste oder Rechtsklick)</value>
@@ -417,6 +354,9 @@
   <data name="MenuIconSize" xml:space="preserve">
     <value>Größe der Menüsymbole:</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Vertikal spiegeln</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
     <value>Bild automatisch zuschneiden...</value>
   </data>
@@ -426,17 +366,47 @@
   <data name="LockMenu" xml:space="preserve">
     <value>Menü sperren</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>In den Vordergrund</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Um 180° drehen</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Einfache Größenänderungspunkte verwenden</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Letzten Bereich aufnehmen</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
     <value>Bild vom Bildschirm einfügen...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Alles löschen</value>
   </data>
   <data name="AutoCopyImageToClipboard" xml:space="preserve">
     <value>Bild automatisch in die Zwischenablage kopieren</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Rahmengröße:</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
     <value>Editormenü</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Bild/Text einfügen</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>Bild zuschneiden...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Rahmenfarbe...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Lupe anzeigen</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Bildeditor</value>
   </data>
   <data name="DropShadowColor" xml:space="preserve">
     <value>Farbe des Schlagschattens...</value>
@@ -444,8 +414,29 @@
   <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
     <value>Nach dem Zeichnen einer Form zum Auswahlwerkzeug wechseln</value>
   </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Rechteckaufnahme Transparent</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Positions- und Größeninformation anzeigen</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Aufnahme Stoppen</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
     <value>Schritttyp:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Bild in Zwischenablage kopieren</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Bildschirmweites Steuerkreuz anzeigen</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Bild</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Lupenpixelanzahl:</value>
   </data>
   <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
     <value>Dieses Fenster wird geschlossen, bevor die Tastenkürzel-Webseite geöffnet wird. Möchten Sie fortfahren?</value>
@@ -459,8 +450,17 @@
   <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
     <value>Tipp: Sie können das Bild schwenken, indem Sie die mittlere Maustaste gedrückt halten und die Maus ziehen.</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Aufgaben nach der Aufnahme ausführen (Eingabe)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Menüzustand merken</value>
+  </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Ausschneide-Effekt:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Lupenpixelgröße:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>Werkzeugoptionen</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.es-MX.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.es-MX.resx
@@ -117,274 +117,274 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Captura de región</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>El portapapeles no contiene ninguna imagen.</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Buscar ffmpeg.exe</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Captura de rectángulo simple</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} An: {2} Al: {3}</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Captura de rectángulo transparente</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Editor de imágenes</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Editor de imágenes</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Consejo: para desplazarse por la imagen, mantener pulsado el botón medio del ratón y arrastrar.</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Detener captura</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Iniciar captura</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Puntos medios:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Radio de desenfoque:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Color de borde...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Grosor de borde:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Capturar</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Capturar monitor activo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Capturar pantalla completa</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Capturar monitor</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Curvatura de esquinas:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Habilitar animaciones</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Color de relleno:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Modo de región con tamaño fijo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Alto:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Color de resalto:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Número de píxeles de la lupa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Tamaño del píxel de la lupa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Modo de varias regiones:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opciones</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Tamaño del píxel:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Recordar estado de menú</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Mostrar FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Mostrar lupa</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Mostrar posición y tamaño</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Mostrar retículo:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Lupa cuadrada</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Ancho:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Menú de anotaciones</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Aplica cambios y continuar tarea (Intro)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Cerrar editor al terminar</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Recorte automático...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Enviar adelante</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Enviar al frente</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>Cancelar tarea (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Tamaño del lienzo:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Capturar regiones</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Continuar tarea (Espacio o clic derecho)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiar imagen al portapapeles (Ctrl+C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Recortar imagen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Borrar</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Borrar todo</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Sombra</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Editar</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Modo de inicio de editor:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Voltear en horizontal</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Voltear en vertical</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Tamaño de la tipografía:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Imagen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Tamaño de la imagen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Insertar archivo de imagen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Insertar imagen desde pantalla...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Modo de interpolación</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Capturar última región</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Nueva imagen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Abrir archivo de imagen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Pegar imagen o texto</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Imprimir imagen... (Ctrl+P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Girar 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Girar 90° a la derecha</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Girar 90° a la izquierda</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Ejecutar tareas de después de capturar (Intro)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Guardar imagen (Ctrl+S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Guardar imagen como... (Ctrl+Mayús+S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Enviar detrás</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>Enviar al fondo</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Deshacer</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Subir imagen (Ctrl+U)</value>
   </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Tipo de puntero:</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Capturar</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Detener</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Valor del primer paso:</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Cerrar (Esc)</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Color de sombra...</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Agregar efectos...</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Usar vértices simples al cambiar el tamaño</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Amplitud de la lupa:</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Abrir página web de atajos de teclado...</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Color de resalto:</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Cambiar a herramienta de dibujo después de seleccionar la forma</value>
   </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Agregar efectos...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Voltear en horizontal</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Detener</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Modo de varias regiones:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Tamaño del píxel:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Tamaño de la imagen...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Borrar</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Aplica cambios y continuar tarea (Intro)</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Abrir página web de atajos de teclado...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Cerrar editor al terminar</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Editor de imágenes</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Captura de región</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Modo de región con tamaño fijo</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>El portapapeles no contiene ninguna imagen.</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Capturar monitor</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>Enviar al fondo</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Capturar monitor activo</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Enviar adelante</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Girar 90° a la izquierda</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Iniciar captura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Modo de interpolación</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Ancho:</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Puntos medios:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opciones</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Capturar</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} An: {2} Al: {3}</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Abrir archivo de imagen...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Girar 90° a la derecha</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Cerrar (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Valor del primer paso:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Capturar</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Amplitud de la lupa:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Curvatura de esquinas:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Imprimir imagen... (Ctrl+P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Mostrar FPS</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Tipo de puntero:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Buscar ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Sombra</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Lupa cuadrada</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Modo de inicio de editor:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Capturar pantalla completa</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Capturar regiones</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Captura de rectángulo simple</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Guardar imagen (Ctrl+S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Nueva imagen...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Radio de desenfoque:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Habilitar animaciones</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Enviar detrás</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Alto:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Color de relleno:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Guardar imagen como... (Ctrl+Mayús+S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Continuar tarea (Espacio o clic derecho)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Tamaño de la tipografía:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Tamaño del lienzo:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Voltear en vertical</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Recorte automático...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Enviar al frente</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Girar 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Usar vértices simples al cambiar el tamaño</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Capturar última región</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Insertar imagen desde pantalla...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Borrar todo</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Grosor de borde:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Menú de anotaciones</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Pegar imagen o texto</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Recortar imagen...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Color de borde...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Mostrar lupa</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Editor de imágenes</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Color de sombra...</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
     <value>Cambiar a herramienta de selección después de dibujar una forma</value>
   </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Captura de rectángulo transparente</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Mostrar posición y tamaño</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Detener captura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copiar imagen al portapapeles (Ctrl+C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Mostrar retículo:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Imagen</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Número de píxeles de la lupa:</value>
+  </data>
   <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
     <value>Esta ventana se cerrará antes de abrir la página web de atajos de teclado. ¿Desea continuar?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Insertar archivo de imagen...</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Consejo: para desplazarse por la imagen, mantener pulsado el botón medio del ratón y arrastrar.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Ejecutar tareas de después de capturar (Intro)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Recordar estado de menú</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Tamaño del píxel de la lupa:</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.es.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.es.resx
@@ -117,17 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Capturar región</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
   <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
     <value>Buscar ffmpeg.exe</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Captura de rectángulo ligero</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Capturar región</value>
   </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Captura de rectángulo transparente</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
@@ -117,68 +117,68 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>پهنا:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>مقدار اولین گام:</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>انصراف از وظیفه (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>آپلود عکس (Ctrl + U)</value>
   </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>توقف ضبط</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>اضافه کردن افکت های عکس...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>چرخاندن افقی تصویر</value>
   </data>
   <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
     <value>توقف</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>نشان دادن ذره بین</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - ویرایشگر عکس</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>فرستادن به پشت</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>فرستادن به جلو</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>عکس را ذخیره کن (Ctrl + S)</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>ناحیه ضبط</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>تنظیمات</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>عکس جدید ...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>ویرایش</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>حذف</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>حذف همه</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>ناحیه های ضبط</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>اندازه پیکسل:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>سایز عکس...</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>تغییرات را اعمال کن و وظیفه را ادامه بده (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>ویرایش</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>برگرداندن</value>
+  </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>ویرایشگر عکس</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>ناحیه ضبط</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>ضبط صفحه نمایش</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>فرستادن به پشت</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>ضبط صفحه نمایش جاری</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>آوردن به جلو</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>۹۰ درجه در جهت خلاف عقربه ساعت بچرخان</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>شروع ضبط</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>پهنا:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>تنظیمات</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
     <value>ضبط</value>
@@ -189,6 +189,9 @@
   <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
     <value>۹۰ درجه در جهت عقربه های ساعت بچرخان</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>مقدار اولین گام:</value>
+  </data>
   <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
     <value>ضبط</value>
   </data>
@@ -198,11 +201,26 @@
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>نوع کرسر:</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>حذف سایه عکس </value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
     <value>ضبط تمام صفحه</value>
   </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>شروع ضبط</value>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>ناحیه های ضبط</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>عکس را ذخیره کن (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>عکس جدید ...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>انیمیشن را فعال کن</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>فرستادن به جلو</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
     <value>ارتفاع:</value>
@@ -210,29 +228,17 @@
   <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
     <value>پرکردن رنگ ...</value>
   </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>اضافه کردن افکت های عکس...</value>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>عکس را با عنوان ... ذخیره کن (Ctrl + Shift + S)</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>ضبط صفحه نمایش جاری</value>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>ادامه دادن وظیفه (کلید space یا راست کلیک)</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>ضبط صفحه نمایش</value>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>اندازه فونت:</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>انیمیشن را فعال کن</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>اندازه پیکسل:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>وضعیت منو را به خاطر داشته باش.</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>اطلاعات اندازه و مکان را نشان بده</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>تغییرات را اعمال کن و وظیفه را ادامه بده (Enter)</value>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>چرخاندن عمودی تصویر</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
     <value>عکس را بصورت خودکار برش بده...</value>
@@ -240,29 +246,35 @@
   <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
     <value>اوردن به جلو</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>انصراف از وظیفه (Esc)</value>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>۱۸۰ درجه بچرخان</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>ادامه دادن وظیفه (کلید space یا راست کلیک)</value>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>وارد کردن عکس از صفحه ...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>کپی کردن تصویر به کلیپ بورد (Ctrl + C)</value>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>حذف همه</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>چسباندن عکس یا متن</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>بریدن عکس ...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>حذف سایه عکس </value>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>نشان دادن ذره بین</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>چرخاندن افقی تصویر</value>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - ویرایشگر عکس</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>چرخاندن عمودی تصویر</value>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>اطلاعات اندازه و مکان را نشان بده</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>اندازه فونت:</value>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>توقف ضبط</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>کپی کردن تصویر به کلیپ بورد (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
     <value>عکس</value>
@@ -270,19 +282,7 @@
   <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
     <value>فایل عکس را وارد کن....</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>وارد کردن عکس از صفحه ...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>چسباندن عکس یا متن</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>۱۸۰ درجه بچرخان</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>عکس را با عنوان ... ذخیره کن (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>برگرداندن</value>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>وضعیت منو را به خاطر داشته باش.</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.fr.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.fr.resx
@@ -117,320 +117,128 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Chercher ffmpeg.exe</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X : {0} Y : {1} L : {2} H : {3}</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Capturer une région</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Capture rectangle transparent</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Capture rectangulaire simple</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Capturer</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Arrêter</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Arrêter la capture</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Démarrer la capture</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Afficher la loupe</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Largeur :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Hauteur :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Capturer l'écran</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Capturer l'écran actif</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Options</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Afficher les IPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Mode multi région</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Taille des pixels de la loupe :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Nombre de pixels de la loupe :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Loupe de forme carrée</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Capture plein écran</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Couleur des bordures...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Taille des bordures :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Taille des pixels :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Rayon du flou :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Rayon des coins :</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Couleur de remplissage...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Couleur de surlignage...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Afficher les infos sur la position et la taille</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Mode région à taille fixe</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Afficher la large croix sur l'écran</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Continuer la tâche (Espace ou clic droit)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Modifier</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Enregistrer l'image (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Enregistrer l'image en tant que... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Supprimer</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Supprimer tout</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Annuler</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>Envoyer en fond</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Mettre au premier plan</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Envoyer vers l'arrière</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Avancer</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Capturer des régions</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Imprimer une image ... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Capturer</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Annuler la tâche (Échap)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Mettre en ligne une image</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Annuler la tâche (Échap)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Activer les animations</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Mémoriser l'état du menu</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copier l'image dans le presse-papier</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Capturer la dernière région</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Exécuter après les tâches de capture</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Appliquer les modifications et continuer la tâche (Entrée)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Ombre portée</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Éditeur d'image</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Éditeur d'image</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Type du curseur :</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Ajouter des effets d'image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Rognage automatique de l'image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Taille du canevas...</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Fermer (Esc)</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Le presse-papier ne contient pas d'image.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Rogner l'image...</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Couleur de l'ombre portée...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Mode de démarrage de l'éditeur :</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Miroir horizontal</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Miroir vertical</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Taille de police :</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Rotation à 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Rotation à 90° en sens horaire</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Rotation à 90° en sens anti-horaire</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Image</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Taille d'image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Nouvelle image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Ouvrir un fichier image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Coller image/texte</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Menu annotations</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Valeur du premier incrément :</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Mode d'interpolation :</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Force du grossissement :</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Insérer un fichier image...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Insérer une image depuis l'écran...</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Couleur de surlignage...</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Basculer vers l'outil de dessin après avoir sélectionné la forme</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Cette fenêtre va se fermer avant d'ouvrir la page web des raccourcis clavier. Voulez-vous continuer ?</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Taille de l'effet de découpe :</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Ajouter des effets d'image...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Miroir horizontal</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Arrêter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Mode multi région</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Taille des pixels :</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Taille d'image...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Appliquer les modifications et continuer la tâche (Entrée)</value>
   </data>
   <data name="OpenKeybindsPage" xml:space="preserve">
     <value>Ouvrir la page web des raccourcis clavier...</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Basculer vers l'outil de sélection après avoir dessiné la forme</value>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Dupliquer</value>
   </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Astuce : Vous pouvez déplacer l'image en maintenant enfoncé le bouton central de la souris et en glissant.</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Utiliser des petites poignées de redimensionnement</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Points de centrage :</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Fermer automatiquement l'éditeur lors du lancement d'une tâche</value>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Modifier</value>
   </data>
   <data name="ImageSaved" xml:space="preserve">
     <value>Image enregistrée</value>
   </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Image enregistrée</value>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Fermer automatiquement l'éditeur lors du lancement d'une tâche</value>
   </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Dupliquer</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Image copiée</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Taille des icônes du menu :</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Direction de la tête de flêche :</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Mise en ligne de l'image</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Nouvelle ligne : Ctrl + Entrée, OK : Entrée</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Nouvelle ligne : Entrée, OK : Ctrl + Entrée</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Verrouiller le menu</value>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Annuler</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
     <value>Rétablir</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Taille de l'effet de découpe :</value>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Éditeur d'image</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Capturer une région</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Mode région à taille fixe</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Le presse-papier ne contient pas d'image.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Nouvelle ligne : Ctrl + Entrée, OK : Entrée</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Capturer l'écran</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>Envoyer en fond</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Capturer l'écran actif</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Avancer</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Rotation à 90° en sens anti-horaire</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Démarrer la capture</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Mode d'interpolation :</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Largeur :</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
     <value>Cliquer pour arrêter l'enregistrement.</value>
   </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Points de centrage :</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Options</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>Style de bord :</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Capturer</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X : {0} Y : {1} L : {2} H : {3}</value>
+  </data>
   <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
     <value>Voulez-vous vraiment annuler cet enregistrement ?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Ouvrir un fichier image...</value>
   </data>
   <data name="Processing" xml:space="preserve">
     <value>Traitement...</value>
@@ -438,14 +246,77 @@
   <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
     <value>Attente...</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Rotation à 90° en sens horaire</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Fermer (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Valeur du premier incrément :</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Capturer</value>
+  </data>
   <data name="Highlight" xml:space="preserve">
     <value>Surligner</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Force du grossissement :</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Rayon des coins :</value>
   </data>
   <data name="Bitrate" xml:space="preserve">
     <value>Bitrate :</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Imprimer une image ... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Afficher les IPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Nouvelle ligne : Entrée, OK : Ctrl + Entrée</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Type du curseur :</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Chercher ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Ombre portée</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Loupe de forme carrée</value>
+  </data>
   <data name="Resume" xml:space="preserve">
     <value>Reprendre</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Mode de démarrage de l'éditeur :</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Image enregistrée</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Direction de la tête de flêche :</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Capture plein écran</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Capturer des régions</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Capture rectangulaire simple</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Enregistrer l'image (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Nouvelle image...</value>
   </data>
   <data name="Blur" xml:space="preserve">
     <value>Flouter</value>
@@ -453,26 +324,155 @@
   <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
     <value>Encodage...</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Rayon du flou :</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Mise en ligne de l'image</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Activer les animations</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Envoyer vers l'arrière</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Hauteur :</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Image copiée</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Couleur de remplissage...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Enregistrer l'image en tant que... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Continuer la tâche (Espace ou clic droit)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Taille de police :</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Taille du canevas...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Taille des icônes du menu :</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Miroir vertical</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Rognage automatique de l'image...</value>
+  </data>
   <data name="Pixelate" xml:space="preserve">
     <value>Pixelliser</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Verrouiller le menu</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Mettre au premier plan</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Rotation à 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Utiliser des petites poignées de redimensionnement</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Capturer la dernière région</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Insérer une image depuis l'écran...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Supprimer tout</value>
   </data>
   <data name="AutoCopyImageToClipboard" xml:space="preserve">
     <value>Copier automatiquement l'image du presse-papier</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Taille des bordures :</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Menu annotations</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Coller image/texte</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Rogner l'image...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Couleur des bordures...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Afficher la loupe</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Éditeur d'image</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Couleur de l'ombre portée...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Basculer vers l'outil de sélection après avoir dessiné la forme</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Capture rectangle transparent</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Afficher les infos sur la position et la taille</value>
+  </data>
   <data name="ScreenRecordForm_Start" xml:space="preserve">
     <value>Démarrer</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Arrêter la capture</value>
   </data>
   <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
     <value>Type de pas :</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copier l'image dans le presse-papier</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Afficher la large croix sur l'écran</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Nombre de pixels de la loupe :</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Cette fenêtre va se fermer avant d'ouvrir la page web des raccourcis clavier. Voulez-vous continuer ?</value>
+  </data>
   <data name="FPSLimit" xml:space="preserve">
     <value>Limite IPS :</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Insérer un fichier image...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
     <value>Zoomer pour ajuster à l'ouverture</value>
   </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Astuce : Vous pouvez déplacer l'image en maintenant enfoncé le bouton central de la souris et en glissant.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Exécuter après les tâches de capture</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Mémoriser l'état du menu</value>
+  </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Effet de découpe :</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Taille des pixels de la loupe :</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>Options de l'outil</value>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.he-IL.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.he-IL.resx
@@ -117,387 +117,387 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>העתק אוטומטית תמונה ללוח הגזירה</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>צלם אזור</value>
-  </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>קצב סיביות:</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>טשטש</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>סגור (Esc)</value>
-  </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>גזור גודל אפקט:</value>
-  </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>גזור אפקט:</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>צבע צללית...</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>שכפל</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>לוח הגזירה אינו מכיל תמונה.</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>חפש את ffmpeg.exe</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>הגבלת FPS:</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>הדגש</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>התמונה הועתקה</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>הוסף אפקטי תמונה...</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>התמונה נשמרה</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>התמונה נשמרה</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>התמונה מועלית</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>השתמש בצמתים לשינוי גודל קל</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>נעל תפריט</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>עוצמת הגדלה:</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>גודל סמל התפריט:</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>שורה חדשה: Ctrl + Enter, OK: Enter</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>שורה חדשה: Enter, OK: Ctrl + Enter</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>פתח את דף האינטרנט של המקשים...</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>השהה</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>פיקסול</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>מעבד...</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>מלבן לכידת אור</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>מלבן לכידה שקוף</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>עורך תמונה</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - עורך תמונה</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>טיפ: ניתן להזיז תמונה על ידי החזקת הלחצן האמצעי של העכבר וגרירתו.</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>המשך</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>האם אתה בטוח שברצונך לבטל את ההקלטה הזו?</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>התחל</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>לחץ כדי להתחיל הקלטה.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>לחץ כדי לעצור את ההקלטה.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>מקודד...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>ממתין...</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>עצור</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>עצור צילום מסך</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>התחל צילום מסך</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>כיוון ראש החץ:</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>סגנון גבול:</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>נקודות מרכז:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>חוזק טשטוש:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>צבע גבול...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>גודל גבול:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>צלם מסך</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>צלם מסך פעיל</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>צלם מסך מלא</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>צלם מסך</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>רדיוס פינה:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>אפשר אנימציות</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>צבע מילוי...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>מצב אזור בגודל קבוע</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>גובה:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>צבע הדגשה...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>כמות פיקסלים של זכוכית מגדלת:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>גודל פיקסל זכוכית מגדלת:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>מצב ריבוי אזורים</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>אפשרויות</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>גודל פיקסל:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>זכור את מצב התפריט</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>הצג FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>הצג זכוכית מגדלת</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>הצג מידע על מיקום וגודל</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>זכוכית מגדלת בצורת ריבוע</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>עבור לכלי הציור לאחר בחירת צורה</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>בור לכלי הבחירה לאחר ציור צורה</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>רוחב:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>תפריט העורך</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>החל שינויים והמשך במשימה (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>סגירה אוטומטית של העורך במשימה</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>חיתוך אוטומטי של תמונה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>הבא קדימה</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>הבא לקידמה</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>ביטול משימה (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>גודל קנבס...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>צלם אזורים</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>המשך משימה (רווח או לחיצה ימנית בעכבר)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>העתק תמונה ללוח הגזירה (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>חתוך תמונה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>מחק</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>מחק הכל</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>צללית</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>ערוך</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>מצב התחלה של העורך:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>הפוך אופקית</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>הפוך אנכית</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>גודל גופן:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>תמונה</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>גודל תמונה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>הוסף קובץ תמונה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>הוסף תמונה מהמסך...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>מצב אינטרפולציה:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>צלם אזור אחרון</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>תמונה חדשה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>פתח קובץ תמונה...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>הדבק תמונה/טקסט</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>הדפס תמונה... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>סובב 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>סובב 90° עם כיוון השעון</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>סובב 90° נגד כיוון השעון</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>הרץ משימות לאחר צילום מסך (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>שמור תמונה (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>שמור תמונה בשם... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>העבר אחורה</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>העבר לרקע</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>ערך השלב הראשון:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>סוג שלב:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>אפשרויות כלי</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>בטל</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>העלה תמונה (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>התקרב כדי להתאים לפתיחה</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>צבע הדגשה...</value>
   </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>סוג הסמן:</value>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>עבור לכלי הציור לאחר בחירת צורה</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>חלון זה ייסגר לפני פתיחת דף האינטרנט של המקשים. האם אתה רוצה להמשיך?</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>גזור גודל אפקט:</value>
   </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>צלם מסך</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>הוסף אפקטי תמונה...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>הפוך אופקית</value>
   </data>
   <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
     <value>עצור</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>מצב ריבוי אזורים</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>גודל פיקסל:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>גודל תמונה...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>מחק</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>החל שינויים והמשך במשימה (Enter)</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>פתח את דף האינטרנט של המקשים...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>שכפל</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>ערוך</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>התמונה נשמרה</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>סגירה אוטומטית של העורך במשימה</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>בטל</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>עשה מחדש</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>עורך תמונה</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>צלם אזור</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>מצב אזור בגודל קבוע</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>לוח הגזירה אינו מכיל תמונה.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>שורה חדשה: Ctrl + Enter, OK: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>צלם מסך</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>העבר לרקע</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>צלם מסך פעיל</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>הבא קדימה</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>סובב 90° נגד כיוון השעון</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>התחל צילום מסך</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>מצב אינטרפולציה:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>רוחב:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>לחץ כדי לעצור את ההקלטה.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>נקודות מרכז:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>אפשרויות</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>סגנון גבול:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>צלם מסך</value>
+  </data>
   <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
     <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>האם אתה בטוח שברצונך לבטל את ההקלטה הזו?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>פתח קובץ תמונה...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>מעבד...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>ממתין...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>סובב 90° עם כיוון השעון</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>סגור (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>ערך השלב הראשון:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>צלם מסך</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>הדגש</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>עוצמת הגדלה:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>רדיוס פינה:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>קצב סיביות:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>הדפס תמונה... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>הצג FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>שורה חדשה: Enter, OK: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>סוג הסמן:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>חפש את ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>צללית</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>זכוכית מגדלת בצורת ריבוע</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>המשך</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>מצב התחלה של העורך:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>התמונה נשמרה</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>כיוון ראש החץ:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>צלם מסך מלא</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>צלם אזורים</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>מלבן לכידת אור</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>שמור תמונה (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>תמונה חדשה...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>טשטש</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>מקודד...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>חוזק טשטוש:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>התמונה מועלית</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>אפשר אנימציות</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>העבר אחורה</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>גובה:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>התמונה הועתקה</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>צבע מילוי...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>שמור תמונה בשם... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>המשך משימה (רווח או לחיצה ימנית בעכבר)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>גודל גופן:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>גודל קנבס...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>גודל סמל התפריט:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>הפוך אנכית</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>חיתוך אוטומטי של תמונה...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>פיקסול</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>נעל תפריט</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>הבא לקידמה</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>סובב 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>השתמש בצמתים לשינוי גודל קל</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>צלם אזור אחרון</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>הוסף תמונה מהמסך...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>מחק הכל</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>העתק אוטומטית תמונה ללוח הגזירה</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>גודל גבול:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>תפריט העורך</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>הדבק תמונה/טקסט</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>חתוך תמונה...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>צבע גבול...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>הצג זכוכית מגדלת</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>השהה</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - עורך תמונה</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>צבע צללית...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>בור לכלי הבחירה לאחר ציור צורה</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>מלבן לכידה שקוף</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>הצג מידע על מיקום וגודל</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>התחל</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>עצור צילום מסך</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>סוג שלב:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>העתק תמונה ללוח הגזירה (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
     <value>הצג כוונת בגודל המסך</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>תמונה</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>כמות פיקסלים של זכוכית מגדלת:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>חלון זה ייסגר לפני פתיחת דף האינטרנט של המקשים. האם אתה רוצה להמשיך?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>הגבלת FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>הוסף קובץ תמונה...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>התקרב כדי להתאים לפתיחה</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>טיפ: ניתן להזיז תמונה על ידי החזקת הלחצן האמצעי של העכבר וגרירתו.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>הרץ משימות לאחר צילום מסך (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>זכור את מצב התפריט</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>גזור אפקט:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>גודל פיקסל זכוכית מגדלת:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>אפשרויות כלי</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>עצור</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>לחץ כדי להתחיל הקלטה.</value>
+  </data>
+  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
+    <value>האם ברצונך לאפס את האפשרויות?</value>
+  </data>
   <data name="Confirmation" xml:space="preserve">
     <value>אישור</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
-    <value>עשה מחדש</value>
+  <data name="ImageURL" xml:space="preserve">
+    <value>קישור התמונה</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>יש שינויים שלא נשמרו.
 
 האם ברצונך לשמור את השינויים לפני סגירת עורך התמונות?</value>
-  </data>
-  <data name="ImageURL" xml:space="preserve">
-    <value>קישור התמונה</value>
-  </data>
-  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
-    <value>האם ברצונך לאפס את האפשרויות?</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.hu.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.hu.resx
@@ -117,16 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Régió felvétele</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
   <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
     <value>Tallózd be az ffmpeg.exe fájlt</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Téglalap lopása finoman</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Régió felvétele</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
@@ -117,241 +117,241 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Ambil</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Ambil</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Hapus</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Edit</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Hentikan</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Buka file gambar...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Gambar</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Tinggi:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Lebar:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Tempel gambar/teks</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Ukuran piksel:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Cetak gambar... (Ctrl + P)</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Ambil area</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Simpan gambar (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Simpan gambar sebagai... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Jalankan tugas setelah mengambil (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Tampilkan FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Tampilkan kaca pembesar</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Tampilkan info ukuran dan posisi</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Tampilkan garis bidik layar</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Batalkan tugas (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Unggah gambar (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opsi</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Aktifkan animasi</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Gambar baru...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Batalkan tugas (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Ukuran kanvas...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Jepret monitor yang aktif</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Jepret area terakhir</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Jepret layar penuh</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Jepret monitor</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Jepret area</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Titik pusat:</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Jelajahi ffmpeg.exe</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Ukuran bingkai:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Warna bingkai...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Radius blur:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Terapkan perubahan &amp; lanjutkan tugas (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Menu anotasi</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Ototmatis tutup editor pada tugas</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Otomatis pangkas gambar...</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Papan klip tidak berisi gambar.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Lanjutkan tugas (Spasi atau klik kanan)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Salin gambar ke papan klip (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Radius sudut:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Pangkas gambar...</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Jenis penunjuk:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Hapus semua</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Buat bayangan</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Mode mulai editor:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Warna isian...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Mode area ukuran tetap</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Ukuran huruf:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Balik vertikal</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Warnas sorot...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>Balik horisontal</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Warnas sorot...</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Editor gambar</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Ukuran gambar...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Sisipkan file gambar...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Sisipkan gambar dari layar...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Mode interpolasi</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Undo</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} L: {2} T: {3}</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Mulai mengambil</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Berhenti mengambil</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Kiat: Anda bisa menggeser gambar dengan menahan tombol tengah tetikus dan menyeretnya.</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Kaca pembesar bentuk persegi</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Rotasi 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Rotasi 90 ° searah jarum jam</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Rotasi 90 ° berlawanan arah jarum jam</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Ingat kondisi menu</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Hentikan</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
     <value>Mode multi area</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Ukuran piksel kaca pembesar:</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Ukuran piksel:</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Jumlah piksel kaca pembesar:</value>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Ukuran gambar...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Hapus</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Terapkan perubahan &amp; lanjutkan tugas (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Ototmatis tutup editor pada tugas</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Editor gambar</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Ambil area</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Mode area ukuran tetap</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Papan klip tidak berisi gambar.</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Jepret monitor</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
     <value>Kirim ke belakang</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Jepret monitor yang aktif</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>Bawa maju</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Rotasi 90 ° berlawanan arah jarum jam</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Mulai mengambil</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Mode interpolasi</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Lebar:</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Titik pusat:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opsi</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Ambil</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} L: {2} T: {3}</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Buka file gambar...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Rotasi 90 ° searah jarum jam</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Ambil</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Radius sudut:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Cetak gambar... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Tampilkan FPS</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Jenis penunjuk:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Jelajahi ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Buat bayangan</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Kaca pembesar bentuk persegi</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Mode mulai editor:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Jepret layar penuh</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Jepret area</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Pengambilan persegi panjang (cahaya)</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Simpan gambar (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Gambar baru...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Radius blur:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Aktifkan animasi</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
     <value>Kirim mundur</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Tinggi:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Warna isian...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Simpan gambar sebagai... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Lanjutkan tugas (Spasi atau klik kanan)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Ukuran huruf:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Ukuran kanvas...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Balik vertikal</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Otomatis pangkas gambar...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
     <value>Bawa ke depan</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Rotasi 180°</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Jepret area terakhir</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Sisipkan gambar dari layar...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Hapus semua</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Ukuran bingkai:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Menu anotasi</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Tempel gambar/teks</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Pangkas gambar...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Warna bingkai...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Tampilkan kaca pembesar</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Pengambilan persegi panjang (transparan)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Tampilkan info ukuran dan posisi</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Berhenti mengambil</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Salin gambar ke papan klip (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Tampilkan garis bidik layar</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Gambar</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Jumlah piksel kaca pembesar:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Sisipkan file gambar...</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Kiat: Anda bisa menggeser gambar dengan menahan tombol tengah tetikus dan menyeretnya.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Jalankan tugas setelah mengambil (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Ingat kondisi menu</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Ukuran piksel kaca pembesar:</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.it-IT.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.it-IT.resx
@@ -117,166 +117,166 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Avvia Cattura</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Ferma Cattura</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Cattura</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Ferma</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Cerca "ffmpeg.exe"</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Cattura Ragionr</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Colore Bordo...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Dimensione Bordo:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Cattura</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Cattura Monitor Attivo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Cattura Schermo Intero</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Cattura Monitor</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Raggio Angolo:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Attiva Animazioni</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Colore Riempimento:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Altezza:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Colore Evidenziazione:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Numero Pixel Lente d'Ingrandimento:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Dimensione Pixel Lente d'Ingrandimento:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Modalità Multi Regione</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opzioni</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Dimensione Pixel:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Raggio Sfocatura:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Modalità Regione a Dimensione Fissa</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Ricorda Stato Menu</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Mostra FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Mostra Lente d'Ingrandimento</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Mostra Informazioni Posizione e Dimensione</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Mostra Mirino a Dimensione Schermo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Lente d'Ingrandimento Quadrata</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Larghezza:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Applica e Continua Operazione (Invio)</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>Annulla Operazione (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Cattura Regioni</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Continua Operazione (Spazio o Click Destro)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copia Immagine negli Appunti</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Cancella</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Cancella Tutto</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Modifica</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Cattura Ultima Regione</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Stampa Immagine...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Esegui dopo le Operazioni di Cattura</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Salva Immagine</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Salva Immagine come...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Annulla</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Carica Immagine</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Porta In Primo Piano</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Colore Evidenziazione:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Ferma</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Modalità Multi Regione</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Dimensione Pixel:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Cancella</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Applica e Continua Operazione (Invio)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Modifica</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Cattura Ragionr</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Modalità Regione a Dimensione Fissa</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Cattura Monitor</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
     <value>Porta in Fondo</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Porta Dietro</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Cattura Monitor Attivo</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>Porta Avanti</value>
   </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Avvia Cattura</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Larghezza:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opzioni</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Cattura</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Cattura</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Raggio Angolo:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Stampa Immagine...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Mostra FPS</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Cerca "ffmpeg.exe"</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
     <value>Ombra</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Lente d'Ingrandimento Quadrata</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Cattura Schermo Intero</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Cattura Regioni</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Cattura Rettangolare Semplice</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Salva Immagine</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Raggio Sfocatura:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Attiva Animazioni</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Porta Dietro</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Altezza:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Colore Riempimento:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Salva Immagine come...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Continua Operazione (Spazio o Click Destro)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Porta In Primo Piano</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Cattura Ultima Regione</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Cancella Tutto</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Dimensione Bordo:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Colore Bordo...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Mostra Lente d'Ingrandimento</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Cattura Rettangolare Trasparente</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Mostra Informazioni Posizione e Dimensione</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Ferma Cattura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copia Immagine negli Appunti</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Mostra Mirino a Dimensione Schermo</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Numero Pixel Lente d'Ingrandimento:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Esegui dopo le Operazioni di Cattura</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Ricorda Stato Menu</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Dimensione Pixel Lente d'Ingrandimento:</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ja-JP.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ja-JP.resx
@@ -126,6 +126,15 @@
   <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
     <value>ハイライト色...</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>図形を選択した後は、図形描画モードにする</value>
+  </data>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>切り抜き削除の効果の大きさ:</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>画像エフェクトを追加...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>左右反転</value>
   </data>
@@ -134,6 +143,9 @@
   </data>
   <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
     <value>複数領域選択モード</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>ピクセルの大きさ:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>画像の大きさ...</value>
@@ -144,8 +156,17 @@
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
     <value>変更を適用してタスクを継続 (Enter)</value>
   </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>キー割り当て一覧のページを開く...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>複製</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>編集</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>画像を保存しました</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>エディターを自動で閉じる</value>
@@ -153,8 +174,8 @@
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>元に戻す</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>幅:</value>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>やり直し</value>
   </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>画像エディター</value>
@@ -167,6 +188,9 @@
   </data>
   <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
     <value>クリップボードに画像がありません。</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Ctrl+Enterで改行 Enterで確定</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
     <value>モニターをキャプチャー</value>
@@ -183,8 +207,17 @@
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>左に90° 回転</value>
   </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>キャプチャー開始</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>補間方式:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>幅:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>クリックすると録画を停止。</value>
   </data>
   <data name="ShapeManager_CenterPoints" xml:space="preserve">
     <value>中間点:</value>
@@ -192,29 +225,59 @@
   <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
     <value>オプション</value>
   </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>線の形式:</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
     <value>キャプチャー</value>
   </data>
   <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
     <value>X: {0} Y: {1} 幅: {2} 高さ: {3}</value>
   </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>録画を中止しますか？</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
     <value>画像ファイルを開く...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>処理中...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>待機中...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
     <value>右に90° 回転</value>
   </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>閉じる(Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>ステップの最初の値:</value>
+  </data>
   <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
     <value>キャプチャー</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>画像をクリップボードにコピー</value>
+  <data name="Highlight" xml:space="preserve">
+    <value>ハイライト</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>拡大率:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>角の半径:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>ビットレート:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>画像を印刷... (Ctrl + P)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
     <value>FPSを表示</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Enterで改行 Ctrl+Enterで確定</value>
   </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>カーソルの種類:</value>
@@ -228,17 +291,23 @@
   <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
     <value>四角形ルーペ</value>
   </data>
+  <data name="Resume" xml:space="preserve">
+    <value>再開</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
     <value>エディターの起動モード:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>画像を保存しました</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>矢の先端の方向:</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
     <value>全画面をキャプチャー</value>
   </data>
   <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
     <value>領域をキャプチャー</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>キャプチャー開始</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>領域キャプチャー (ライトモード)</value>
@@ -249,8 +318,17 @@
   <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
     <value>新しい画像...</value>
   </data>
+  <data name="Blur" xml:space="preserve">
+    <value>ぼかし</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>エンコード中...</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
     <value>ぼかしの半径:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>画像をアップロード中</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
     <value>アニメーション有効</value>
@@ -261,6 +339,9 @@
   <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
     <value>高さ:</value>
   </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>画像をコピーしました</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
     <value>塗りつぶしの色...</value>
   </data>
@@ -270,8 +351,14 @@
   <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
     <value>タスクを継続 (スペース または 右クリック)</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>文字サイズ:</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
     <value>キャンバスの大きさ...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>画像エディタのアイコンサイズ:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
     <value>上下反転</value>
@@ -279,11 +366,20 @@
   <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
     <value>自動で画像切り抜き...</value>
   </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>モザイク</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>ツールバーメニューを固定する</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
     <value>最前面へ移動</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
     <value>180° 回転</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>小さいリサイズ用ハンドルを使う</value>
   </data>
   <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
     <value>最近使用した領域をキャプチャー</value>
@@ -293,6 +389,9 @@
   </data>
   <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
     <value>すべて削除</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>クリップボードに自動でコピー</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
     <value>枠の太さ:</value>
@@ -312,14 +411,35 @@
   <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
     <value>ルーペを表示</value>
   </data>
+  <data name="Pause" xml:space="preserve">
+    <value>一時停止</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - 画像エディタ</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>影の色...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>図形を描いた後は、図形選択モードにする</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>領域キャプチャー (透過モード)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
     <value>位置と大きさの情報を表示</value>
   </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>録画開始</value>
+  </data>
   <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
     <value>キャプチャー停止</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>文字の種類:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>画像をクリップボードにコピー</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
     <value>十字線カーソルを表示</value>
@@ -330,11 +450,17 @@
   <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
     <value>ルーペの表示ピクセル数:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>文字サイズ:</value>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>キーバインドのウェブページを開く前に、このウィンドウを閉じます。続行しますか？</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>FPS 上限:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
     <value>画像ファイルを挿入...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>開いたら幅に合わせて拡大表示</value>
   </data>
   <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
     <value>ヒント: 表示領域の移動はマウス中ボタンを押したままドラッグ</value>
@@ -345,160 +471,34 @@
   <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
     <value>メニューの選択状態を記憶する</value>
   </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>切り抜き削除の効果:</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
     <value>ルーペのピクセルの大きさ:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>角の半径:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>ピクセルの大きさ:</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - 画像エディタ</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>図形を選択した後は、図形描画モードにする</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>図形を描いた後は、図形選択モードにする</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>ステップの最初の値:</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>閉じる(Esc)</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>拡大率:</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>影の色...</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>画像エフェクトを追加...</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>小さいリサイズ用ハンドルを使う</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>キー割り当て一覧のページを開く...</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>複製</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>画像エディタのアイコンサイズ:</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Ctrl+Enterで改行 Enterで確定</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Enterで改行 Ctrl+Enterで確定</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>矢の先端の方向:</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>ツールバーメニューを固定する</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>線の形式:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>文字の種類:</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>録画終了</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>録画開始</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>クリックで録画を開始。</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>クリックすると録画を停止。</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>録画を中止しますか？</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>クリップボードに自動でコピー</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>ぼかし</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>モザイク</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>ほかのオプション</value>
   </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>ビットレート:</value>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>録画終了</value>
   </data>
-  <data name="Processing" xml:space="preserve">
-    <value>処理中...</value>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>クリックで録画を開始。</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>エンコード中...</value>
+  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
+    <value>オプションを初期化しますか？</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>待機中...</value>
+  <data name="Confirmation" xml:space="preserve">
+    <value>確認</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>キーバインドのウェブページを開く前に、このウィンドウを閉じます。続行しますか？</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>開いたら幅に合わせて拡大表示</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>再開</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>一時停止</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>FPS 上限:</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>画像をコピーしました</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>画像を保存しました</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>画像を保存しました</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>画像をアップロード中</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>ハイライト</value>
-  </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>切り抜き削除の効果:</value>
-  </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>切り抜き削除の効果の大きさ:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
-    <value>やり直し</value>
+  <data name="ImageURL" xml:space="preserve">
+    <value>画像URL</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>変更内容が保存されていません。
 
 画像エディタを閉じる前に変更を保存しますか？</value>
-  </data>
-  <data name="ImageURL" xml:space="preserve">
-    <value>画像URL</value>
-  </data>
-  <data name="Confirmation" xml:space="preserve">
-    <value>確認</value>
-  </data>
-  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
-    <value>オプションを初期化しますか？</value>
   </data>
   <data name="CutOutBackgroundColor" xml:space="preserve">
     <value>切り抜き削除の背景色...</value>
@@ -506,25 +506,25 @@
   <data name="RulerAngle" xml:space="preserve">
     <value>角度</value>
   </data>
-  <data name="RulerWidth" xml:space="preserve">
-    <value>幅</value>
-  </data>
-  <data name="RulerHeight" xml:space="preserve">
-    <value>高さ</value>
-  </data>
-  <data name="RulerRight" xml:space="preserve">
-    <value>右</value>
-  </data>
-  <data name="RulerBottom" xml:space="preserve">
-    <value>下</value>
-  </data>
   <data name="RulerPerimeter" xml:space="preserve">
     <value>外周</value>
   </data>
   <data name="RulerArea" xml:space="preserve">
     <value>面積</value>
   </data>
+  <data name="RulerWidth" xml:space="preserve">
+    <value>幅</value>
+  </data>
+  <data name="RulerHeight" xml:space="preserve">
+    <value>高さ</value>
+  </data>
   <data name="RulerDistance" xml:space="preserve">
     <value>距離</value>
+  </data>
+  <data name="RulerRight" xml:space="preserve">
+    <value>右</value>
+  </data>
+  <data name="RulerBottom" xml:space="preserve">
+    <value>下</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ko-KR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ko-KR.resx
@@ -117,203 +117,191 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>직사각형 어둡지 않게 촬영</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>ffmpeg.exe 탐색하기</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>영역 촬영</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>투명 직사각형 영역 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>FPS 표시</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>테두리 색...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>테두리 크기:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>채워넣기 색...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>가장자리 반경:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>흐림효과 반경:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>픽셀 크기:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>강조색...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>설정</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>모니터 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>활성화 된 모니터 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>전체 화면 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>너비:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>높이:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>돋보기 픽셀 갯수:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>돋보기 픽셀 크기:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>돋보기 보이기</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>정사각형 모양 돋보기</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>멀티 영역 모드</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>위치와 크기 정보 보이기</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>작업 취소 (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>고정 영역 크기 모드</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>화면을 가로지르는 조준선 보이기</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>애니메이션 활성화</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>메뉴 상태 기억하기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>편집</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>되돌리기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>그림자</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>영역 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>삭제</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>모두 삭제</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>앞으로 보내기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>뒤로 보내기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>맨 앞으로 보내기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>맨 뒤로 보내기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>변경 사항 적용 &amp; 작업 재개 (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>작업 재개 (스페이스 바 또는 우클릭)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>이미지 저장</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>다른 이름으로 이미지 저장... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>이미지를 클립보드에 복사</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>이미지 업로드</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>이미지 인쇄... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>촬영 뒤 할 일 하기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>이전 영역 촬영</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>촬영</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>이미지 편집기</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>이미지</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>이미지 크기...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>캔버스 크기...</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>중지</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>촬영</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>촬영 시작하기</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>촬영 중지</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>시계방향으로 90도 회전</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>반시계방향으로 90도 회전</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>180도 회전</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>강조색...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>가로로 뒤집기</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>세로로 뒤집기</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>중지</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>편집기 시작 상태:</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>멀티 영역 모드</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>픽셀 크기:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>이미지 크기...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>삭제</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>변경 사항 적용 &amp; 작업 재개 (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>편집</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>작업 실행 시 편집기 자동 닫기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>되돌리기</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>이미지 편집기</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>영역 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>고정 영역 크기 모드</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>클립보드에 이미지가 없습니다</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>모니터 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>맨 뒤로 보내기</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>활성화 된 모니터 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>앞으로 보내기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>반시계방향으로 90도 회전</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>촬영 시작하기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>보간 모드</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>너비:</value>
   </data>
   <data name="ShapeManager_CenterPoints" xml:space="preserve">
     <value>중심점:</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>설정</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>촬영</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>이미지 파일 열기...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>시계방향으로 90도 회전</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>촬영</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>가장자리 반경:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>이미지 인쇄... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>FPS 표시</value>
+  </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>커서 모양:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>ffmpeg.exe 탐색하기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>그림자</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>정사각형 모양 돋보기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>편집기 시작 상태:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>전체 화면 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>영역 촬영</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>직사각형 어둡지 않게 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>이미지 저장</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>새 이미지...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>흐림효과 반경:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>애니메이션 활성화</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>뒤로 보내기</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>높이:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>채워넣기 색...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>다른 이름으로 이미지 저장... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>작업 재개 (스페이스 바 또는 우클릭)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>글꼴 크기:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>캔버스 크기...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>세로로 뒤집기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>이미지 알아서 자르기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>맨 앞으로 보내기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>180도 회전</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>이전 영역 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>화면에서 이미지 삽입...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>모두 삭제</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>테두리 크기:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
     <value>주석 메뉴</value>
@@ -321,43 +309,55 @@
   <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
     <value>이미지/텍스트 붙여넣기</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>이미지 알아서 자르기</value>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>이미지 자르기...</value>
   </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>팁: 가운데 마우스 버튼을 누르고 드래그하면 이미지를 이동시킬 수 있습니다.</value>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>테두리 색...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>돋보기 보이기</value>
   </data>
   <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
     <value>ShareX - 이미지 편집기</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>글꼴 크기:</value>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>투명 직사각형 영역 촬영</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>위치와 크기 정보 보이기</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>촬영 중지</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>이미지를 클립보드에 복사</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>화면을 가로지르는 조준선 보이기</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>이미지</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>돋보기 픽셀 갯수:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>이 창은 keybinds 웹 페이지를 열기 전에 닫힙니다. 계속하시겠습니까?</value>
   </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
     <value>이미지 파일 삽입:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>새 이미지...</value>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>팁: 가운데 마우스 버튼을 누르고 드래그하면 이미지를 이동시킬 수 있습니다.</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>화면에서 이미지 삽입...</value>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>촬영 뒤 할 일 하기</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>이미지 자르기...</value>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>메뉴 상태 기억하기</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>이미지 파일 열기...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>보간 모드</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>클립보드에 이미지가 없습니다</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>작업 실행 시 편집기 자동 닫기</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>이 창은 keybinds 웹 페이지를 열기 전에 닫힙니다. 계속하시겠습니까?</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>돋보기 픽셀 크기:</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.nl-NL.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.nl-NL.resx
@@ -117,88 +117,88 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Selecteer ffmpeg.exe</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} B: {2} H: {3}</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Transparante rechthoek vastleggen</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Regio vastleggen</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Rechthoek vastleggen (snel)</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Opname stoppen</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Opname starten</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Afbeelding opslaan</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Afbeelding opslaan als...</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Afbeelding uploaden</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Afbeelding printen...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Verwijder</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Verwijder alles</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Bewerken</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Afbeelding</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Pixel grootte:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>Afbeelding grootte...</value>
   </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Vastleggen</value>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Verwijder</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Bewerken</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>Ongedaan maken</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Regios vastleggen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Naar voren brengen</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Naar achteren sturen</value>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Regio vastleggen</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>Naar voren brengen</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Hoogte:</value>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Opname starten</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
     <value>Breedte</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Grens kleur...</value>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} B: {2} H: {3}</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Grens grootte</value>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Vastleggen</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Afbeelding printen...</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Selecteer ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Regios vastleggen</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Rechthoek vastleggen (snel)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Afbeelding opslaan</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Naar achteren sturen</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Hoogte:</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
     <value>Vul kleur...</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Pixel grootte:</value>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Afbeelding opslaan als...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Naar voren brengen</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Verwijder alles</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Grens grootte</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Grens kleur...</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Transparante rechthoek vastleggen</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Opname stoppen</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Afbeelding</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pl.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pl.resx
@@ -117,367 +117,367 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Blur" xml:space="preserve">
-    <value>Rozmycie</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Obraz skopiowany</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Przechwytywanie regionu</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Automatycznie kopiuj obraz do schowka</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Zamknij (Esc)</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Powiel</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Schowek nie zawiera obrazu.</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Zatrzymaj</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Przechwyć</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>Limit FPS:</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Obraz zapisany</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Obraz zapisany</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Przesyłanie obrazu</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Zatrzymaj</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Zatrzymaj przechwytywanie</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Kliknij, aby zatrzymać nagrywanie.</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Rozpocznij</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Kliknij, aby rozpocząć nagrywanie.</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Rozpocznij przechwytywanie</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opcje</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>Opcje narzędzi</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Oczekiwanie...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Enkodowanie...</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Rozmiar ikony menu:</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Nowa linia: Ctrl + Enter, OK: Enter</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Nowa linia: Enter, OK: Ctrl + Enter</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Anuluj zadanie (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Prześlij obraz (Ctrl + U)</value>
   </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Kolor cienia...</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Zablokuj menu</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Czy na pewno chcesz przerwać to nagrywanie?</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Siła rozmycia:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Kolor obramowania...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Rozmiar obramowania:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Wysokość:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Pokaż FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Szerokość:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Menu edytora</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Edytuj</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Obraz</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Cofnij</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Przeglądaj w poszukiwaniu ffmpeg.exe</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Podświetl</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Dodawanie efektów obrazu...</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Stopień powiększenia:</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Otwórz stronę skrótów klawiszowych...</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Pikseluj</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>Przetwarzanie...</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Edytor obrazów</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Edytor obrazów</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Wskazówka: Możesz przesuwać obraz przytrzymując środkowy przycisk myszy i przeciągając.</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Styl obramowania:</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Punkty środkowe:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Rozmiar piksela:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Zapamiętaj stan menu</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Pokaż lupę</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Liczba pikseli lupy:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Rozmiar piksela lupy:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Lupa o kwadratowym kształcie</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Pokaż informacje o pozycji i rozmiarze</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Pokaż celownik na całym ekranie</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Kolor wypełnienia...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Włącz animacje</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Tryb regionu o stałym rozmiarze</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Przechwytywanie</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Przechwytywanie aktywnego monitora</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Przechwytywanie całego ekranu</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Przechwytywanie monitora</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Promień narożnika:</value>
-  </data>
   <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
     <value>Kolor podświetlenia...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Tryb wielu regionów</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Usuń</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Przełączanie na narzędzie do rysowania po zaznaczeniu kształtu</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Przełączenie na narzędzie do zaznaczania po narysowaniu kształtu</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Rozmiar efektu wycięcia:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Zastosuj zmiany i kontynuuj zadanie (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Automatycznie zamknij edytor podczas zadania</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Automatyczne przytnij obraz...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Anuluj zadanie (Esc)</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Typ kursora:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>Powiększ, aby zmieścić się na otwartym</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Rodzaj kroku:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Usuń wszystko</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Cień</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Tryb startowy edytora:</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Dodawanie efektów obrazu...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>Odwróć w poziomie</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Odwróć w pionie</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Zatrzymaj</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Rozmiar czcionki:</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Tryb wielu regionów</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Przytnij obraz...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Rozmiar płótna...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Przechwytywanie regionów</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Kontynuuj zadanie (spacja lub prawy przycisk myszy)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Skopiuj obraz do schowka (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Przesuń na wierzch</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Przesuń do góry</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>Przesuń na dół</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Przesuń niżej</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Zapisz obraz jako... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Zapisz obraz (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Uruchom zadanie po przechwytywaniu (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Obróć o 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Drukuj obraz... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Wklej obraz/tekst</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Otwórz plik obrazu...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Nowy obraz...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Przechwycenie ostatniego regionu</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Tryb interpolacji:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Wstaw obraz z ekranu...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Wstaw plik obrazu...</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Rozmiar piksela:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>Rozmiar obrazu...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Obróć o 90° z ruchem wskazówek zegara</value>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Usuń</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Zastosuj zmiany i kontynuuj zadanie (Enter)</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Otwórz stronę skrótów klawiszowych...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Powiel</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Edytuj</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Obraz zapisany</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Automatycznie zamknij edytor podczas zadania</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Cofnij</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Edytor obrazów</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Przechwytywanie regionu</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Tryb regionu o stałym rozmiarze</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Schowek nie zawiera obrazu.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Nowa linia: Ctrl + Enter, OK: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Przechwytywanie monitora</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>Przesuń na dół</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Przechwytywanie aktywnego monitora</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Przesuń do góry</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>Obróć o 90° przeciwnie do ruchu wskazówek zegara</value>
   </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Rozpocznij przechwytywanie</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Tryb interpolacji:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Szerokość:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Kliknij, aby zatrzymać nagrywanie.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Punkty środkowe:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opcje</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Styl obramowania:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Przechwytywanie</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Czy na pewno chcesz przerwać to nagrywanie?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Otwórz plik obrazu...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>Przetwarzanie...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Oczekiwanie...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Obróć o 90° z ruchem wskazówek zegara</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Zamknij (Esc)</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
     <value>Wartość pierwszego kroku:</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>To okno zostanie zamknięte przed otwarciem strony internetowej skrótów klawiszowych. Czy chcesz kontynuować?</value>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Przechwyć</value>
   </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Kierunek grotu strzałki:</value>
+  <data name="Highlight" xml:space="preserve">
+    <value>Podświetl</value>
   </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Przechwytywanie przezroczystego prostokąta</value>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Stopień powiększenia:</value>
   </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Proste przechwytywanie prostokąta</value>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Promień narożnika:</value>
   </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Użyj lekkich węzłów zmiany rozmiaru</value>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Bitrate:</value>
   </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>Efekt wycięcia:</value>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Drukuj obraz... (Ctrl + P)</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Rozmiar efektu wycięcia:</value>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Pokaż FPS</value>
   </data>
-  <data name="Pause" xml:space="preserve">
-    <value>Pauza</value>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Nowa linia: Enter, OK: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Typ kursora:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Przeglądaj w poszukiwaniu ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Cień</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Lupa o kwadratowym kształcie</value>
   </data>
   <data name="Resume" xml:space="preserve">
     <value>Ponów</value>
   </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>Bitrate:</value>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Tryb startowy edytora:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Obraz zapisany</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Kierunek grotu strzałki:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Przechwytywanie całego ekranu</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Przechwytywanie regionów</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Proste przechwytywanie prostokąta</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Zapisz obraz (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Nowy obraz...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Rozmycie</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Enkodowanie...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Siła rozmycia:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Przesyłanie obrazu</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Włącz animacje</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Przesuń niżej</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Wysokość:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Obraz skopiowany</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Kolor wypełnienia...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Zapisz obraz jako... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Kontynuuj zadanie (spacja lub prawy przycisk myszy)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Rozmiar czcionki:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Rozmiar płótna...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Rozmiar ikony menu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Odwróć w pionie</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Automatyczne przytnij obraz...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Pikseluj</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Zablokuj menu</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Przesuń na wierzch</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Obróć o 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Użyj lekkich węzłów zmiany rozmiaru</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Przechwycenie ostatniego regionu</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Wstaw obraz z ekranu...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Usuń wszystko</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Automatycznie kopiuj obraz do schowka</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Rozmiar obramowania:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Menu edytora</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Wklej obraz/tekst</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Przytnij obraz...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Kolor obramowania...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Pokaż lupę</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pauza</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Edytor obrazów</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Kolor cienia...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Przełączenie na narzędzie do zaznaczania po narysowaniu kształtu</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Przechwytywanie przezroczystego prostokąta</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Pokaż informacje o pozycji i rozmiarze</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Rozpocznij</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Zatrzymaj przechwytywanie</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Rodzaj kroku:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Skopiuj obraz do schowka (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Pokaż celownik na całym ekranie</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Obraz</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Liczba pikseli lupy:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>To okno zostanie zamknięte przed otwarciem strony internetowej skrótów klawiszowych. Czy chcesz kontynuować?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>Limit FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Wstaw plik obrazu...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>Powiększ, aby zmieścić się na otwartym</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Wskazówka: Możesz przesuwać obraz przytrzymując środkowy przycisk myszy i przeciągając.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Uruchom zadanie po przechwytywaniu (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Zapamiętaj stan menu</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>Efekt wycięcia:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Rozmiar piksela lupy:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>Opcje narzędzi</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Zatrzymaj</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Kliknij, aby rozpocząć nagrywanie.</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
@@ -117,113 +117,35 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Procurar por ffmpeg.exe</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} L: {2} A: {3}</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Captura de retângulo transparente</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Captura de região</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Captura de retângulo leve</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Parar captura</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Iniciar captura</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Capturar</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Parar</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Raio dos cantos:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Mostrar FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Altura:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Largura:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Modo de região de tamanho fixo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Mostrar a cruz na tela</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Tamanho da lupa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Quantidade de pixels da lupa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Lupa quadrada</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Mostrar lupa</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Mostrar tamanho e posição</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Modo multirregião</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opções</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Capturar monitor</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Capturar monitor ativo</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Capturar janela cheia</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Cor de realce...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Tamanho do pixel:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Tamanho do embaçado:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Cor de preenchimento...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Tamanho da borda:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Cor da borda...</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Fechar (Esc)</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>Cancelar tarefa (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Enviar imagem (Ctrl + U)</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Cor de realce...</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Mudar para a ferramenta de desenho após a seleção da forma</value>
   </data>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Cortar tamanho do efeito:</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Adicionar efeitos de imagem...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>Virar na horizontal</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Parar</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Modo multirregião</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Tamanho do pixel:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>Tamanho da imagem...</value>
@@ -237,8 +159,14 @@
   <data name="OpenKeybindsPage" xml:space="preserve">
     <value>Abrir página da web de atalhos de teclado ...</value>
   </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Duplicar</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>Editar</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Imagem salva</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>Editor de fechamento automático na tarefa</value>
@@ -249,17 +177,29 @@
   <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
     <value>Refazer</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Sombra projetada</value>
-  </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>Editor de imagem</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Captura de região</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Modo de região de tamanho fixo</value>
   </data>
   <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
     <value>A área de transferência não contém uma imagem.</value>
   </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Nova linha: Ctrl + Enter, OK: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Capturar monitor</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
     <value>Enviar para trás</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Capturar monitor ativo</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>Trazer para frente</value>
@@ -267,38 +207,110 @@
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>Girar 90 ° no sentido anti-horário</value>
   </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Iniciar captura</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>Modo de interpolação:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Largura:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Clique para parar a gravação.</value>
   </data>
   <data name="ShapeManager_CenterPoints" xml:space="preserve">
     <value>Pontos centrais:</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opções</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Estilo da borda:</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
     <value>Capturar</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} L: {2} A: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Tem certeza de que deseja abortar esta gravação?</value>
   </data>
   <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
     <value>Abrir arquivo de imagem ...</value>
   </data>
+  <data name="Processing" xml:space="preserve">
+    <value>Processando...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Aguardando...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
     <value>Girar 90 ° no sentido horário</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Fechar (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Valor da primeira etapa:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Capturar</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>Realçar</value>
   </data>
   <data name="MagnifyStrength" xml:space="preserve">
     <value>Força de ampliação:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Raio dos cantos:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Taxa de bits:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Imprimir imagem ... (Ctrl + P)</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Mostrar FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Nova linha: Enter, OK: Ctrl + Enter</value>
+  </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>Tipo de cursor:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Procurar por ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Sombra projetada</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Lupa quadrada</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Continuar</value>
   </data>
   <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
     <value>Modo de início do editor:</value>
   </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Imagem salva</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Direção da seta:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Capturar janela cheia</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
     <value>Capturar regiões</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Captura de retângulo leve</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
     <value>Salvar imagem (Ctrl + S)</value>
@@ -306,14 +318,32 @@
   <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
     <value>Nova imagem...</value>
   </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Borrar</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Codificando...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Tamanho do embaçado:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Upload de imagem</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
     <value>Habilitar animações</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
     <value>Enviar para trás</value>
   </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Adicionar efeitos de imagem...</value>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Altura:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Imagem copiada</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Cor de preenchimento...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
     <value>Salvar imagem como ... (Ctrl + Shift + S)</value>
@@ -321,8 +351,14 @@
   <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
     <value>Continuar tarefa (espaço ou clique com o botão direito)</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Tamanho da fonte:</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
     <value>Tamanho da tela...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Tamanho do ícone do menu:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
     <value>Virar na vertical</value>
@@ -330,8 +366,11 @@
   <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
     <value>Cortar imagem automaticamente ...</value>
   </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Cor da sombra projetada ...</value>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Pixelar</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Bloquear menu</value>
   </data>
   <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
     <value>Trazer para frente</value>
@@ -342,11 +381,20 @@
   <data name="LightResizeNodes" xml:space="preserve">
     <value>Use nós de redimensionamento claro</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Capturar a última região</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
     <value>Inserir imagem da tela ...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
     <value>Apagar tudo</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Auto copiar imagem para a área de transferência</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Tamanho da borda:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
     <value>Menu de anotações</value>
@@ -357,26 +405,62 @@
   <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
     <value>Cortar imagem...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Valor da primeira etapa:</value>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Cor da borda...</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Esta janela será fechada antes de abrir a página da web dos atalhos de teclado. Você quer continuar?</value>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Mostrar lupa</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Pausar</value>
   </data>
   <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
     <value>ShareX - Editor de imagens</value>
   </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Cor da sombra projetada ...</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
     <value>Mudar para a ferramenta de seleção após o desenho da forma</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Captura de retângulo transparente</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Mostrar tamanho e posição</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Iniciar</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Parar captura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Tipo de uso:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Mostrar a cruz na tela</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
     <value>Imagem</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Tamanho da fonte:</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Quantidade de pixels da lupa:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Esta janela será fechada antes de abrir a página da web dos atalhos de teclado. Você quer continuar?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>Limite FPS:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
     <value>Inserir arquivo de imagem ...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>Zoom para caber em aberto</value>
   </data>
   <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
     <value>Dica: Você pode deslocar a imagem segurando o botão do meio do mouse e arrastando.</value>
@@ -387,104 +471,20 @@
   <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
     <value>Lembrar do estado do menu</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Capturar a última região</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Direção da seta:</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Nova linha: Enter, OK: Ctrl + Enter</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Nova linha: Ctrl + Enter, OK: Enter</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Bloquear menu</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Upload de imagem</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Imagem copiada</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Imagem salva</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Imagem salva</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Duplicar</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Tamanho do ícone do menu:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Tipo de uso:</value>
-  </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Cortar tamanho do efeito:</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Clicar para iniciar a gravação.</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>Processando...</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Realçar</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Auto copiar imagem para a área de transferência</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Tem certeza de que deseja abortar esta gravação?</value>
-  </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>Taxa de bits:</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>Borrar</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Estilo da borda:</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Clique para parar a gravação.</value>
-  </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Efeito de corte:</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Codificando...</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>Limite FPS:</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>Pausar</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Pixelar</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>Continuar</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Iniciar</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Parar</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Tamanho da lupa:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>Opções de ferramentas</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Aguardando...</value>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Parar</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>Zoom para caber em aberto</value>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Clicar para iniciar a gravação.</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>Existem alterações não salvas.

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
@@ -126,6 +126,12 @@
   <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
     <value>Cor para realçar...</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>Mudar para a ferramenta de desenho depois de seleccionar a forma</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Adicionar efeitos de imagem...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>Inversão horizontal</value>
   </data>
@@ -135,8 +141,8 @@
   <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
     <value>Modo multi-região</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Valor do primeiro passo:</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Tamanho do pixel:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>Tamanho da imagem...</value>
@@ -147,6 +153,9 @@
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
     <value>Aplicar alterações e continuar tarefa (Enter)</value>
   </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Abrir site de atalhos...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>Editar</value>
   </data>
@@ -155,9 +164,6 @@
   </data>
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>Reverter</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Largura:</value>
   </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>Editor de Imagem</value>
@@ -186,8 +192,14 @@
   <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
     <value>Rodar 90º contrário ao relógio</value>
   </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Iniciar captura</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
     <value>Modo de interpolação</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Largura:</value>
   </data>
   <data name="ShapeManager_CenterPoints" xml:space="preserve">
     <value>Pontos centrais:</value>
@@ -207,23 +219,26 @@
   <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
     <value>Rodar 90º</value>
   </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Fechar (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Valor do primeiro passo:</value>
+  </data>
   <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
     <value>Capturar</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Força da lupa:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Raio dos cantos:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Imprimir imagem... (Ctrl + P)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
     <value>Mostrar FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>Mudar para a ferramenta de desenho depois de seleccionar a forma</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Mudar para a ferramenta da forma depois do desenho</value>
   </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>Tipo de cursor:</value>
@@ -245,9 +260,6 @@
   </data>
   <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
     <value>Capturar regiões</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Iniciar captura</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Captura de retângulo leve</value>
@@ -279,6 +291,9 @@
   <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
     <value>Continuar tarefa (Espaço ou clique lado direito)</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Tamanho da fonte:</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
     <value>Tamanho do ecrã...</value>
   </data>
@@ -293,6 +308,9 @@
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
     <value>Rodar 180º</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Utilizar nós de redireccionamento transparentes</value>
   </data>
   <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
     <value>Capturar última região</value>
@@ -324,6 +342,12 @@
   <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
     <value>ShareX - Editor de imagem</value>
   </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Cor da sombra projectada...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Mudar para a ferramenta da forma depois do desenho</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Captura de retângulo transparente</value>
   </data>
@@ -332,6 +356,9 @@
   </data>
   <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
     <value>Para captura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copiar imagem para a área de transferência (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
     <value>Mostrar mira da largura do ecrã</value>
@@ -342,8 +369,8 @@
   <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
     <value>Quantidade de pixels da lupa:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Tamanho da fonte:</value>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Esta janela irá fechar antes de abrir o site de atalhos. Deseja continuar?</value>
   </data>
   <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
     <value>Inserir imagem...</value>
@@ -359,32 +386,5 @@
   </data>
   <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
     <value>Tamanho da lupa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Raio dos cantos:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Tamanho do pixel:</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Utilizar nós de redireccionamento transparentes</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Abrir site de atalhos...</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Esta janela irá fechar antes de abrir o site de atalhos. Deseja continuar?</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Cor da sombra projectada...</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Adicionar efeitos de imagem...</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Força da lupa:</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Fechar (Esc)</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -857,4 +857,7 @@ Would you like to save the changes before closing the image editor?</value>
   <data name="RulerBottom" xml:space="preserve">
     <value>Bottom</value>
   </data>
+  <data name="QP" xml:space="preserve">
+    <value>QP:</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ro.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ro.resx
@@ -117,134 +117,44 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Decupare automată imagine...</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>Anulați sarcina (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Încărcați imaginea (Ctrl + U)</value>
   </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Clipboard-ul nu conține o imagine.</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Culoarea evdențierii...</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Capturați monitorul activ</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>Trimitere în ultimul plan</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Rotiți 90° în sens invers acelor de ceasornic</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Capturați monitorul</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Aducere în față</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Opțiuni</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Puncte centrale:</value>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>Comutare la instrumentul de desen după selectarea formei</value>
   </data>
   <data name="ImageEffects" xml:space="preserve">
     <value>Adăugați efecte de imagine...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Aplicați schimbările și continuați sarcina (Enter)</value>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Răsturnare orizontală</value>
   </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Sigur abandonați această înregistrare?</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Stop</value>
   </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Direcția capului de săgeată:</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Mod multi-regiune</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Închideți automat editorul pe sarcină</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Dimensiune pixel:</value>
   </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Copiați automat imaginea în clipboard</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>Încețoșare</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Intensitatea încețoșării:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Culoarea bordurii...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Mărimea bordurii:</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Stilul bordurii:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Aducere în faţă</value>
-  </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Răsfoire după ffmpeg.exe</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Dimensiunea pânzei...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Capturați</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Capturați</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Capturați tot ecarnul</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Capturați ultima regiune</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Capturați regiuni</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Click pentru a începe înregistrarea.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Click pentru a începe înregistrarea.</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Închideți (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Continuați sarcina (Spațiu sau click dreapta)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Copiați imaginea în clipboard (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Raza colțului:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Decupați imaginea...</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Tipul cursorului:</value>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Dimensiunea imaginii...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
     <value>Ștergeți</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Ștergeți toate</value>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Aplicați schimbările și continuați sarcina (Enter)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Umbră</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Culoarea umbrei...</value>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Deschideți pagina web cu scurtături...</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
     <value>Duplicare</value>
@@ -252,222 +162,312 @@
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>Editare</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Meniu de editare</value>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Imagine salvată</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Modul de start al editorului:</value>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Închideți automat editorul pe sarcină</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Activați animațiile</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Se codifică...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Culoarea evdențierii...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Culoarea de umplere...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Mod regiune de dimensiune fixă</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Răsturnare orizontală</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Răsturnare verticală</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Dimensiunea fontului:</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>Limită FPS:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Înălțime:</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Evidențiere</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Imagine</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Imagine copiată</value>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Anulare</value>
   </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>Editor de imagini</value>
   </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Imagine salvată</value>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Capturare regiune</value>
   </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Imagine salvată</value>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Mod regiune de dimensiune fixă</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Dimensiunea imaginii...</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Se încarcă imaginea</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Inserați fișier imagine...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Inserați imagine din ecran...</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Blocați meniul</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Numărul de pixeli ai lupei:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Dimensiunea pixelilor lupei:</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Puterea lupei:</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Dimensiunea pictogramelor din meniu:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Mod multi-regiune</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Imagine nouă...</value>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Clipboard-ul nu conține o imagine.</value>
   </data>
   <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
     <value>Linie nouă: Ctrl + Enter, OK: Enter</value>
   </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Linie nouă: Enter, OK: Ctrl + Enter</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Capturați monitorul</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>Trimitere în ultimul plan</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Capturați monitorul activ</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Aducere în față</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Rotiți 90° în sens invers acelor de ceasornic</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Începeți captura</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Lățime:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Click pentru a începe înregistrarea.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Puncte centrale:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Opțiuni</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Stilul bordurii:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Capturați</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Sigur abandonați această înregistrare?</value>
   </data>
   <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
     <value>Deshideți fișier imagine...</value>
   </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Deschideți pagina web cu scurtături...</value>
+  <data name="Processing" xml:space="preserve">
+    <value>Se procesează...</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Lipiți imagine/text</value>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>În așteptare...</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Dimensiune pixel:</value>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Rotiți 90° în sensul acelor ceasornicului</value>
   </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Pixelare</value>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Închideți (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Valorea primului pas:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Capturați</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>Evidențiere</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Puterea lupei:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Raza colțului:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
     <value>Imprimare imagine... (Ctrl + P)</value>
   </data>
-  <data name="Processing" xml:space="preserve">
-    <value>Se procesează...</value>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Afișare FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Linie nouă: Enter, OK: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Tipul cursorului:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Răsfoire după ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Umbră</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Lupă în formă de pătrat</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Modul de start al editorului:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Imagine salvată</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Direcția capului de săgeată:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Capturați tot ecarnul</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Capturați regiuni</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Captură dreptunghiulară clară</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Salvați imaginea (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Imagine nouă...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Încețoșare</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Se codifică...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Intensitatea încețoșării:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Se încarcă imaginea</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Activați animațiile</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Trimiteți în primul plan</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Înălțime:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Imagine copiată</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Culoarea de umplere...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Salvați imaginea ca... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Continuați sarcina (Spațiu sau click dreapta)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Dimensiunea fontului:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Dimensiunea pânzei...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Dimensiunea pictogramelor din meniu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Răsturnare verticală</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Decupare automată imagine...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Pixelare</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Blocați meniul</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Aducere în faţă</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Rotiți 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Utilizare noduri de redimensionare ușoară</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Capturați ultima regiune</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Inserați imagine din ecran...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Ștergeți toate</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Copiați automat imaginea în clipboard</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Mărimea bordurii:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Meniu de editare</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Lipiți imagine/text</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Decupați imaginea...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Culoarea bordurii...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Afișare lupă</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Editor de imagini</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Culoarea umbrei...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Comutare la instrumentul de selecție după desenarea formei</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Captură dreptunghiulară transparentă</value>
   </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Capturare regiune</value>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Afișare informații poziție și dimensiune</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Rețineți starea meniului</value>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Opriți captura</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Tip de pas:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Copiați imaginea în clipboard (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Afișare reticul larg al ecranului</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Imagine</value>
   </data>
   <data name="RectangleRegion_GetColorPickerText" xml:space="preserve">
     <value>RGB: {0}, {1}, {2}
 Hex: {3}
 X: {4} Y: {5}</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Rotiți 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Rotiți 90° în sensul acelor ceasornicului</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Rulați sarcinile după captura (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Salvați imaginea (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Salvați imaginea ca... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Trimiteți în primul plan</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Editor de imagini</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Afișare FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Afișare lupă</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Afișare informații poziție și dimensiune</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Afișare reticul larg al ecranului</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Lupă în formă de pătrat</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Start</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Începeți captura</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Tip de pas:</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Opriți captura</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>Comutare la instrumentul de desen după selectarea formei</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Comutare la instrumentul de selecție după desenarea formei</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Numărul de pixeli ai lupei:</value>
   </data>
   <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
     <value>Această fereastră se va închide înainte de a deschide pagina web de scurtături. Doriți să continuați?</value>
   </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>Limită FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Inserați fișier imagine...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>Zoom pentru a se potrivi la deschidere</value>
+  </data>
   <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
     <value>Sfat: Puteți face panoramarea imaginii ținând apăsat butonul din mijloc al mouse-ului și trăgând.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Rulați sarcinile după captura (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Rețineți starea meniului</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Dimensiunea pixelilor lupei:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>Opțiuni instrument</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Anulare</value>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Stop</value>
   </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Utilizare noduri de redimensionare ușoară</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Valorea primului pas:</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>În așteptare...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Lățime:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>Zoom pentru a se potrivi la deschidere</value>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Click pentru a începe înregistrarea.</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ru.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ru.resx
@@ -117,371 +117,374 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Выберите ffmpeg.exe</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} Ш: {2} В: {3}</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Упрощенный захват области</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Захват</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Стоп</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Остановить захват</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Начать захват</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Захват области</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Захват области с прозрачным фоном</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Показать FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Ширина:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Высота:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Цвет рамки...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Размер рамки:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Цвет заливки...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Показывать полноэкранное перекрестье</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Опции</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Квадратная лупа</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Захват активного монитора</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Режим области фиксированного размера</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Захват всего экрана</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Показывать лупу</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Количество пикселей в лупе:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Размер пикселя в лупе:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Показывать информацию о позиции и размере</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Захват нескольких областей</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Захват монитора</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Сила размытия:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Цвет подсветки...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Размер пикселя:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Радиус скругления:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Включить анимации</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Помнить состояние меню</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Тень</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Захват областей</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Изменить</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Отменить</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Удалить</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Удалить все</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Применить изменения и продолжить задачу (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Продолжить задачу (Пробел или ПКМ)</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>Отменить задачу (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Сохранить изображение (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Сохранить изображение как... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Скопировать изображение в буфер обмена (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Загрузить изображение (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Распечатать изображение... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Выполнить задачи после захвата</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>На задний план</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>На передний план</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Переместить назад</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Переместить вперед</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Захват последней области</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Захват</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Редактор изображений</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Меню примечаний</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Тип курсора:</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Центральных точек:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Изображение</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Размер изображения...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Размер полотна...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Повернуть на 90° по часовой стрелке</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Повернуть на 90° против часовой стрелки</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Повернуть на 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Отразить по горизонтали</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Отразить по вертикали</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Режим запуска редактора:</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Заметка: Изображение можно перемещать, удерживая среднюю кнопку мыши.</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Буфер обмена не содержит изображение.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Вставить картинку/текст</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Автокадрирование...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Новое изображение...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Открыть файл изображения...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Вставить файл изображения...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Вставить картинку с экрана...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Кадрировать...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Закрывать редактор по задаче</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Размер шрифта:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Режим интерполяции:</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Редактор изображений</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Значение на первом шаге:</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Упрощенные элементы масштабирования</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Цвет тени...</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Добавить эффекты изображений...</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Открыть страницу горячих клавиш...</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Это окно закроется перед тем, как открыть страницу с горячими клавишами. Хотите продолжить?</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Цвет подсветки...</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Выбирать инструмент рисования после выбора фигуры</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Выбирать инструмент выделения после рисования</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Размер эффекта:</value>
   </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Степень увеличения:</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Добавить эффекты изображений...</value>
   </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Закрыть (Esc)</value>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Отразить по горизонтали</value>
   </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Направление стрелки:</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Стоп</value>
   </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Новая строка: Enter, OK: Ctrl + Enter</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Захват нескольких областей</value>
   </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Новая строка: Ctrl + Enter, OK: Enter</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Размер пикселя:</value>
   </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Зафиксировать меню</value>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Размер изображения...</value>
   </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Изображение загружается</value>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Удалить</value>
   </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Изображение скопировано</value>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Применить изменения и продолжить задачу (Enter)</value>
   </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Изображение сохранено</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Изображение сохранено</value>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Открыть страницу горячих клавиш...</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
     <value>Дублировать</value>
   </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Размер иконок меню:</value>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Изменить</value>
   </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Стоп</value>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Изображение сохранено</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Закрывать редактор по задаче</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Отменить</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>Повторить</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Редактор изображений</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Захват области</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Режим области фиксированного размера</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Буфер обмена не содержит изображение.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Новая строка: Ctrl + Enter, OK: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Захват монитора</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>На задний план</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Захват активного монитора</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Переместить вперед</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Повернуть на 90° против часовой стрелки</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Начать захват</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Режим интерполяции:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Ширина:</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
     <value>Нажмите, чтобы остановить запись.</value>
   </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Центральных точек:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Опции</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>Стиль рамки:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Тип шага:</value>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Захват</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} Ш: {2} В: {3}</value>
   </data>
   <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
     <value>Отменить эту запись?</value>
   </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Начать</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Нажмите, чтобы начать запись.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Ожидание...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Кодирование...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>Настройки инструмента</value>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Открыть файл изображения...</value>
   </data>
   <data name="Processing" xml:space="preserve">
     <value>Обработка...</value>
   </data>
-  <data name="Blur" xml:space="preserve">
-    <value>Размытие</value>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Ожидание...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Повернуть на 90° по часовой стрелке</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Закрыть (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Значение на первом шаге:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Захват</value>
   </data>
   <data name="Highlight" xml:space="preserve">
     <value>Подсвечивание</value>
   </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Пикселизация</value>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Степень увеличения:</value>
   </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Автоматически копировать изображение в буфер обмена</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>Лимит FPS:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>Подогнать под размеры окна при открывании</value>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Радиус скругления:</value>
   </data>
   <data name="Bitrate" xml:space="preserve">
     <value>Битрейт:</value>
   </data>
-  <data name="Pause" xml:space="preserve">
-    <value>Пауза</value>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Распечатать изображение... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Показать FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Новая строка: Enter, OK: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Тип курсора:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Выберите ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Тень</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Квадратная лупа</value>
   </data>
   <data name="Resume" xml:space="preserve">
     <value>Продолжить</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Режим запуска редактора:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Изображение сохранено</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Направление стрелки:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Захват всего экрана</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Захват областей</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Упрощенный захват области</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Сохранить изображение (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Новое изображение...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Размытие</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Кодирование...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Сила размытия:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Изображение загружается</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Включить анимации</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Переместить назад</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Высота:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Изображение скопировано</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Цвет заливки...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Сохранить изображение как... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Продолжить задачу (Пробел или ПКМ)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Размер шрифта:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Размер полотна...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Размер иконок меню:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Отразить по вертикали</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Автокадрирование...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Пикселизация</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Зафиксировать меню</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>На передний план</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Повернуть на 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Упрощенные элементы масштабирования</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Захват последней области</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Вставить картинку с экрана...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Удалить все</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Автоматически копировать изображение в буфер обмена</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Размер рамки:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Меню примечаний</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Вставить картинку/текст</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Кадрировать...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Цвет рамки...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Показывать лупу</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Пауза</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Редактор изображений</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Цвет тени...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Выбирать инструмент выделения после рисования</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Захват области с прозрачным фоном</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Показывать информацию о позиции и размере</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Начать</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Остановить захват</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Тип шага:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Скопировать изображение в буфер обмена (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Показывать полноэкранное перекрестье</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Изображение</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Количество пикселей в лупе:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Это окно закроется перед тем, как открыть страницу с горячими клавишами. Хотите продолжить?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>Лимит FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Вставить файл изображения...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>Подогнать под размеры окна при открывании</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Заметка: Изображение можно перемещать, удерживая среднюю кнопку мыши.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Выполнить задачи после захвата</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Помнить состояние меню</value>
+  </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Эффект разрыва:</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Размер эффекта:</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Размер пикселя в лупе:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>Настройки инструмента</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Стоп</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Нажмите, чтобы начать запись.</value>
   </data>
   <data name="WouldYouLikeToResetOptions" xml:space="preserve">
     <value>Хотите сбросить настройки?</value>
@@ -489,42 +492,39 @@
   <data name="Confirmation" xml:space="preserve">
     <value>Подтверждение</value>
   </data>
+  <data name="ImageURL" xml:space="preserve">
+    <value>URL изображения</value>
+  </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>Есть несохраненные изменения.
 
 Хотите сохранить изменения перед тем, как закрыть редактор?</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
-    <value>Повторить</value>
-  </data>
   <data name="CutOutBackgroundColor" xml:space="preserve">
     <value>Цвет фона разрыва...</value>
-  </data>
-  <data name="ImageURL" xml:space="preserve">
-    <value>URL изображения</value>
   </data>
   <data name="RulerAngle" xml:space="preserve">
     <value>Угол</value>
   </data>
-  <data name="RulerArea" xml:space="preserve">
-    <value>Площадь</value>
-  </data>
-  <data name="RulerDistance" xml:space="preserve">
-    <value>Расстояние</value>
-  </data>
-  <data name="RulerHeight" xml:space="preserve">
-    <value>Высота</value>
-  </data>
   <data name="RulerPerimeter" xml:space="preserve">
     <value>Периметр</value>
+  </data>
+  <data name="RulerArea" xml:space="preserve">
+    <value>Площадь</value>
   </data>
   <data name="RulerWidth" xml:space="preserve">
     <value>Ширина</value>
   </data>
-  <data name="RulerBottom" xml:space="preserve">
-    <value>Низ</value>
+  <data name="RulerHeight" xml:space="preserve">
+    <value>Высота</value>
+  </data>
+  <data name="RulerDistance" xml:space="preserve">
+    <value>Расстояние</value>
   </data>
   <data name="RulerRight" xml:space="preserve">
     <value>Право</value>
+  </data>
+  <data name="RulerBottom" xml:space="preserve">
+    <value>Низ</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
@@ -117,364 +117,364 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>ffmpeg.exe için gözat</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Yakalama bölgesi</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} G: {2} Y: {3}</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Dikdörtgen yakalama saydam</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Dikdörtgen yakalama basit</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Yakala</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Durdur</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Yakalamayı durdur</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Yakalamayı başlat</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Yükseklik:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Genişlik:</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Resim düzenleyici</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Resim düzenleyici</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Orta noktalar:</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Pano resim içermiyor.</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Yakala</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Çerçeve rengi...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Çerçeve boyutu:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Yeni resim...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Resim/yazı yapıştır</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Resim dosyasını aç...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Sil</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Hepsini sil</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Yazı boyutu:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Resim</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Resim boyutu...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Resim dosyası ekle...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Ekrandan resim ekle...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Resimi yazdır... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Geri al</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Görevi iptal et (Esc)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>Resimi yükle (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Düzenle</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Öne getir</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>En öne getir</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Arkaya gönder</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>En arkaya gönder</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Ayarlar</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Doldurma rengi...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Kenar yarıçapı:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Bulanıklık gücü:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Yatay olarak döndür</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Dikey olarak döndür</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>Resimi kaydet (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Resimi farklı kaydet... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Başlat</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Durdur</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Kodlanıyor...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Bekleniyor...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Kayda başlamak için tıklayın.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Kaydı durdurmak için tıklayın.</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Çoğalt</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Kapat (Esc)</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Resim kopyalandı</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Resim kaydedildi</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Resim kaydedildi</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Resim karşıya yükleniyor</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Resim efekti ekle...</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Düşen gölge rengi...</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Çerçeve stili:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>Aktif ekranı yakala</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>Tam ekran yakala</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Son bölgeyi yakala</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Resimi panoya kopyala (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Resimi kırp...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Düşen gölge</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Sabit boyut bölge modu</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Büyüteç piksel sayısı:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Büyüteç piksel boyutu:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>FPS göster</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Pozisyon ve boyut bilgisi göster</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Büyüteç göster</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Ekranı kaplayan artı şeklinde imleç göster</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>İmleç tipi:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Editör menüsü</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Editör başlangıç modu:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>Değişiklikleri uygula ve göreve devam et (Enter)</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Kaydı iptal etmek istediğinize emin misiniz?</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Ok başı yönü:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Görevden sonra editörü otomatik kapat</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Resmi otomatik kırp...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Görevi iptal et (Esc)</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Basit yeniden boyutlandırma tutamacı kullan</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Menüyü kitle</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Büyütme gücü:</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Menü ikon boyutu:</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Yeni satır: Ctrl + Enter, Tamam: Enter</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Yeni satır: Enter, Tamam: Ctrl + Enter</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Tuşlar web sayfasını aç...</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>İpucu: Farenin orta düğmesini basılı tutup sürükleyerek resmi kaydırabilirsiniz.</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Monitör yakala</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Animasyonları etkinleştir</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Piksel boyutu:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Menü durumunu hatırla</value>
-  </data>
   <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
     <value>Vurgulama rengi...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Çoklu bölge modu</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Kare şeklinde büyüteç</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Tuval boyutu...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Bölgeleri yakala</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Göreve devam et (Space veya sağ tıklama)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>180° döndür</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Saat yönünde 90° döndür</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>90° saat yönünün tersine döndür</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Yakalama sonrası görevlerini çalıştır (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>Araç seçenekleri</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Aradeğerleme modu:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Kademe tipi:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>İlk kademe değeri:</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Tuşlar web sayfası açılmadan önce bu pencere kapanacaktır. Devam etmek istediğinize emin misiniz?</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>Nesne seçtikten sonra çizim aracına geç</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Nesne çizdikten sonra seçim aracına geç</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Kesip çıkarma efekt boyutu:</value>
   </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Resmi otomatik olarak panoya kopyala</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Resim efekti ekle...</value>
   </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>Bit hızı:</value>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Yatay olarak döndür</value>
   </data>
-  <data name="Blur" xml:space="preserve">
-    <value>Bulanıklaştır</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Durdur</value>
   </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>FPS limiti:</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Çoklu bölge modu</value>
   </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Vurgula</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Piksel boyutu:</value>
   </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Mozaikle</value>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Resim boyutu...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Sil</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>Değişiklikleri uygula ve göreve devam et (Enter)</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Tuşlar web sayfasını aç...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Çoğalt</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Düzenle</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Resim kaydedildi</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Görevden sonra editörü otomatik kapat</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Geri al</value>
+  </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Resim düzenleyici</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Yakalama bölgesi</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Sabit boyut bölge modu</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Pano resim içermiyor.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Yeni satır: Ctrl + Enter, Tamam: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Monitör yakala</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>En arkaya gönder</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>Aktif ekranı yakala</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Öne getir</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>90° saat yönünün tersine döndür</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Yakalamayı başlat</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Aradeğerleme modu:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Genişlik:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Kaydı durdurmak için tıklayın.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Orta noktalar:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Ayarlar</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Çerçeve stili:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Yakala</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} G: {2} Y: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Kaydı iptal etmek istediğinize emin misiniz?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Resim dosyasını aç...</value>
   </data>
   <data name="Processing" xml:space="preserve">
     <value>İşleniyor...</value>
   </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Bekleniyor...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Saat yönünde 90° döndür</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Kapat (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>İlk kademe değeri:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Yakala</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>Vurgula</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Büyütme gücü:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Kenar yarıçapı:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Bit hızı:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Resimi yazdır... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>FPS göster</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Yeni satır: Enter, Tamam: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>İmleç tipi:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>ffmpeg.exe için gözat</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Düşen gölge</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Kare şeklinde büyüteç</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Editör başlangıç modu:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Resim kaydedildi</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Ok başı yönü:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>Tam ekran yakala</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Bölgeleri yakala</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Dikdörtgen yakalama basit</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>Resimi kaydet (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Yeni resim...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Bulanıklaştır</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Kodlanıyor...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Bulanıklık gücü:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Resim karşıya yükleniyor</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Animasyonları etkinleştir</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Arkaya gönder</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Yükseklik:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Resim kopyalandı</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Doldurma rengi...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Resimi farklı kaydet... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Göreve devam et (Space veya sağ tıklama)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Yazı boyutu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Tuval boyutu...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Menü ikon boyutu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Dikey olarak döndür</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Resmi otomatik kırp...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Mozaikle</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Menüyü kitle</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>En öne getir</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>180° döndür</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Basit yeniden boyutlandırma tutamacı kullan</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Son bölgeyi yakala</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Ekrandan resim ekle...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Hepsini sil</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Resmi otomatik olarak panoya kopyala</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Çerçeve boyutu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Editör menüsü</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Resim/yazı yapıştır</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Resimi kırp...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Çerçeve rengi...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Büyüteç göster</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Resim düzenleyici</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Düşen gölge rengi...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Nesne çizdikten sonra seçim aracına geç</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Dikdörtgen yakalama saydam</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Pozisyon ve boyut bilgisi göster</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Başlat</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Yakalamayı durdur</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Kademe tipi:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Resimi panoya kopyala (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Ekranı kaplayan artı şeklinde imleç göster</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Resim</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Büyüteç piksel sayısı:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Tuşlar web sayfası açılmadan önce bu pencere kapanacaktır. Devam etmek istediğinize emin misiniz?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>FPS limiti:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Resim dosyası ekle...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
     <value>Açılışta sığdırmak için yakınlaştır</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Kesip çıkarma efekt boyutu:</value>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>İpucu: Farenin orta düğmesini basılı tutup sürükleyerek resmi kaydırabilirsiniz.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Yakalama sonrası görevlerini çalıştır (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Menü durumunu hatırla</value>
   </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Kesip çıkarma efekti:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Büyüteç piksel boyutu:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>Araç seçenekleri</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Durdur</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Kayda başlamak için tıklayın.</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.uk.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.uk.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -126,6 +126,15 @@
   <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
     <value>Колір підсвічування...</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>Переключитися на інструмент малювання після виділення фігури</value>
+  </data>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Розмір ефекту вирізання:</value>
+  </data>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Додати ефекти зображення...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
     <value>Віддзеркалити по горизонталі</value>
   </data>
@@ -135,8 +144,8 @@
   <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
     <value>Захоплення кількох областей</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Значення на першому кроці:</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Розмір пікселя:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
     <value>Розмір зображення...</value>
@@ -147,14 +156,26 @@
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
     <value>Застосувати зміни та продовжити завдання (Enter)</value>
   </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Відкрити веб-сторінку клавішних сполучень...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Дублювати</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
     <value>Змінити</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Зображення збережено</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>Автозакриття редактора за завданням</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>Скасувати</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Ширина:</value>
+  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
+    <value>Повторити</value>
   </data>
   <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
     <value>Редактор зображень</value>
@@ -165,8 +186,47 @@
   <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
     <value>Режим області фіксованого розміру</value>
   </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Буфер обміну не містить зображень.</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Новий рядок: Ctrl + Enter, OK: Enter</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Захоплення монітора</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>На задній план</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
     <value>Захоплення активного монітора</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Перемістити вперед</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Повернути на 90° проти годинникової стрілки</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Почати захоплення</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Режим інтерполяції:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Ширина:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Натисніть, щоб зупинити запис.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Центральні точки:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Стиль рамки:</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
     <value>Захоплення</value>
@@ -174,11 +234,50 @@
   <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
     <value>X: {0} Y: {1} Ш: {2} В: {3}</value>
   </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Ви впевнені, що хочете перервати запис?</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
     <value>Відкрити файл зображення...</value>
   </data>
+  <data name="Processing" xml:space="preserve">
+    <value>Обробка...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Очікування...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Повернути на 90° за годинниковою стрілкою</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Закрити (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Значення на першому кроці:</value>
+  </data>
   <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
     <value>Захопити</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>Підсвічування</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Ступінь збільшення:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Радіус скруглення:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Бітрейт:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>Друк зображення... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Показати FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Новий рядок: Enter, OK: Ctrl + Enter</value>
   </data>
   <data name="ShapeManager_CursorType" xml:space="preserve">
     <value>Тип курсора:</value>
@@ -189,11 +288,26 @@
   <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
     <value>Тінь</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Квадратна лупа</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Продовжити</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Режим редактора при запуску:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Зображення збережено</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Напрямок стрілки:</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
     <value>Захоплення всього екрану</value>
   </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Почати захоплення</value>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>Захоплення областей</value>
   </data>
   <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
     <value>Прямокутне захоплення з підсвічуванням</value>
@@ -201,8 +315,32 @@
   <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
     <value>Зберегти зображення</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Нове зображення...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>Розмиття</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Кодування...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Сила розмивання:</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>Зображення вивантажується</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Увімкнути анімації</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Перемістити назад</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
     <value>Висота:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Зображення скопійовано</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
     <value>Колір заливки...</value>
@@ -210,8 +348,17 @@
   <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
     <value>Зберегти зображення як... (Ctrl + Shift + S)</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Продовжити завдання (пробіл або ПКМ)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Розмір шрифту:</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
     <value>Розмір полотна...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>Розмір іконок меню:</value>
   </data>
   <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
     <value>Віддзеркалити по вертикалі</value>
@@ -219,17 +366,32 @@
   <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
     <value>Автообрізання...</value>
   </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>Пікселювання</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Зафіксувати меню</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
     <value>На передній план</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
     <value>Повернути на 180°</value>
   </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Легкі елементи для зміни розміру</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
     <value>Захопити останню область</value>
   </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Вставити зображення з екрану...</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
     <value>Видалити все</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Автоматично копіювати зображення до буфера обміну</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
     <value>Товщина меж:</value>
@@ -249,8 +411,17 @@
   <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
     <value>Показувати лупу</value>
   </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Пауза</value>
+  </data>
   <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
     <value>ShareX — Редактор зображень</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Колір тіні...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Переключитися на інструмент виділення після малювання фігури</value>
   </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Прозоре прямокутне захоплення</value>
@@ -258,8 +429,17 @@
   <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
     <value>Показувати інформацію про положення та розмір</value>
   </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Почати</value>
+  </data>
   <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
     <value>Зупинити захоплення</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Тип кроку:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Скопіювати зображення в буфер обміну (Ctrl + C)</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
     <value>Показувати широке перехрестя на екрані</value>
@@ -270,261 +450,81 @@
   <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
     <value>Кількість пікселів у лупі:</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Розмір шрифту:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Вставити файл зображення...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Памʼятати стан меню</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Розмір пікселя в лупі:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Радіус скруглення:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Розмір пікселя:</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Ступінь збільшення:</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Закрити (Esc)</value>
-  </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>Бітрейт:</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>Розмиття</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Автоматично копіювати зображення до буфера обміну</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Дублювати</value>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Це вікно закриється перед відкриттям веб-сторінки сполучень клавіш. Ви хочете продовжити?</value>
   </data>
   <data name="FPSLimit" xml:space="preserve">
     <value>Обмеження FPS:</value>
   </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Підсвічування</value>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Вставити файл зображення...</value>
   </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Зображення скопійовано</value>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>Масштабувати до розміру вікна при відкриванні</value>
   </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Зображення збережено</value>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Порада: Ви можете переміщувати зображення, утримуючи середню кнопку миші.</value>
   </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Зображення збережено</value>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Виконати завдання після захоплення (Enter)</value>
   </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>Зображення вивантажується</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Зафіксувати меню</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>Пауза</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Показати FPS</value>
-  </data>
-  <data name="Confirmation" xml:space="preserve">
-    <value>Підтвердження</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Додати ефекти зображення...</value>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Памʼятати стан меню</value>
   </data>
   <data name="CutOutEffectType" xml:space="preserve">
     <value>Ефект вирізання:</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Розмір ефекту вирізання:</value>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Розмір пікселя в лупі:</value>
   </data>
-  <data name="CutOutBackgroundColor" xml:space="preserve">
-    <value>Колір вирізаного тла...</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Колір тіні...</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Буфер обміну не містить зображень.</value>
-  </data>
-  <data name="ImageURL" xml:space="preserve">
-    <value>URL-адреса зображення</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Легкі елементи для зміни розміру</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>Розмір іконок меню:</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Відкрити веб-сторінку клавішних сполучень...</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>Пікселювання</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>Обробка...</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>Продовжити</value>
-  </data>
-  <data name="RulerAngle" xml:space="preserve">
-    <value>Кут</value>
-  </data>
-  <data name="RulerArea" xml:space="preserve">
-    <value>Площа</value>
-  </data>
-  <data name="RulerDistance" xml:space="preserve">
-    <value>Відстань</value>
-  </data>
-  <data name="RulerHeight" xml:space="preserve">
-    <value>Висота</value>
-  </data>
-  <data name="RulerWidth" xml:space="preserve">
-    <value>Ширина</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Почати</value>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>Налаштування інструменту</value>
   </data>
   <data name="ScreenRecordForm_Stop" xml:space="preserve">
     <value>Зупинити</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Налаштування</value>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Натисніть, щоб почати запис.</value>
   </data>
-  <data name="RulerBottom" xml:space="preserve">
-    <value>Низ</value>
+  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
+    <value>Бажаєте скинути налаштування?</value>
   </data>
-  <data name="RulerPerimeter" xml:space="preserve">
-    <value>Периметр</value>
+  <data name="Confirmation" xml:space="preserve">
+    <value>Підтвердження</value>
   </data>
-  <data name="RulerRight" xml:space="preserve">
-    <value>Право</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Ви впевнені, що хочете перервати запис?</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Новий рядок: Ctrl + Enter, OK: Enter</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Новий рядок: Enter, OK: Ctrl + Enter</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Порада: Ви можете переміщувати зображення, утримуючи середню кнопку миші.</value>
+  <data name="ImageURL" xml:space="preserve">
+    <value>URL-адреса зображення</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>Залишилися незбережені зміни.
 
 Бажаєте зберегти зміни перед закриттям редактора зображень?</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Натисніть, щоб почати запис.</value>
+  <data name="CutOutBackgroundColor" xml:space="preserve">
+    <value>Колір вирізаного тла...</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Натисніть, щоб зупинити запис.</value>
+  <data name="RulerAngle" xml:space="preserve">
+    <value>Кут</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Кодування...</value>
+  <data name="RulerPerimeter" xml:space="preserve">
+    <value>Периметр</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Очікування...</value>
+  <data name="RulerArea" xml:space="preserve">
+    <value>Площа</value>
   </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Стиль рамки:</value>
+  <data name="RulerWidth" xml:space="preserve">
+    <value>Ширина</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Сила розмивання:</value>
+  <data name="RulerHeight" xml:space="preserve">
+    <value>Висота</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Захоплення монітора</value>
+  <data name="RulerDistance" xml:space="preserve">
+    <value>Відстань</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Увімкнути анімації</value>
+  <data name="RulerRight" xml:space="preserve">
+    <value>Право</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Квадратна лупа</value>
-  </data>
-  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
-    <value>Бажаєте скинути налаштування?</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Це вікно закриється перед відкриттям веб-сторінки сполучень клавіш. Ви хочете продовжити?</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>Масштабувати до розміру вікна при відкриванні</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>Налаштування інструменту</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Нове зображення...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>Друк зображення... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Режим інтерполяції:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Режим редактора при запуску:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>Захоплення областей</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Центральні точки:</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Напрямок стрілки:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Перемістити вперед</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
-    <value>Повторити</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Вставити зображення з екрану...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Перемістити назад</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>На задній план</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>Автозакриття редактора за завданням</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Скопіювати зображення в буфер обміну (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Тип кроку:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>Переключитися на інструмент малювання після виділення фігури</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Переключитися на інструмент виділення після малювання фігури</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Продовжити завдання (пробіл або ПКМ)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Виконати завдання після захоплення (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Повернути на 90° за годинниковою стрілкою</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Повернути на 90° проти годинникової стрілки</value>
+  <data name="RulerBottom" xml:space="preserve">
+    <value>Низ</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
@@ -117,74 +117,188 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>Bắt đầu chụp</value>
+  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
+    <value>Hủy tác vụ (Esc)</value>
   </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>Dừng chụp</value>
+  <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
+    <value>Tải lên ảnh (Ctrl + U)</value>
   </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>Chụp theo vùng</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>Màu đánh dấu...</value>
   </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>Chụp hình chữ nhật (Bản nhẹ)</value>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>Chuyển qua công vụ vẽ sau khi chọn hình</value>
   </data>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>Duyệt đến ffmpeg.exe</value>
+  <data name="CutOutEffectSize" xml:space="preserve">
+    <value>Cắt bỏ kích thước hiệu ứng:</value>
   </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>Thêm hiệu ứng ảnh...</value>
   </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>Chụp hình chữ nhật kiểu trong suốt</value>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>Lật theo chiều ngang</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>Menu chú thích</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>Dừng lại</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>Chế độ đa vùng</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>Kích thước điểm ảnh:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>Kích thước ảnh...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>Xóa</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
     <value>Áp dụng thay đổi và tiếp tục tác vụ (Enter)</value>
   </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>Mở trang web chứa thiết lập phím tắt...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Nhân bản</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>Chỉnh sửa</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>Đã lưu hình ảnh</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>Tự đóng trình chỉnh sửa khi chạy tác vụ</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>Tự động cắt ảnh...</value>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>Hoàn tác</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>Độ làm mờ:</value>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>Trình chỉnh sửa ảnh</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>Màu đường viền...</value>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>Chụp theo vùng</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>Kích cỡ đường viền:</value>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>Chế độ vùng cố định kích thước</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>Đem ra phía trước</value>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>Vùng nhớ tạm không chứa hình ảnh.</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>Đem ra đằng trước nhất</value>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Dòng mới: Ctrl + Enter, OK: Enter</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
-    <value>Hủy tác vụ (Esc)</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>Chụp màn hình</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>Kích thước canvas...</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>Chụp</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>Chụp</value>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>Đẩy về phía sau</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
     <value>Chụp màn hình đang hoạt động</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>Chụp vùng lần trước</value>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>Đem ra phía trước</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>Chụp màn hình</value>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>Xoay 90° ngược chiều kim đồng hồ</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>Bắt đầu chụp</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>Chế độ nội suy:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>Rộng:</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>Bấm để dừng ghi.</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>Các điểm giữa:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>Lựa chọn</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>Kiểu viền:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>Chụp</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>Bạn có chắc chắn muốn hủy bản ghi này không?</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>Mở tệp ảnh...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>Đang xử lý...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>Đang chờ đợi...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>Xoay 90° theo chiều kim đồng hồ</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>Đóng (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>Giá trị bước đầu tiên:</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>Chụp</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>Điểm nổi bật</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>Độ phóng to:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>Bán kính góc:</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Tốc độ bit:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>In ảnh... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>Hiện tốc độ khung hình/giây (FPS)</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Dòng mới: Enter, OK: Ctrl + Enter</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>Kiểu con trỏ:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>Duyệt đến ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>Đổ bóng</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>Phóng đại kiểu hình vuông</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Tiếp tục</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>Chế độ bắt đầu trình chỉnh sửa:</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>Đã lưu hình ảnh</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>Hướng đầu mũi tên:</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
     <value>Chụp toàn màn hình</value>
@@ -192,295 +306,181 @@
   <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
     <value>Chụp theo các vùng</value>
   </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>Các điểm giữa:</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>Vùng nhớ tạm không chứa hình ảnh.</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>Tiếp tục tác vụ (Phím cách hoặc chuột phải)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>Chép ảnh vào vùng nhớ tạm (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>Bán kính góc:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>Cắt ảnh...</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>Kiểu con trỏ:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>Xóa</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>Xóa tất cả</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>Đổ bóng</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>Chỉnh sửa</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>Chế độ bắt đầu trình chỉnh sửa:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>Kích hoạt hiệu ứng hoạt hình/animation</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>Tô màu...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>Chế độ vùng cố định kích thước</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>Lật theo chiều ngang</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>Lật theo chiều dọc</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>Cỡ phông chữ:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>Rộng:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>Giá trị bước đầu tiên:</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - Trình chỉnh sửa ảnh</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>Hiện tốc độ khung hình/giây (FPS)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>Hiện vùng phóng đại</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>Hiện thông tin vị trí và kích thước</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>Hoàn tác</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
-    <value>Tải lên ảnh (Ctrl + U)</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>Dừng lại</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>Cao:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>Màu đánh dấu...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>Chế độ nội suy:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>Chế độ đa vùng</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>Ảnh mới...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>Lựa chọn</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>Mở tệp ảnh...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>Dán ảnh/văn bản</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>Kích thước điểm ảnh:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>In ảnh... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>Xoay 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>Xoay 90° theo chiều kim đồng hồ</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>Xoay 90° ngược chiều kim đồng hồ</value>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>Chụp hình chữ nhật (Bản nhẹ)</value>
   </data>
   <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
     <value>Lưu ảnh (Ctrl + S)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>Lưu ảnh thành... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>Kích thước ảnh...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>Kích cỡ phóng đại điểm ảnh:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>Chèn tệp ảnh...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>Số lượng điểm ảnh phóng đại:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>Ghi nhớ trạng thái menu</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>Chạy tác vụ sau khi chụp (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>Ảnh</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>Hiện tâm ngắm trên màn hình</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>Chèn ảnh từ màn hình...</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>Tip: Bạn có thể di chuyển ảnh bằng cách giữ nút chuột giữa và kéo.</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>Trình chỉnh sửa ảnh</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>Đẩy về sau cùng</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>Đẩy về phía sau</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>Phóng đại kiểu hình vuông</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>Chuyển qua công vụ vẽ sau khi chọn hình</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>Chuyển qua công cụ chọn hình sau khi vẽ hình</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>Đóng (Esc)</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>Thêm hiệu ứng ảnh...</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>Đổ bóng có màu...</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>Độ phóng to:</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>Mở trang web chứa thiết lập phím tắt...</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>Dùng light resize nodes</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>Cửa sổ sẽ được đóng trước khi mở trang web chứa thông tin phím tắt. Bạn có muốn tiếp tục không?</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>Tự động sao chép hình ảnh vào khay nhớ tạm</value>
-  </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>Tốc độ bit:</value>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>Ảnh mới...</value>
   </data>
   <data name="Blur" xml:space="preserve">
     <value>Làm mờ</value>
   </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>Cắt bỏ hiệu ứng:</value>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>Mã hóa ...</value>
   </data>
-  <data name="CutOutEffectSize" xml:space="preserve">
-    <value>Cắt bỏ kích thước hiệu ứng:</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>Nhân bản</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>Giới hạn FPS:</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>Điểm nổi bật</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>Đã sao chép hình ảnh</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>Đã lưu hình ảnh</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>Đã lưu hình ảnh</value>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>Độ làm mờ:</value>
   </data>
   <data name="ImageUploading" xml:space="preserve">
     <value>Tải lên hình ảnh</value>
   </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>Khóa menu</value>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>Kích hoạt hiệu ứng hoạt hình/animation</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>Đẩy về sau cùng</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>Cao:</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>Đã sao chép hình ảnh</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>Tô màu...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>Lưu ảnh thành... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>Tiếp tục tác vụ (Phím cách hoặc chuột phải)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>Cỡ phông chữ:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>Kích thước canvas...</value>
   </data>
   <data name="MenuIconSize" xml:space="preserve">
     <value>Kích thước biểu tượng menu:</value>
   </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Dòng mới: Ctrl + Enter, OK: Enter</value>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>Lật theo chiều dọc</value>
   </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Dòng mới: Enter, OK: Ctrl + Enter</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>Dừng</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>Đang xử lý...</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>Tiếp tục</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>Bạn có chắc chắn muốn hủy bản ghi này không?</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>Bấm để bắt đầu ghi.</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>Bấm để dừng ghi.</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>Bắt đầu</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>Mã hóa ...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>Đang chờ đợi...</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>Dừng</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>Hướng đầu mũi tên:</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>Kiểu viền:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>Loại bước:</value>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>Tự động cắt ảnh...</value>
   </data>
   <data name="Pixelate" xml:space="preserve">
     <value>Pixelate</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>Tùy chọn công cụ</value>
+  <data name="LockMenu" xml:space="preserve">
+    <value>Khóa menu</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>Đem ra đằng trước nhất</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>Xoay 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>Dùng light resize nodes</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>Chụp vùng lần trước</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>Chèn ảnh từ màn hình...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>Xóa tất cả</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>Tự động sao chép hình ảnh vào khay nhớ tạm</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>Kích cỡ đường viền:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>Menu chú thích</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>Dán ảnh/văn bản</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>Cắt ảnh...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>Màu đường viền...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>Hiện vùng phóng đại</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>Dừng</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - Trình chỉnh sửa ảnh</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>Đổ bóng có màu...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>Chuyển qua công cụ chọn hình sau khi vẽ hình</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>Chụp hình chữ nhật kiểu trong suốt</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>Hiện thông tin vị trí và kích thước</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>Bắt đầu</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>Dừng chụp</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>Loại bước:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>Chép ảnh vào vùng nhớ tạm (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>Hiện tâm ngắm trên màn hình</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>Ảnh</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>Số lượng điểm ảnh phóng đại:</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>Cửa sổ sẽ được đóng trước khi mở trang web chứa thông tin phím tắt. Bạn có muốn tiếp tục không?</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>Giới hạn FPS:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>Chèn tệp ảnh...</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
     <value>Thu phóng để vừa mở</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>Tip: Bạn có thể di chuyển ảnh bằng cách giữ nút chuột giữa và kéo.</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>Chạy tác vụ sau khi chụp (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>Ghi nhớ trạng thái menu</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>Cắt bỏ hiệu ứng:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>Kích cỡ phóng đại điểm ảnh:</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>Tùy chọn công cụ</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>Dừng</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>Bấm để bắt đầu ghi.</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
@@ -117,355 +117,355 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>浏览 ffmpeg.exe</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>区域捕捉</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>开始捕捉</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>停止捕捉</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>透明矩形（ShareX 窗口透明）</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>矩形捕捉（不变暗）</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>显示 FPS</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>高度：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>宽度：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>固定尺寸区域模式</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>显示屏幕宽十字线</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>放大镜像素尺寸：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>放大镜像素数量：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>方形放大镜</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>显示放大镜</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>显示位置和尺寸信息</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>多区域模式</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>选项</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>捕捉显示器</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>捕捉活动显示器</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>截图全屏</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>高亮颜色...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>像素尺寸:</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>模糊半径：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>圆角半径：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>填充颜色...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>边框尺寸：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>边框颜色...</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>截图</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>停止</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>记住菜单状态</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>阴影</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>截图区域</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>编辑</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>撤消</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>删除</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>删除全部</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>下移一层</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>置于顶层</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>置于底层</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>上移一层</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>应用更改并继续任务 (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>继续（空格或鼠标右键）</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>取消任务 (ESC)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>保存图像 (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>保存图像为… (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>将图像复制到剪贴板</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>上传图像 (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>打印图像… (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>完成捕捉任务后运行 (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>截图上次区域</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>截图</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>自动裁剪图像...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>任务中自动关闭编辑器</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>注释菜单</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>画布尺寸...</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>中心点:</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>剪贴板中无图像。</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>裁剪图像...</value>
-  </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>指针类型:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>编辑器启动模式：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>启用动画</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>水平翻转</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>垂直翻转</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>字号：</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>图像</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>图像编辑器</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>图像尺寸...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>插入图像文件...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>从屏幕中插入图像...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>插值模式:</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>新图像...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>打开图像文件...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>粘贴图像/文本</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>旋转180度</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>顺时针旋转90度</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>逆时针旋转90度</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - 图像编辑器</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>提示：按住鼠标中键并拖拽可以平移图像。</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>添加图像特效...</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>阴影颜色...</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>打开按键绑定网页...</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>高亮颜色...</value>
   </data>
   <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
     <value>选择形状后切换到绘图工具</value>
   </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>绘制形状后切换到选区工具</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>添加图像特效...</value>
   </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>此窗口将在打开按键绑定页面前关闭，要继续吗？</value>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>水平翻转</value>
   </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>使用简单的尺寸调整节点</value>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>停止</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>第一步的值：</value>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>多区域模式</value>
   </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>关闭 (Esc)</value>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>像素尺寸:</value>
   </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>放大强度:</value>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>图像尺寸...</value>
   </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>自动复制图像到剪贴板</value>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>删除</value>
   </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>高亮</value>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>应用更改并继续任务 (Enter)</value>
   </data>
-  <data name="Blur" xml:space="preserve">
-    <value>模糊</value>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>打开按键绑定网页...</value>
   </data>
   <data name="Duplicate" xml:space="preserve">
     <value>克隆</value>
   </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>帧率限制：</value>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>编辑</value>
   </data>
   <data name="ImageSaved" xml:space="preserve">
     <value>图像已保存</value>
   </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>图像已保存</value>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>任务中自动关闭编辑器</value>
   </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>图像已复制</value>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>撤消</value>
   </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>正在上传图像</value>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>图像编辑器</value>
   </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>锁定菜单</value>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>区域捕捉</value>
   </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>菜单图标大小：</value>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>固定尺寸区域模式</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>剪贴板中无图像。</value>
   </data>
   <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
     <value>回车键确认，Ctrl+回车 换行</value>
   </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>回车键换行，Ctrl+回车 确认</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>捕捉显示器</value>
   </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>像素化</value>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>置于底层</value>
   </data>
-  <data name="Processing" xml:space="preserve">
-    <value>正在处理...</value>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>捕捉活动显示器</value>
   </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>确定终止此录制？</value>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>上移一层</value>
   </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>开始</value>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>逆时针旋转90度</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>点击开始录制。</value>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>开始捕捉</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>插值模式:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>宽度：</value>
   </data>
   <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
     <value>点击停止录制。</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>正在编码...</value>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>中心点:</value>
   </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>请稍候...</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>停止</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>箭头头部方向：</value>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>选项</value>
   </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>边框样式：</value>
   </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>截图</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>确定终止此录制？</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>打开图像文件...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>正在处理...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>请稍候...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>顺时针旋转90度</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>关闭 (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>第一步的值：</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>截图</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>高亮</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>放大强度:</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>圆角半径：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>打印图像… (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>显示 FPS</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>回车键换行，Ctrl+回车 确认</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>指针类型:</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>浏览 ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>阴影</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>方形放大镜</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>编辑器启动模式：</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>图像已保存</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>箭头头部方向：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>截图全屏</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>截图区域</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>矩形捕捉（不变暗）</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>保存图像 (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>新图像...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>模糊</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>正在编码...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>模糊半径：</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>正在上传图像</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>启用动画</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>下移一层</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>高度：</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>图像已复制</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>填充颜色...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>保存图像为… (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>继续（空格或鼠标右键）</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>字号：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>画布尺寸...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>菜单图标大小：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>垂直翻转</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>自动裁剪图像...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>像素化</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>锁定菜单</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>置于顶层</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>旋转180度</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>使用简单的尺寸调整节点</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>截图上次区域</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>从屏幕中插入图像...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>删除全部</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>自动复制图像到剪贴板</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>边框尺寸：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>注释菜单</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>粘贴图像/文本</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>裁剪图像...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>边框颜色...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>显示放大镜</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - 图像编辑器</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>阴影颜色...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>绘制形状后切换到选区工具</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>透明矩形（ShareX 窗口透明）</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>显示位置和尺寸信息</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>开始</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>停止捕捉</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
     <value>步进类型：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>将图像复制到剪贴板</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>显示屏幕宽十字线</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>图像</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>放大镜像素数量：</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>此窗口将在打开按键绑定页面前关闭，要继续吗？</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>帧率限制：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>插入图像文件...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>打开时缩放到适当大小</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>提示：按住鼠标中键并拖拽可以平移图像。</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>完成捕捉任务后运行 (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>记住菜单状态</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>放大镜像素尺寸：</value>
   </data>
   <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
     <value>工具选项</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>打开时缩放到适当大小</value>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>点击开始录制。</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
@@ -53,6 +53,7 @@
     value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
+
     mimetype: application/x-microsoft.net.object.bytearray.base64
     value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
@@ -116,390 +117,390 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
-    <value>瀏覽 ffmpeg.exe</value>
-  </data>
-  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
-    <value>區域擷取</value>
-  </data>
-  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
-    <value>開始擷取</value>
-  </data>
-  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
-    <value>停止擷取</value>
-  </data>
-  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
-    <value>矩形擷取 (透明)</value>
-  </data>
-  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
-    <value>矩形擷取 (高亮)</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
-    <value>顯示幀率</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
-    <value>高：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
-    <value>寬：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
-    <value>固定尺寸區域模式</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
-    <value>顯示全螢幕十字線</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
-    <value>放大鏡像素尺寸：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
-    <value>放大鏡像素數量：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
-    <value>方形放大鏡</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
-    <value>顯示放大鏡</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
-    <value>顯示位置和尺寸資訊</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
-    <value>多區域模式</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
-    <value>選項</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
-    <value>擷取顯示器</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
-    <value>擷取目前顯示器</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
-    <value>擷取全螢幕</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
-    <value>高亮顏色...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
-    <value>像素尺寸：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
-    <value>模糊強度：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
-    <value>圓角半徑：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
-    <value>填充顏色...</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
-    <value>邊框尺寸：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
-    <value>邊框顏色...</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
-    <value>擷取</value>
-  </data>
-  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
-    <value>停止</value>
-  </data>
-  <data name="CloseEsc" xml:space="preserve">
-    <value>關閉 (Esc)</value>
-  </data>
-  <data name="DropShadowColor" xml:space="preserve">
-    <value>陰影顏色...</value>
-  </data>
-  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
-    <value>剪貼簿中無圖片。</value>
-  </data>
-  <data name="ImageEffects" xml:space="preserve">
-    <value>新增圖片效果...</value>
-  </data>
-  <data name="LightResizeNodes" xml:space="preserve">
-    <value>使用高亮尺寸調整點</value>
-  </data>
-  <data name="MagnifyStrength" xml:space="preserve">
-    <value>放大強度：</value>
-  </data>
-  <data name="OpenKeybindsPage" xml:space="preserve">
-    <value>開啟按鍵配置網頁...</value>
-  </data>
-  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
-    <value>圖片編輯器</value>
-  </data>
-  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
-    <value>ShareX - 圖片編輯器</value>
-  </data>
-  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
-    <value>提示：點擊滑鼠中鍵並拖曳即可平移圖片。</value>
-  </data>
-  <data name="ShapeManager_CenterPoints" xml:space="preserve">
-    <value>中心點：</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
-    <value>擷取</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
-    <value>啟用動畫</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
-    <value>記住選單狀態</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
-    <value>選取形狀後切換到繪圖工具</value>
-  </data>
-  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
-    <value>繪製形狀後切換到選取工具</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
-    <value>編輯器選單</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
-    <value>套用變更並繼續排程 (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
-    <value>在排程中自動關閉編輯器</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
-    <value>自動裁切圖片...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
-    <value>上移一層</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
-    <value>置於最上層</value>
-  </data>
   <data name="ShapeManager_CreateToolbar_CancelTaskEsc" xml:space="preserve">
     <value>取消排程 (Esc)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
-    <value>畫布尺寸...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
-    <value>擷取區域</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
-    <value>繼續排程 (空白鍵或滑鼠右鍵)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
-    <value>將圖片複製到剪貼簿 (Ctrl + C)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
-    <value>裁切圖片...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
-    <value>刪除</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
-    <value>刪除全部</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
-    <value>陰影</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
-    <value>編輯</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
-    <value>編輯器啟動模式：</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
-    <value>水平翻轉</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
-    <value>垂直翻轉</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
-    <value>字型大小：</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
-    <value>圖片</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
-    <value>圖片尺寸...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
-    <value>插入圖片檔案...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
-    <value>從螢幕插入圖片...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
-    <value>內插模式：</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
-    <value>擷取上個區域</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
-    <value>新圖片...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
-    <value>開啟圖片檔案...</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
-    <value>貼上圖片/文字</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
-    <value>列印圖片... (Ctrl + P)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
-    <value>旋轉 180°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
-    <value>順時針旋轉 90°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
-    <value>逆時針旋轉 90°</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
-    <value>執行擷取後的排程 (Enter)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
-    <value>儲存圖片 (Ctrl + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
-    <value>儲存圖片為... (Ctrl + Shift + S)</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
-    <value>下移一層</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
-    <value>置於底層</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
-    <value>復原</value>
   </data>
   <data name="ShapeManager_CreateToolbar_UploadImage" xml:space="preserve">
     <value>上傳圖片 (Ctrl + U)</value>
   </data>
-  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
-    <value>第一步的值：</value>
+  <data name="ShapeManager_CreateContextMenu_Highlight_color___" xml:space="preserve">
+    <value>高亮顏色...</value>
   </data>
-  <data name="ShapeManager_CursorType" xml:space="preserve">
-    <value>游標類型：</value>
-  </data>
-  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
-    <value>此視窗將在開啟按鍵配置網頁前關閉。是否要繼續？</value>
-  </data>
-  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
-    <value>是否要重設選項？</value>
-  </data>
-  <data name="AutoCopyImageToClipboard" xml:space="preserve">
-    <value>自動複製圖片到剪貼簿</value>
-  </data>
-  <data name="Bitrate" xml:space="preserve">
-    <value>位元率：</value>
-  </data>
-  <data name="Blur" xml:space="preserve">
-    <value>模糊</value>
-  </data>
-  <data name="Confirmation" xml:space="preserve">
-    <value>確認</value>
-  </data>
-  <data name="Duplicate" xml:space="preserve">
-    <value>複製</value>
-  </data>
-  <data name="FPSLimit" xml:space="preserve">
-    <value>幀率限制：</value>
-  </data>
-  <data name="Highlight" xml:space="preserve">
-    <value>高亮</value>
-  </data>
-  <data name="ImageCopied" xml:space="preserve">
-    <value>已複製圖片</value>
-  </data>
-  <data name="ImageSaved" xml:space="preserve">
-    <value>已儲存圖片</value>
-  </data>
-  <data name="ImageSavedAs" xml:space="preserve">
-    <value>已儲存圖片</value>
-  </data>
-  <data name="ImageUploading" xml:space="preserve">
-    <value>正在上傳圖片</value>
-  </data>
-  <data name="LockMenu" xml:space="preserve">
-    <value>鎖定選單</value>
-  </data>
-  <data name="MenuIconSize" xml:space="preserve">
-    <value>選單圖示大小：</value>
-  </data>
-  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
-    <value>Ctrl + Enter：換行；Enter：確認</value>
-  </data>
-  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
-    <value>Ctrl + Enter：確認；Enter：換行</value>
-  </data>
-  <data name="Pause" xml:space="preserve">
-    <value>暫停</value>
-  </data>
-  <data name="Pixelate" xml:space="preserve">
-    <value>像素化</value>
-  </data>
-  <data name="Processing" xml:space="preserve">
-    <value>處理中...</value>
-  </data>
-  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
-    <value>X: {0} Y: {1} W: {2} H: {3}</value>
-  </data>
-  <data name="Resume" xml:space="preserve">
-    <value>繼續</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
-    <value>工具選項</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
-    <value>步驟類型：</value>
-  </data>
-  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
-    <value>打開時縮放到適當大小</value>
-  </data>
-  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
-    <value>確定要取消這次錄製嗎？</value>
-  </data>
-  <data name="ScreenRecordForm_Start" xml:space="preserve">
-    <value>開始</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
-    <value>點擊開始錄製。</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
-    <value>點擊停止錄製。</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
-    <value>轉檔中...</value>
-  </data>
-  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
-    <value>等待中...</value>
-  </data>
-  <data name="ScreenRecordForm_Stop" xml:space="preserve">
-    <value>停止</value>
-  </data>
-  <data name="ShapeManager_BorderStyle" xml:space="preserve">
-    <value>邊框樣式：</value>
-  </data>
-  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
-    <value>箭頭頭部方向：</value>
+  <data name="ShapeManager_CreateContextMenu_SwitchToDrawingToolAfterSelection" xml:space="preserve">
+    <value>選取形狀後切換到繪圖工具</value>
   </data>
   <data name="CutOutEffectSize" xml:space="preserve">
     <value>剪紙效果大小：</value>
   </data>
-  <data name="CutOutEffectType" xml:space="preserve">
-    <value>剪紙效果：</value>
+  <data name="ImageEffects" xml:space="preserve">
+    <value>新增圖片效果...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipHorizontal" xml:space="preserve">
+    <value>水平翻轉</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Multi_region_mode" xml:space="preserve">
+    <value>多區域模式</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
+    <value>像素尺寸：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ImageSize" xml:space="preserve">
+    <value>圖片尺寸...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Delete" xml:space="preserve">
+    <value>刪除</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ApplyChangesContinueTaskEnter" xml:space="preserve">
+    <value>套用變更並繼續排程 (Enter)</value>
+  </data>
+  <data name="OpenKeybindsPage" xml:space="preserve">
+    <value>開啟按鍵配置網頁...</value>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>複製</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Edit" xml:space="preserve">
+    <value>編輯</value>
+  </data>
+  <data name="ImageSaved" xml:space="preserve">
+    <value>已儲存圖片</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
+    <value>在排程中自動關閉編輯器</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
+    <value>復原</value>
   </data>
   <data name="ShapeManager_CreateToolbar_Redo" xml:space="preserve">
     <value>重做</value>
   </data>
+  <data name="RegionCaptureForm_InitializeComponent_ImageEditor" xml:space="preserve">
+    <value>圖片編輯器</value>
+  </data>
+  <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
+    <value>區域擷取</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fixed_size_region_mode" xml:space="preserve">
+    <value>固定尺寸區域模式</value>
+  </data>
+  <data name="EditorStartupForm_ClipboardDoesNotContainAnImage" xml:space="preserve">
+    <value>剪貼簿中無圖片。</value>
+  </data>
+  <data name="NewLineCtrlEnterOKEnter" xml:space="preserve">
+    <value>Ctrl + Enter：換行；Enter：確認</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_monitor" xml:space="preserve">
+    <value>擷取顯示器</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendToBack" xml:space="preserve">
+    <value>置於底層</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_active_monitor" xml:space="preserve">
+    <value>擷取目前顯示器</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
+    <value>上移一層</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90CounterClockwise" xml:space="preserve">
+    <value>逆時針旋轉 90°</value>
+  </data>
+  <data name="ScrollingCaptureForm_StopCapture_Start_capture" xml:space="preserve">
+    <value>開始擷取</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InterpolationMode" xml:space="preserve">
+    <value>內插模式：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Width_" xml:space="preserve">
+    <value>寬：</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_stop_recording_" xml:space="preserve">
+    <value>點擊停止錄製。</value>
+  </data>
+  <data name="ShapeManager_CenterPoints" xml:space="preserve">
+    <value>中心點：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Options" xml:space="preserve">
+    <value>選項</value>
+  </data>
+  <data name="ShapeManager_BorderStyle" xml:space="preserve">
+    <value>邊框樣式：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture" xml:space="preserve">
+    <value>擷取</value>
+  </data>
+  <data name="RectangleRegion_GetAreaText_Area" xml:space="preserve">
+    <value>X: {0} Y: {1} W: {2} H: {3}</value>
+  </data>
+  <data name="ScreenRecordForm_ConfirmCancel" xml:space="preserve">
+    <value>確定要取消這次錄製嗎？</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_OpenImageFile" xml:space="preserve">
+    <value>開啟圖片檔案...</value>
+  </data>
+  <data name="Processing" xml:space="preserve">
+    <value>處理中...</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Waiting___" xml:space="preserve">
+    <value>等待中...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate90Clockwise" xml:space="preserve">
+    <value>順時針旋轉 90°</value>
+  </data>
+  <data name="CloseEsc" xml:space="preserve">
+    <value>關閉 (Esc)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StartingStepValue" xml:space="preserve">
+    <value>第一步的值：</value>
+  </data>
+  <data name="WebpageCaptureForm_UpdateControls_Capture" xml:space="preserve">
+    <value>擷取</value>
+  </data>
+  <data name="Highlight" xml:space="preserve">
+    <value>高亮</value>
+  </data>
+  <data name="MagnifyStrength" xml:space="preserve">
+    <value>放大強度：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Corner_radius_" xml:space="preserve">
+    <value>圓角半徑：</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>位元率：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PrintImage" xml:space="preserve">
+    <value>列印圖片... (Ctrl + P)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_FPS" xml:space="preserve">
+    <value>顯示幀率</value>
+  </data>
+  <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
+    <value>Ctrl + Enter：確認；Enter：換行</value>
+  </data>
+  <data name="ShapeManager_CursorType" xml:space="preserve">
+    <value>游標類型：</value>
+  </data>
+  <data name="FFmpegOptionsForm_buttonFFmpegBrowse_Click_Browse_for_ffmpeg_exe" xml:space="preserve">
+    <value>瀏覽 ffmpeg.exe</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DropShadow" xml:space="preserve">
+    <value>陰影</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Square_shape_magnifier" xml:space="preserve">
+    <value>方形放大鏡</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>繼續</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_EditorStartMode" xml:space="preserve">
+    <value>編輯器啟動模式：</value>
+  </data>
+  <data name="ImageSavedAs" xml:space="preserve">
+    <value>已儲存圖片</value>
+  </data>
+  <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
+    <value>箭頭頭部方向：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
+    <value>擷取全螢幕</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CaptureRegions" xml:space="preserve">
+    <value>擷取區域</value>
+  </data>
+  <data name="RectangleLight_InitializeComponent_Rectangle_capture_light" xml:space="preserve">
+    <value>矩形擷取 (高亮)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImage" xml:space="preserve">
+    <value>儲存圖片 (Ctrl + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_NewImage" xml:space="preserve">
+    <value>新圖片...</value>
+  </data>
+  <data name="Blur" xml:space="preserve">
+    <value>模糊</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Encoding___" xml:space="preserve">
+    <value>轉檔中...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Blur_radius_" xml:space="preserve">
+    <value>模糊強度：</value>
+  </data>
+  <data name="ImageUploading" xml:space="preserve">
+    <value>正在上傳圖片</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_EnableAnimations" xml:space="preserve">
+    <value>啟用動畫</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SendBackward" xml:space="preserve">
+    <value>下移一層</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Height_" xml:space="preserve">
+    <value>高：</value>
+  </data>
+  <data name="ImageCopied" xml:space="preserve">
+    <value>已複製圖片</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Fill_color___" xml:space="preserve">
+    <value>填充顏色...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_SaveImageAs" xml:space="preserve">
+    <value>儲存圖片為... (Ctrl + Shift + S)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ContinueTaskSpaceOrRightClick" xml:space="preserve">
+    <value>繼續排程 (空白鍵或滑鼠右鍵)</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FontSize" xml:space="preserve">
+    <value>字型大小：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CanvasSize" xml:space="preserve">
+    <value>畫布尺寸...</value>
+  </data>
+  <data name="MenuIconSize" xml:space="preserve">
+    <value>選單圖示大小：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_FlipVertical" xml:space="preserve">
+    <value>垂直翻轉</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AutoCropImage" xml:space="preserve">
+    <value>自動裁切圖片...</value>
+  </data>
+  <data name="Pixelate" xml:space="preserve">
+    <value>像素化</value>
+  </data>
+  <data name="LockMenu" xml:space="preserve">
+    <value>鎖定選單</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_BringToFront" xml:space="preserve">
+    <value>置於最上層</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Rotate180" xml:space="preserve">
+    <value>旋轉 180°</value>
+  </data>
+  <data name="LightResizeNodes" xml:space="preserve">
+    <value>使用高亮尺寸調整點</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_LastRegion" xml:space="preserve">
+    <value>擷取上個區域</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFromScreen" xml:space="preserve">
+    <value>從螢幕插入圖片...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_DeleteAll" xml:space="preserve">
+    <value>刪除全部</value>
+  </data>
+  <data name="AutoCopyImageToClipboard" xml:space="preserve">
+    <value>自動複製圖片到剪貼簿</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_size_" xml:space="preserve">
+    <value>邊框尺寸：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_AnnotateMenu" xml:space="preserve">
+    <value>編輯器選單</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_PasteImageText" xml:space="preserve">
+    <value>貼上圖片/文字</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CropImage" xml:space="preserve">
+    <value>裁切圖片...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Border_color___" xml:space="preserve">
+    <value>邊框顏色...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_magnifier" xml:space="preserve">
+    <value>顯示放大鏡</value>
+  </data>
+  <data name="Pause" xml:space="preserve">
+    <value>暫停</value>
+  </data>
+  <data name="RegionCaptureForm_ShowExitConfirmation_ShareXImageEditor" xml:space="preserve">
+    <value>ShareX - 圖片編輯器</value>
+  </data>
+  <data name="DropShadowColor" xml:space="preserve">
+    <value>陰影顏色...</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
+    <value>繪製形狀後切換到選取工具</value>
+  </data>
+  <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
+    <value>矩形擷取 (透明)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_position_and_size_info" xml:space="preserve">
+    <value>顯示位置和尺寸資訊</value>
+  </data>
+  <data name="ScreenRecordForm_Start" xml:space="preserve">
+    <value>開始</value>
+  </data>
+  <data name="ScrollingCaptureForm_StartCapture_Stop_capture" xml:space="preserve">
+    <value>停止擷取</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_StepType" xml:space="preserve">
+    <value>步驟類型：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_CopyImageToClipboard" xml:space="preserve">
+    <value>將圖片複製到剪貼簿 (Ctrl + C)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Show_screen_wide_crosshair" xml:space="preserve">
+    <value>顯示全螢幕十字線</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_Image" xml:space="preserve">
+    <value>圖片</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_count_" xml:space="preserve">
+    <value>放大鏡像素數量：</value>
+  </data>
+  <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
+    <value>此視窗將在開啟按鍵配置網頁前關閉。是否要繼續？</value>
+  </data>
+  <data name="FPSLimit" xml:space="preserve">
+    <value>幀率限制：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_InsertImageFile" xml:space="preserve">
+    <value>插入圖片檔案...</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ZoomToFitOnOpen" xml:space="preserve">
+    <value>打開時縮放到適當大小</value>
+  </data>
+  <data name="RegionCaptureForm_TipYouCanPanImageByHoldingMouseMiddleButtonAndDragging" xml:space="preserve">
+    <value>提示：點擊滑鼠中鍵並拖曳即可平移圖片。</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_RunAfterCaptureTasks" xml:space="preserve">
+    <value>執行擷取後的排程 (Enter)</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_RememberMenuState" xml:space="preserve">
+    <value>記住選單狀態</value>
+  </data>
+  <data name="CutOutEffectType" xml:space="preserve">
+    <value>剪紙效果：</value>
+  </data>
+  <data name="ShapeManager_CreateContextMenu_Magnifier_pixel_size_" xml:space="preserve">
+    <value>放大鏡像素尺寸：</value>
+  </data>
+  <data name="ShapeManager_CreateToolbar_ToolOptions" xml:space="preserve">
+    <value>工具選項</value>
+  </data>
+  <data name="ScreenRecordForm_Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="ScreenRecordForm_StartRecording_Click_tray_icon_to_start_recording_" xml:space="preserve">
+    <value>點擊開始錄製。</value>
+  </data>
+  <data name="WouldYouLikeToResetOptions" xml:space="preserve">
+    <value>是否要重設選項？</value>
+  </data>
+  <data name="Confirmation" xml:space="preserve">
+    <value>確認</value>
+  </data>
   <data name="ImageURL" xml:space="preserve">
     <value>圖片網址</value>
-  </data>
-  <data name="CutOutBackgroundColor" xml:space="preserve">
-    <value>剪紙背景顏色...</value>
   </data>
   <data name="RegionCaptureForm_SaveChangesBeforeClosingEditor" xml:space="preserve">
     <value>有尚未儲存的變更。
 
 是否要在關閉圖片編輯器前儲存變更？</value>
+  </data>
+  <data name="CutOutBackgroundColor" xml:space="preserve">
+    <value>剪紙背景顏色...</value>
   </data>
 </root>

--- a/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
@@ -51,14 +51,20 @@ namespace ShareX.ScreenCaptureLib
         public FFmpegNVENCPreset NVENC_Preset { get; set; } = FFmpegNVENCPreset.p4;
         public FFmpegNVENCTune NVENC_Tune { get; set; } = FFmpegNVENCTune.ll;
         public int NVENC_Bitrate { get; set; } = 3000; // kbps
+        public bool NVENC_Use_Bitrate { get; set; } = false;
+        public int NVENC_QP { get; set; } = 28;
         public FFmpegPaletteGenStatsMode GIFStatsMode { get; set; } = FFmpegPaletteGenStatsMode.full;
         public FFmpegPaletteUseDither GIFDither { get; set; } = FFmpegPaletteUseDither.sierra2_4a;
         public int GIFBayerScale { get; set; } = 2;
         public FFmpegAMFUsage AMF_Usage { get; set; } = FFmpegAMFUsage.lowlatency;
         public FFmpegAMFQuality AMF_Quality { get; set; } = FFmpegAMFQuality.speed;
         public int AMF_Bitrate { get; set; } = 3000; // kbps
+        public bool AMF_Use_Bitrate { get; set; } = false;
+        public int AMF_QP { get; set; } = 28;
         public FFmpegQSVPreset QSV_Preset { get; set; } = FFmpegQSVPreset.fast;
         public int QSV_Bitrate { get; set; } = 3000; // kbps
+        public bool QSV_Use_Bitrate { get; set; } = false;
+        public int QSV_QP { get; set; } = 28;
 
         // Audio
         public int AAC_Bitrate { get; set; } = 128; // kbps

--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecordingOptions.cs
@@ -267,20 +267,41 @@ namespace ShareX.ScreenCaptureLib
                         case FFmpegVideoCodec.hevc_nvenc:
                             args.Append($"-preset {FFmpeg.NVENC_Preset} ");
                             args.Append($"-tune {FFmpeg.NVENC_Tune} ");
-                            args.Append($"-b:v {FFmpeg.NVENC_Bitrate}k ");
+                            if (FFmpeg.NVENC_Use_Bitrate)
+                            {
+                                args.Append($"-b:v {FFmpeg.NVENC_Bitrate}k ");
+                            }
+                            else
+                            {
+                                args.Append($"-rc cqp -qp {FFmpeg.NVENC_QP} ");
+                            }
                             args.Append("-movflags +faststart "); // This will move some information to the beginning of your file and allow the video to begin playing before it is completely downloaded by the viewer
                             break;
                         case FFmpegVideoCodec.h264_amf:
                         case FFmpegVideoCodec.hevc_amf:
                             args.Append($"-usage {FFmpeg.AMF_Usage} ");
                             args.Append($"-quality {FFmpeg.AMF_Quality} ");
-                            args.Append($"-b:v {FFmpeg.AMF_Bitrate}k ");
+                            if (FFmpeg.AMF_Use_Bitrate)
+                            {
+                                args.Append($"-b:v {FFmpeg.AMF_Bitrate}k ");
+                            }
+                            else
+                            {
+                                args.Append($"-rc cqp -qp {FFmpeg.AMF_QP} ");
+                            }
                             args.Append("-pix_fmt yuv420p ");
                             break;
                         case FFmpegVideoCodec.h264_qsv: // https://trac.ffmpeg.org/wiki/Hardware/QuickSync
                         case FFmpegVideoCodec.hevc_qsv:
                             args.Append($"-preset {FFmpeg.QSV_Preset} ");
-                            args.Append($"-b:v {FFmpeg.QSV_Bitrate}k ");
+                            if (FFmpeg.QSV_Use_Bitrate)
+                            {
+                                args.Append($"-b:v {FFmpeg.QSV_Bitrate}k ");
+                            }
+                            else
+                            {
+                                args.Append($"-rc cqp -qp {FFmpeg.QSV_QP} ");
+                            }
                             break;
                         case FFmpegVideoCodec.libwebp: // https://www.ffmpeg.org/ffmpeg-codecs.html#libwebp
                             args.Append("-lossless 0 ");


### PR DESCRIPTION
I've added options to use CQP instead of a set bitrate to the hardware encoders, in the same way that CRF is implemented for x264 and x265.

I wasn't fully sure if I should enable it by default since it is a (mildly) breaking change, but I ended up doing it because I was going for "feature parity" with the software encoders. If I should change this, please let me know.