### PR TITLE
Added sftp option to URL browser protocols

### DIFF
--- a/ShareX.UploadersLib/Enums.cs
+++ b/ShareX.UploadersLib/Enums.cs
@@ -223,7 +223,9 @@ namespace ShareX.UploadersLib
         [Description("ftps://")]
         ftps,
         [Description("file://")]
-        file
+        file,
+        [Description("sftp://")]
+        sftp
     }
 
     public enum Privacy


### PR DESCRIPTION
This change adds `sftp://` to the list of browser protocols for preview URLs, so that users who upload to SFTP sites can generate `sftp://` URLs from that to open with support programs (i.e, cyberduck)