### PR TITLE
Fix: Add robust FFmpeg fallback for WebP encoding when native codecs fail

### DIFF
--- a/ShareX.HelpersLib/Enums.cs
+++ b/ShareX.HelpersLib/Enums.cs
@@ -63,7 +63,9 @@ namespace ShareX.HelpersLib
         [Description("bmp")]
         BMP,
         [Description("tif")]
-        TIFF
+        TIFF,
+        [Description("webp")]
+        WEBP
     }
 
     public enum HashType

--- a/ShareX.HelpersLib/Helpers/ImageHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/ImageHelpers.cs
@@ -2127,8 +2127,8 @@ namespace ShareX.HelpersLib
         {
             using (OpenFileDialog ofd = new OpenFileDialog())
             {
-                ofd.Filter = "Image files (*.png, *.jpg, *.jpeg, *.jpe, *.jfif, *.gif, *.bmp, *.tif, *.tiff)|*.png;*.jpg;*.jpeg;*.jpe;*.jfif;*.gif;*.bmp;*.tif;*.tiff|" +
-                    "PNG (*.png)|*.png|JPEG (*.jpg, *.jpeg, *.jpe, *.jfif)|*.jpg;*.jpeg;*.jpe;*.jfif|GIF (*.gif)|*.gif|BMP (*.bmp)|*.bmp|TIFF (*.tif, *.tiff)|*.tif;*.tiff";
+                ofd.Filter = "Image files (*.png, *.jpg, *.jpeg, *.jpe, *.jfif, *.gif, *.bmp, *.tif, *.tiff, *.webp)|*.png;*.jpg;*.jpeg;*.jpe;*.jfif;*.gif;*.bmp;*.tif;*.tiff;*.webp|" +
+                    "PNG (*.png)|*.png|JPEG (*.jpg, *.jpeg, *.jpe, *.jfif)|*.jpg;*.jpeg;*.jpe;*.jfif|GIF (*.gif)|*.gif|BMP (*.bmp)|*.bmp|TIFF (*.tif, *.tiff)|*.tif;*.tiff|WEBP (*.webp)|*.webp";
 
                 ofd.Multiselect = multiselect;
 
@@ -2182,6 +2182,25 @@ namespace ShareX.HelpersLib
         public static bool SaveImage(Image img, string filePath)
         {
             FileHelpers.CreateDirectoryFromFilePath(filePath);
+
+            string ext = FileHelpers.GetFileNameExtension(filePath);
+
+            if (!string.IsNullOrEmpty(ext) && ext.Equals("webp", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    SaveWEBP(img, filePath, 75);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    DebugHelper.WriteException(e);
+                    e.ShowError();
+                }
+
+                return false;
+            }
+
             ImageFormat imageFormat = GetImageFormat(filePath);
 
             try
@@ -2202,7 +2221,7 @@ namespace ShareX.HelpersLib
         {
             using (SaveFileDialog sfd = new SaveFileDialog())
             {
-                sfd.Filter = "PNG (*.png)|*.png|JPEG (*.jpg, *.jpeg, *.jpe, *.jfif)|*.jpg;*.jpeg;*.jpe;*.jfif|GIF (*.gif)|*.gif|BMP (*.bmp)|*.bmp|TIFF (*.tif, *.tiff)|*.tif;*.tiff";
+                sfd.Filter = "PNG (*.png)|*.png|JPEG (*.jpg, *.jpeg, *.jpe, *.jfif)|*.jpg;*.jpeg;*.jpe;*.jfif|GIF (*.gif)|*.gif|BMP (*.bmp)|*.bmp|TIFF (*.tif, *.tiff)|*.tif;*.tiff|WEBP (*.webp)|*.webp";
                 sfd.DefaultExt = "png";
 
                 string initialDirectory = null;
@@ -2249,6 +2268,9 @@ namespace ShareX.HelpersLib
                             case "tif":
                             case "tiff":
                                 sfd.FilterIndex = 5;
+                                break;
+                            case "webp":
+                                sfd.FilterIndex = 6;
                                 break;
                         }
                     }
@@ -3039,6 +3061,100 @@ namespace ShareX.HelpersLib
 
             return ms;
         }
+
+        public static MemoryStream SaveWEBP(Image img, int quality)
+        {
+            MemoryStream ms = new MemoryStream();
+            SaveWEBP(img, ms, quality);
+            return ms;
+        }
+
+        public static void SaveWEBP(Image img, string filePath, int quality)
+        {
+            using (FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            {
+                SaveWEBP(img, fs, quality);
+            }
+        }
+
+        public static void SaveWEBP(Image img, Stream stream, int quality)
+        {
+            quality = quality.Clamp(0, 100);
+
+            try
+            {
+                // Try GDI+ Encoder first
+                ImageCodecInfo webpCodec = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.MimeType == "image/webp");
+
+                if (webpCodec != null)
+                {
+                    using (EncoderParameters encoderParameters = new EncoderParameters(1))
+                    {
+                        encoderParameters.Param[0] = new EncoderParameter(System.Drawing.Imaging.Encoder.Quality, quality);
+                        img.Save(stream, webpCodec, encoderParameters);
+                    }
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugHelper.WriteException(ex);
+            }
+
+            // Try WPF WIC Encoder second
+            try
+            {
+                // Use the known GUID for the WebP WIC encoder (Google's or Microsoft's)
+                // {275D7A94-C8E6-4E83-8B7C-A54A6B63B6F6} for WebP
+                Guid webpGuid = new Guid("275D7A94-C8E6-4E83-8B7C-A54A6B63B6F6");
+                
+                BitmapSource bitmapSource;
+                IntPtr hBitmap;
+
+                if (img is Bitmap bmp)
+                {
+                    hBitmap = bmp.GetHbitmap();
+                }
+                else
+                {
+                    using (Bitmap newBmp = new Bitmap(img))
+                    {
+                        hBitmap = newBmp.GetHbitmap();
+                    }
+                }
+
+                try
+                {
+                    bitmapSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                        hBitmap,
+                        IntPtr.Zero,
+                        System.Windows.Int32Rect.Empty,
+                        BitmapSizeOptions.FromEmptyOptions());
+
+                    BitmapEncoder encoder = BitmapEncoder.Create(webpGuid);
+                    encoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+                    encoder.Save(stream);
+                    return;
+                }
+                finally
+                {
+                     NativeMethods.DeleteObject(hBitmap);
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugHelper.WriteException(ex);
+            }
+
+            if (FFmpegWebPSaver != null && FFmpegWebPSaver(img, stream, quality))
+            {
+                return;
+            }
+
+            throw new Exception("WebP encoder not found. Native and WIC encoders failed. External FFmpeg fallback failed or not found (see debug log or install FFmpeg/WebP Extensions).");
+        }
+
+        public static Func<Image, Stream, int, bool> FFmpegWebPSaver { get; set; }
 
         public static MemoryStream SaveGIF(Image img, GIFQuality quality)
         {

--- a/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
+++ b/ShareX.ScreenCaptureLib/ScreenRecording/FFmpegOptions.cs
@@ -25,6 +25,7 @@
 
 using ShareX.HelpersLib;
 using System;
+using System.IO;
 
 namespace ShareX.ScreenCaptureLib
 {
@@ -75,7 +76,30 @@ namespace ShareX.ScreenCaptureLib
                     return FileHelpers.GetAbsolutePath(CLIPath);
                 }
 
-                return FileHelpers.GetAbsolutePath("ffmpeg.exe");
+                string localPath = FileHelpers.GetAbsolutePath("ffmpeg.exe");
+                if (File.Exists(localPath)) return localPath;
+
+                // Fallback 1: Personal Tools folder (Standard ShareX location)
+                string personalPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ShareX", "Tools", "ffmpeg.exe");
+                if (File.Exists(personalPath)) return personalPath;
+
+                // Fallback 2: Check PATH
+                var pathEnv = Environment.GetEnvironmentVariable("PATH");
+                if (!string.IsNullOrEmpty(pathEnv))
+                {
+                    foreach (var p in pathEnv.Split(Path.PathSeparator))
+                    {
+                        try 
+                        {
+                            var fullPath = Path.Combine(p.Trim(), "ffmpeg.exe");
+                            if (File.Exists(fullPath)) return fullPath;
+                        }
+                        catch {}
+                    }
+                }
+
+                // Default to local path even if missing, so error message shows expected location
+                return localPath;
             }
         }
 

--- a/ShareX/Forms/MainForm.cs
+++ b/ShareX/Forms/MainForm.cs
@@ -25,7 +25,10 @@
 
 using ShareX.HelpersLib;
 using ShareX.ImageEffectsLib;
+using ShareX.MediaLib;
 using ShareX.Properties;
+using ShareX.HelpersLib;
+using System.IO.Compression;
 using ShareX.ScreenCaptureLib;
 using ShareX.UploadersLib;
 using System;
@@ -33,6 +36,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -51,6 +55,194 @@ namespace ShareX
         public MainForm()
         {
             InitializeControls();
+            InitializeWebPFallback();
+        }
+
+        private void InitializeWebPFallback()
+        {
+            ImageHelpers.FFmpegWebPSaver = (img, stream, quality) =>
+            {
+                string ffmpegPath = Program.DefaultTaskSettings.CaptureSettings.FFmpegOptions.FFmpegPath;
+                StringBuilder sbDebug = new StringBuilder();
+                sbDebug.AppendLine("FFmpeg Discovery Log:");
+
+                // 1. Check configured path
+                if (!string.IsNullOrEmpty(ffmpegPath) && File.Exists(ffmpegPath))
+                {
+                    sbDebug.AppendLine($"[Success] Found configured path: {ffmpegPath}");
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(ffmpegPath)) sbDebug.AppendLine($"[Fail] Configured path not found: {ffmpegPath}");
+
+                    // 2. Check "Tools" folder in Personal Folder (Documents/ShareX/Tools/ffmpeg.exe)
+                    string personalTools = Path.Combine(Program.PersonalFolder, "Tools", "ffmpeg.exe");
+                    if (File.Exists(personalTools))
+                    {
+                        ffmpegPath = personalTools;
+                        sbDebug.AppendLine($"[Success] Found personal tools path: {ffmpegPath}");
+                    }
+                    else
+                    {
+                        sbDebug.AppendLine($"[Fail] Personal tools path: {personalTools}");
+                        
+                         // 3. Check Base Directory and Tools subdirectory
+                        string[] searchPaths = new string[] 
+                        { 
+                            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ffmpeg.exe"),
+                            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tools", "ffmpeg.exe") 
+                        };
+
+                        foreach (string path in searchPaths)
+                        {
+                            if (File.Exists(path))
+                            {
+                                ffmpegPath = path;
+                                sbDebug.AppendLine($"[Success] Found app directory path: {ffmpegPath}");
+                                break;
+                            }
+                            sbDebug.AppendLine($"[Fail] App directory path: {path}");
+                        }
+                    }
+
+                    // 4. Check PATH
+                    if (string.IsNullOrEmpty(ffmpegPath) || !File.Exists(ffmpegPath))
+                    {
+                        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+                        if (!string.IsNullOrEmpty(pathEnv))
+                        {
+                            foreach (var p in pathEnv.Split(Path.PathSeparator))
+                            {
+                                try 
+                                {
+                                    var fullPath = Path.Combine(p.Trim(), "ffmpeg.exe");
+                                    if (File.Exists(fullPath))
+                                    {
+                                        ffmpegPath = fullPath;
+                                        sbDebug.AppendLine($"[Success] Found in PATH: {ffmpegPath}");
+                                        break;
+                                    }
+                                }
+                                catch {}
+                            }
+                        }
+                    }
+                }
+
+                if (string.IsNullOrEmpty(ffmpegPath) || !File.Exists(ffmpegPath))
+                {
+                    // Prompt user to download FFmpeg
+                    DialogResult dr = MessageBox.Show(
+                        "FFmpeg is required for WebP encoding because native Windows components are missing.\n\n" +
+                        "Would you like to download FFmpeg automatically?", 
+                        "ShareX - FFmpeg Missing", 
+                        MessageBoxButtons.YesNo, 
+                        MessageBoxIcon.Question);
+                    
+                    if (dr == DialogResult.Yes)
+                    {
+                        try 
+                        {
+                            var toolsFolder = Path.Combine(Program.PersonalFolder, "Tools");
+                            FileHelpers.CreateDirectory(toolsFolder);
+
+                            // Use a direct reliable URL fallback to avoid empty URL issues failing the downloader
+                            string url = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip";
+                            
+                            using (DownloaderForm form = new DownloaderForm(url, "ffmpeg.zip"))
+                            {
+                                form.InstallType = InstallType.Event;
+                                form.RunInstallerInBackground = false;
+                                form.InstallRequested += (filePath) => 
+                                {
+                                    try 
+                                    {
+                                        using (ZipArchive archive = ZipFile.OpenRead(filePath))
+                                        {
+                                            var entry = archive.Entries.FirstOrDefault(e => e.Name.Equals("ffmpeg.exe", StringComparison.OrdinalIgnoreCase));
+                                            if (entry != null)
+                                            {
+                                                string destinationPath = Path.Combine(toolsFolder, "ffmpeg.exe");
+                                                if (File.Exists(destinationPath)) File.Delete(destinationPath);
+                                                entry.ExtractToFile(destinationPath);
+                                                ffmpegPath = destinationPath;
+                                            }
+                                            else
+                                            {
+                                                DebugHelper.WriteLine("ffmpeg.exe not found in archive: " + filePath);
+                                            }
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        DebugHelper.WriteException(ex);
+                                    }
+                                };
+                                form.ShowDialog();
+                            }
+                            
+                            // Check if download succeeded and set path
+                            string potentialPath = Path.Combine(toolsFolder, "ffmpeg.exe");
+                            if (File.Exists(potentialPath))
+                            {
+                                ffmpegPath = potentialPath;
+                                sbDebug.AppendLine($"[Success] Downloaded to: {ffmpegPath}");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            sbDebug.AppendLine($"[Fail] Download attempt failed: {ex.Message}");
+                        }
+                    }
+                }
+
+                if (string.IsNullOrEmpty(ffmpegPath) || !File.Exists(ffmpegPath))
+                {
+                    // Throw specific error instead of returning false
+                    throw new FileNotFoundException($"FFmpeg not found. Please install FFmpeg or set the path in Task Settings.\n\n{sbDebug.ToString()}");
+                }
+
+                string tempPngPath = Path.Combine(Path.GetTempPath(), "ShareX_temp_" + Guid.NewGuid().ToString() + ".png");
+                string tempWebpPath = Path.Combine(Path.GetTempPath(), "ShareX_temp_" + Guid.NewGuid().ToString() + ".webp");
+
+                try
+                {
+                    img.Save(tempPngPath, System.Drawing.Imaging.ImageFormat.Png);
+
+                    quality = Math.Max(0, Math.Min(100, quality));
+                    
+                    string args = $"-y -i \"{tempPngPath}\" -c:v libwebp -q:v {quality} \"{tempWebpPath}\"";
+                    
+                    FFmpegCLIManager ffmpeg = new FFmpegCLIManager(ffmpegPath);
+                    if (ffmpeg.Run(args))
+                    {
+                        if (File.Exists(tempWebpPath))
+                        {
+                            byte[] bytes = File.ReadAllBytes(tempWebpPath);
+                            stream.Write(bytes, 0, bytes.Length);
+                            return true;
+                        }
+                        else
+                        {
+                            throw new FileNotFoundException("FFmpeg reported success but output file described not found: " + tempWebpPath);
+                        }
+                    }
+                    else
+                    {
+                       throw new Exception($"FFmpeg execution failed for '{ffmpegPath}'.\nArguments: {args}\nOutput:\n{ffmpeg.Output.ToString()}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    DebugHelper.WriteException(ex);
+                    throw; // Re-throw to show the user
+                }
+                finally
+                {
+                    if (File.Exists(tempPngPath)) File.Delete(tempPngPath);
+                    if (File.Exists(tempWebpPath)) File.Delete(tempWebpPath);
+                }
+            };
         }
 
         private async void MainForm_HandleCreated(object sender, EventArgs e)
@@ -233,6 +425,8 @@ namespace ShareX
 #endif
 
             HandleCreated += MainForm_HandleCreated;
+
+
         }
 
         public async Task UpdateControls()

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -233,7 +233,6 @@ namespace ShareX
             cbImageFormat.SelectedIndex = (int)TaskSettings.ImageSettings.ImageFormat;
             cbImagePNGBitDepth.Items.AddRange(Helpers.GetLocalizedEnumDescriptions<PNGBitDepth>());
             cbImagePNGBitDepth.SelectedIndex = (int)TaskSettings.ImageSettings.ImagePNGBitDepth;
-            nudImageJPEGQuality.SetValue(TaskSettings.ImageSettings.ImageJPEGQuality);
             cbImageGIFQuality.Items.AddRange(Helpers.GetLocalizedEnumDescriptions<GIFQuality>());
             cbImageGIFQuality.SelectedIndex = (int)TaskSettings.ImageSettings.ImageGIFQuality;
             cbImageAutoUseJPEG.Checked = TaskSettings.ImageSettings.ImageAutoUseJPEG;
@@ -970,6 +969,7 @@ namespace ShareX
         private void cbImageFormat_SelectedIndexChanged(object sender, EventArgs e)
         {
             TaskSettings.ImageSettings.ImageFormat = (EImageFormat)cbImageFormat.SelectedIndex;
+            UpdateImageQualityControls();
         }
 
         private void cbImagePNGBitDepth_SelectedIndexChanged(object sender, EventArgs e)
@@ -977,9 +977,37 @@ namespace ShareX
             TaskSettings.ImageSettings.ImagePNGBitDepth = (PNGBitDepth)cbImagePNGBitDepth.SelectedIndex;
         }
 
+        private void UpdateImageQualityControls()
+        {
+            if (TaskSettings.ImageSettings.ImageFormat == EImageFormat.JPEG)
+            {
+                lblImageJPEGQuality.Text = "JPEG quality:";
+                nudImageJPEGQuality.Enabled = true;
+                nudImageJPEGQuality.SetValue(TaskSettings.ImageSettings.ImageJPEGQuality);
+            }
+            else if (TaskSettings.ImageSettings.ImageFormat == EImageFormat.WEBP)
+            {
+                lblImageJPEGQuality.Text = "WEBP quality:";
+                nudImageJPEGQuality.Enabled = true;
+                nudImageJPEGQuality.SetValue(TaskSettings.ImageSettings.ImageWEBPQuality);
+            }
+            else
+            {
+                lblImageJPEGQuality.Text = "JPEG quality:";
+                nudImageJPEGQuality.Enabled = false;
+            }
+        }
+
         private void nudImageJPEGQuality_ValueChanged(object sender, EventArgs e)
         {
-            TaskSettings.ImageSettings.ImageJPEGQuality = (int)nudImageJPEGQuality.Value;
+            if (TaskSettings.ImageSettings.ImageFormat == EImageFormat.WEBP)
+            {
+                TaskSettings.ImageSettings.ImageWEBPQuality = (int)nudImageJPEGQuality.Value;
+            }
+            else
+            {
+                TaskSettings.ImageSettings.ImageJPEGQuality = (int)nudImageJPEGQuality.Value;
+            }
         }
 
         private void cbImageGIFQuality_SelectedIndexChanged(object sender, EventArgs e)

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -431,11 +431,11 @@ namespace ShareX
         public static MemoryStream SaveImageAsStream(Image img, EImageFormat imageFormat, TaskSettings taskSettings)
         {
             return SaveImageAsStream(img, imageFormat, taskSettings.ImageSettings.ImagePNGBitDepth,
-                taskSettings.ImageSettings.ImageJPEGQuality, taskSettings.ImageSettings.ImageGIFQuality);
+                taskSettings.ImageSettings.ImageJPEGQuality, taskSettings.ImageSettings.ImageWEBPQuality, taskSettings.ImageSettings.ImageGIFQuality);
         }
 
         public static MemoryStream SaveImageAsStream(Image img, EImageFormat imageFormat, PNGBitDepth pngBitDepth = PNGBitDepth.Automatic,
-            int jpegQuality = 90, GIFQuality gifQuality = GIFQuality.Default)
+            int jpegQuality = 90, int webpQuality = 75, GIFQuality gifQuality = GIFQuality.Default)
         {
             MemoryStream ms = new MemoryStream();
 
@@ -468,6 +468,9 @@ namespace ShareX
                         break;
                     case EImageFormat.TIFF:
                         img.Save(ms, ImageFormat.Tiff);
+                        break;
+                    case EImageFormat.WEBP:
+                        ImageHelpers.SaveWEBP(img, ms, webpQuality);
                         break;
                 }
             }

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -338,6 +338,7 @@ namespace ShareX
         public EImageFormat ImageFormat = EImageFormat.PNG;
         public PNGBitDepth ImagePNGBitDepth = PNGBitDepth.Default;
         public int ImageJPEGQuality = 90;
+        public int ImageWEBPQuality = 75;
         public GIFQuality ImageGIFQuality = GIFQuality.Default;
         public bool ImageAutoUseJPEG = true;
         public int ImageAutoUseJPEGSize = 2048;


### PR DESCRIPTION
This PR addresses the "WEBP encoder not found" error by implementing a robust fallback mechanism using FFmpeg.

### Changes:
- **FFmpeg Fallback**: If standard Windows/WIC WebP encoders fail, ShareX will now attempt to use FFmpeg.
- **Automatic FFmpeg Download**: If FFmpeg is not found, the user is prompted to download it automatically (using a reliable build from gyan.dev).
- **Enhanced Discovery**: Improved logic to find `ffmpeg.exe` in common locations (Config, Tools folder, App directory, PATH).
- **Personal Tools Folder**: Ensures the downloaded FFmpeg is placed in `Documents/ShareX/Tools/` and that this path is checked by the Screen Recorder as well.

Closes #5250
Closes #6090
