### PR TITLE
feat: sticker rotation and centering (#5632)

### DIFF
--- a/ShareX.ScreenCaptureLib/Shapes/Drawing/StickerDrawingShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Drawing/StickerDrawingShape.cs
@@ -73,7 +73,26 @@ namespace ShareX.ScreenCaptureLib
 
         public override void Resize(int x, int y, bool fromBottomRight)
         {
-            Move(x, y);
+            // Store the current center
+            PointF center = new PointF(Rectangle.X + Rectangle.Width / 2, Rectangle.Y + Rectangle.Height / 2);
+            if (x != 0)
+            {
+                Image.RotateFlip(RotateFlipType.Rotate90FlipNone);
+            }
+            if (y != 0)
+            {
+                Image.RotateFlip(RotateFlipType.RotateNoneFlipY);
+            }
+
+            Bitmap flippedBmp = (Bitmap)Image.Clone();
+            SetImage(flippedBmp, true);
+            Rectangle = new RectangleF(
+                    center.X - flippedBmp.Width / 2,
+                    center.Y - flippedBmp.Height / 2,
+                    flippedBmp.Width,
+                    flippedBmp.Height
+                );
+
         }
 
         private bool OpenStickerForm()


### PR DESCRIPTION
- Store the current center of the sticker during resizing.
- Rotate the sticker image based on x and y movement.
- Update the rectangle to center the flipped image correctly.

Rotation is triggered using `CTRL` / `ALT` + `arrowKeys`

https://github.com/user-attachments/assets/e86e6c59-afc2-4bdb-8709-89c5a5a6567a


Closes #5632
