### PR TITLE
Restore UNC path support by parsing connection string with .NET

### DIFF
--- a/ShareX.HistoryLib/HistoryManagerSQLite.cs
+++ b/ShareX.HistoryLib/HistoryManagerSQLite.cs
@@ -28,7 +28,6 @@ using ShareX.HelpersLib;
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
-using System.Text.RegularExpressions;
 
 namespace ShareX.HistoryLib
 {

--- a/ShareX.HistoryLib/HistoryManagerSQLite.cs
+++ b/ShareX.HistoryLib/HistoryManagerSQLite.cs
@@ -28,6 +28,7 @@ using ShareX.HelpersLib;
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
+using System.Text.RegularExpressions;
 
 namespace ShareX.HistoryLib
 {
@@ -46,7 +47,10 @@ namespace ShareX.HistoryLib
             FileHelpers.CreateDirectoryFromFilePath(filePath);
 
             string connectionString = $"Data Source={filePath};Version=3;";
-            connection = new SQLiteConnection(connectionString);
+            connection = new SQLiteConnection(connectionString)
+            {
+                ParseViaFramework = true
+            };
             connection.Open();
 
             SetBusyTimeout(5000);


### PR DESCRIPTION

Previously, opening a SQLite database stored on a network share via a UNC path


 e.g. `\\server\share\file.db`) would fail with `unable to open database file`

 This change uses .NET’s connection string parsing to correctly handle UNC paths,
 ensuring databases on network shares can be opened without errors.

The previous failure of parsing lies in `System.Data.Sqlite`. SnapX does not have this bug because it uses Microsoft's `Microsoft.Data.Sqlite`, which has never had this exact bug, while the bug has [stayed open for over a decade in `System.Data.Sqlite`](https://system.data.sqlite.org/home/info/283344397b)

If ShareX runs into any further issues with `System.Data.Sqlite`, I'm happy to send a PR to switch it over.

This change has been tested on SMB3 shares and works on both network drive letters and UNC paths. Most importantly, it has been tested against regular paths. 

Fixes ShareX/ShareX#8047