### PR TITLE
Add automatic retry mechanism for hotkey registration

### DIFF
--- a/ShareX/ApplicationConfig.cs
+++ b/ShareX/ApplicationConfig.cs
@@ -72,6 +72,12 @@ namespace ShareX
         public HotkeyType TrayLeftDoubleClickAction = HotkeyType.OpenMainWindow;
         public HotkeyType TrayMiddleClickAction = HotkeyType.ClipboardUploadWithContentViewer;
 
+        // Hotkey retry settings - helps with race conditions at startup (e.g., OneDrive conflict)
+        // Values are clamped at runtime: HotkeyRetryCount [1-10], HotkeyRetryDelayMs [500-30000]
+        public bool HotkeyRetryEnabled = true;
+        public int HotkeyRetryCount = 3;
+        public int HotkeyRetryDelayMs = 2000;
+
         public bool AutoCheckUpdate = true;
         public UpdateChannel UpdateChannel = UpdateChannel.Release;
         // TEMP: For backward compatibility

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -365,7 +365,9 @@ namespace ShareX
                 Program.HotkeyManager.HotkeyTrigger += HandleHotkeys;
             }
 
-            Program.HotkeyManager.UpdateHotkeys(Program.HotkeysConfig.Hotkeys, !Program.IgnoreHotkeyWarning);
+            // Use retry mechanism to handle race conditions with other apps (e.g., OneDrive)
+            // Retries run in background to avoid blocking startup and WaitFormLoad timeout
+            Program.HotkeyManager.UpdateHotkeysWithBackgroundRetry(Program.HotkeysConfig.Hotkeys, !Program.IgnoreHotkeyWarning);
 
             DebugHelper.WriteLine("HotkeyManager started.");
 


### PR DESCRIPTION
## Summary
- Add automatic retry mechanism for hotkey registration to handle race conditions at startup
- Fixes the common issue where OneDrive (or other apps) temporarily claim PrintScreen hotkeys before ShareX can register them
- New configurable settings: `HotkeyRetryEnabled`, `HotkeyRetryCount`, `HotkeyRetryDelayMs`
- Backward compatible - existing `UpdateHotkeys()` method preserved

## Problem

When ShareX starts, it immediately attempts to register global hotkeys using the Win32 `RegisterHotKey` API. Other applications like OneDrive often claim these same hotkeys (PrintScreen, Alt+PrintScreen) during their own startup sequence, causing:

1. ShareX calls `RegisterAllHotkeys()` immediately at startup
2. OneDrive has already registered the hotkey
3. `RegisterHotKey` returns `false`, hotkey status set to `Failed`
4. "Hotkey registration failed" error dialog shown
5. User must manually restart ShareX or open Hotkey Settings

**Note:** OneDrive claims these hotkeys even when its screenshot feature is disabled.

## Solution

### New Method: `UpdateHotkeysWithBackgroundRetry()`
- Performs initial registration synchronously (fast startup)
- If hotkeys fail, starts background retry task (fire-and-forget)
- **Does not block `IsReady`** - CLI invocations from second instances work immediately
- Shows error dialog only after all retry attempts are exhausted

### New Configuration Settings (ApplicationConfig)

| Setting | Default | Range | Description |
|---------|---------|-------|-------------|
| `HotkeyRetryEnabled` | true | - | Enable/disable automatic retry |
| `HotkeyRetryCount` | 3 | 1-10 | Number of retry attempts |
| `HotkeyRetryDelayMs` | 2000 | 500-30000 | Delay between retries (ms) |

## Security Considerations

Settings are clamped to safe ranges to prevent DoS via malicious config files:
- Max retry count: 10 (prevents infinite loops)
- Max delay: 30 seconds (prevents extreme startup delays)
- Worst case: 10 × 30s = 5 minutes background retry window

## Files Changed

| File | Changes |
|------|---------|
| `ShareX/ApplicationConfig.cs` | Added 3 new settings for retry configuration |
| `ShareX/HotkeyManager.cs` | Added `UpdateHotkeysWithBackgroundRetry()`, `RetryFailedHotkeysInBackgroundAsync()`, and `HasFailedHotkeys()` |
| `ShareX/Forms/MainForm.cs` | Updated `InitHotkeys()` to use non-blocking retry method |

## Related Issues

- #6581 - OneDrive causing hotkey conflict
- #3431 - Hotkey registration failed (every Windows 10 install)
- #5720 - Conflict with OneDrive
- #6193 - Suggestion for OneDrive instructions
- #1144 - Windows 10 standard shortcuts fail
- #7461 - Error on startup - Unable to register hotkey