### PR TITLE
Use mpdecimate ffmpeg video filter for encoding GIFs

### DIFF
--- a/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecorder.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/ScreenRecorder.cs
@@ -283,6 +283,9 @@ namespace ShareX.ScreenCaptureLib
                     args.Append(":new=1");
                 }
 
+                // https://ffmpeg.org/ffmpeg-filters.html#mpdecimate
+                args.Append(",mpdecimate");
+
                 args.Append("\" ");
                 args.Append("-y ");
                 args.Append($"\"{output}\"");


### PR DESCRIPTION
When there is no activity in a GIF there is still a new frame generated every 1/framerate seconds. At the default recording of 15 FPS this means that a new frame is generated and stored in the file every 6/100 or 7/100 of a second. If nothing changed between the two frames, it is more efficient to extend the duration of the first frame and drop the second. This is what ffmpeg's mpdecimate filter does.

For more info see https://trembit.com/blog/ffmpeg-mpdecimate-filter-for-dummies/