### PR TITLE
Improve delete confirmation messaging

### DIFF
--- a/ShareX.HistoryLib/HistoryItemManager.cs
+++ b/ShareX.HistoryLib/HistoryItemManager.cs
@@ -53,6 +53,7 @@ namespace ShareX.HistoryLib
         public bool IsFileExist { get; private set; }
         public bool IsImageFile { get; private set; }
         public bool IsTextFile { get; private set; }
+        public int SelectedItemCount { get; private set; }
 
         private Action<string> uploadFile, editImage, pinToScreen;
 
@@ -80,6 +81,7 @@ namespace ShareX.HistoryLib
         public HistoryItem UpdateSelectedHistoryItem()
         {
             HistoryItem[] historyItems = OnGetHistoryItems();
+            SelectedItemCount = historyItems?.Length ?? 0;
 
             if (historyItems != null && historyItems.Length > 0)
             {
@@ -103,7 +105,7 @@ namespace ShareX.HistoryLib
                 IsImageFile = IsFileExist && FileHelpers.IsImageFile(HistoryItem.FilePath);
                 IsTextFile = IsFileExist && FileHelpers.IsTextFile(HistoryItem.FilePath);
 
-                UpdateContextMenu(historyItems.Length);
+                UpdateContextMenu(SelectedItemCount);
             }
             else
             {
@@ -657,7 +659,11 @@ namespace ShareX.HistoryLib
         public void Delete()
         {
             // TODO: Translate
-            if (MessageBox.Show("Do you really want to delete this item?", "ShareX - Confirmation", MessageBoxButtons.YesNo) == DialogResult.Yes)
+            string message = SelectedItemCount > 1 ?
+                "Do you really want to delete these items?" :
+                "Do you really want to delete this item?";
+
+            if (MessageBox.Show(message, "ShareX - Confirmation", MessageBoxButtons.YesNo) == DialogResult.Yes)
             {
                 HistoryItem[] historyItems = OnGetHistoryItems();
 
@@ -671,7 +677,11 @@ namespace ShareX.HistoryLib
         public void DeleteFile()
         {
             // TODO: Translate
-            if (MessageBox.Show("Do you really want to delete this file?", "ShareX - Confirmation", MessageBoxButtons.YesNo) == DialogResult.Yes)
+            string message = SelectedItemCount > 1 ?
+                "Do you really want to delete these files?" :
+                "Do you really want to delete this file?";
+
+            if (MessageBox.Show(message, "ShareX - Confirmation", MessageBoxButtons.YesNo) == DialogResult.Yes)
             {
                 HistoryItem[] historyItems = OnGetHistoryItems();
 

--- a/ShareX.HistoryLib/HistoryItemManager.cs
+++ b/ShareX.HistoryLib/HistoryItemManager.cs
@@ -650,7 +650,7 @@ namespace ShareX.HistoryLib
             if (!string.IsNullOrEmpty(newFileName) && !HistoryItem.FileName.Equals(newFileName, StringComparison.OrdinalIgnoreCase))
             {
                 HistoryItem.FileName = newFileName;
-                  string newFilePath = FileHelpers.RenameFile(HistoryItem.FilePath, newFileName);
+                string newFilePath = FileHelpers.RenameFile(HistoryItem.FilePath, newFileName);
                 HistoryItem.FilePath = newFilePath;
                 OnEditRequested(HistoryItem);
             }


### PR DESCRIPTION
## Summary
- track selected item count in `HistoryItemManager`
- use plural-friendly confirmation prompts for Delete & DeleteFile

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d7154e09083248a780beb0b63edd3