### PR TITLE
Add scale step option to pin to screen tool

### DIFF
--- a/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.Designer.cs
+++ b/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.Designer.cs
@@ -46,6 +46,8 @@
             this.nudMinimizeSizeWidth = new System.Windows.Forms.NumericUpDown();
             this.nudMinimizeSizeHeight = new System.Windows.Forms.NumericUpDown();
             this.lblMinimizeSizeX = new System.Windows.Forms.Label();
+            this.lblScaleStep = new System.Windows.Forms.Label();
+            this.nudScaleStep = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)(this.nudPlacementOffset)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudBorderSize)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMinimizeSizeWidth)).BeginInit();
@@ -179,11 +181,38 @@
             // 
             resources.ApplyResources(this.lblMinimizeSizeX, "lblMinimizeSizeX");
             this.lblMinimizeSizeX.Name = "lblMinimizeSizeX";
+            //
+            // lblScaleStep
+            //
+            resources.ApplyResources(this.lblScaleStep, "lblScaleStep");
+            this.lblScaleStep.Name = "lblScaleStep";
+            //
+            // nudScaleStep
+            //
+            resources.ApplyResources(this.nudScaleStep, "nudScaleStep");
+            this.nudScaleStep.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.nudScaleStep.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudScaleStep.Name = "nudScaleStep";
+            this.nudScaleStep.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
             // 
             // PinToScreenOptionsForm
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.nudScaleStep);
+            this.Controls.Add(this.lblScaleStep);
             this.Controls.Add(this.lblMinimizeSizeX);
             this.Controls.Add(this.nudMinimizeSizeHeight);
             this.Controls.Add(this.nudMinimizeSizeWidth);
@@ -232,5 +261,7 @@
         private System.Windows.Forms.NumericUpDown nudMinimizeSizeWidth;
         private System.Windows.Forms.NumericUpDown nudMinimizeSizeHeight;
         private System.Windows.Forms.Label lblMinimizeSizeX;
+        private System.Windows.Forms.Label lblScaleStep;
+        private System.Windows.Forms.NumericUpDown nudScaleStep;
     }
 }

--- a/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.cs
+++ b/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.cs
@@ -62,6 +62,7 @@ namespace ShareX
             btnBorderColor.Color = Options.BorderColor;
             nudMinimizeSizeWidth.SetValue(Options.MinimizeSize.Width);
             nudMinimizeSizeHeight.SetValue(Options.MinimizeSize.Height);
+            nudScaleStep.SetValue(Options.ScaleStep);
         }
 
         private void SaveOptions()
@@ -75,6 +76,7 @@ namespace ShareX
             Options.BorderSize = (int)nudBorderSize.Value;
             Options.BorderColor = btnBorderColor.Color;
             Options.MinimizeSize = new Size((int)nudMinimizeSizeWidth.Value, (int)nudMinimizeSizeHeight.Value);
+            Options.ScaleStep = (int)nudScaleStep.Value;
         }
 
         private void btnOK_Click(object sender, EventArgs e)

--- a/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.resx
+++ b/ShareX/Tools/PinToScreen/PinToScreenOptionsForm.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>192, 336</value>
+    <value>192, 400</value>
   </data>
   <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
     <value>104, 32</value>
@@ -144,7 +144,7 @@
     <value>16</value>
   </data>
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 336</value>
+    <value>304, 400</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>104, 32</value>
@@ -554,6 +554,57 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMinimizeSizeX.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblScaleStep.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblScaleStep.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 336</value>
+  </data>
+  <data name="lblScaleStep.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 16</value>
+  </data>
+  <data name="lblScaleStep.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblScaleStep.Text" xml:space="preserve">
+    <value>Scale step:</value>
+  </data>
+  <data name="&gt;&gt;lblScaleStep.Name" xml:space="preserve">
+    <value>lblScaleStep</value>
+  </data>
+  <data name="&gt;&gt;lblScaleStep.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblScaleStep.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblScaleStep.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="nudScaleStep.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 361</value>
+  </data>
+  <data name="nudScaleStep.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 22</value>
+  </data>
+  <data name="nudScaleStep.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="nudScaleStep.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Center</value>
+  </data>
+  <data name="&gt;&gt;nudScaleStep.Name" xml:space="preserve">
+    <value>nudScaleStep</value>
+  </data>
+  <data name="&gt;&gt;nudScaleStep.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nudScaleStep.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;nudScaleStep.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -563,7 +614,7 @@
     <value>8, 16</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>420, 380</value>
+    <value>420, 445</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 9.75pt</value>


### PR DESCRIPTION
I've recently tried to use the pin to screen tool to precisely fit an image in a frame. I wasn't successful, as the image was either too big or too small when I've adjusted its scale with the scroll wheel.

I saw in the source code that the scale step option is already implemented and just lacks a form input in the options. This pull request addresses that.

The scale step options shows up in the pin to screen options menu (NumericUpDown, min=1, max=100). No translations were added.