### PR TITLE
fix: handle old custom uploader without the field Data

### DIFF
--- a/ShareX.UploadersLib/CustomUploader/CustomUploaderItem.cs
+++ b/ShareX.UploadersLib/CustomUploader/CustomUploaderItem.cs
@@ -383,8 +383,12 @@ namespace ShareX.UploadersLib
                     }
                 }
 
-                Data = Data.Replace("$input$", "{input}", StringComparison.OrdinalIgnoreCase).
-                    Replace("$filename$", "{filename}", StringComparison.OrdinalIgnoreCase);
+                if (Data != null)
+                {
+                    Data = Data.Replace("$input$", "{input}", StringComparison.OrdinalIgnoreCase).
+                        Replace("$filename$", "{filename}", StringComparison.OrdinalIgnoreCase);
+                }
+
                 URL = MigrateOldSyntax(URL);
                 ThumbnailURL = MigrateOldSyntax(ThumbnailURL);
                 DeletionURL = MigrateOldSyntax(DeletionURL);


### PR DESCRIPTION
Handle import of old custom uploader files, between `12.3.1` (exclusive) and `13.7.1` (inclusive).

The root cause of this issue seems to stem from the upgrade to .NET 9, this does not fix that and only mitigates this specific issue.

This PR mitigates #8070 