### PR TITLE
Onboard onto Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <!-- Disable CPM for the ImageEditor submodule which manages its own package versions -->
+    <ManagePackageVersionsCentrally Condition="!$(MSBuildProjectDirectory.Contains('ImageEditor'))">true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FluentFTP" Version="53.0.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.2" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="ZXing.Net" Version="0.16.11" />
+    <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.14" />
+  </ItemGroup>
+</Project>

--- a/ShareX.HelpersLib/ShareX.HelpersLib.csproj
+++ b/ShareX.HelpersLib/ShareX.HelpersLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
@@ -7,6 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 </Project>

--- a/ShareX.HistoryLib/ShareX.HistoryLib.csproj
+++ b/ShareX.HistoryLib/ShareX.HistoryLib.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />

--- a/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
+++ b/ShareX.ImageEffectsLib/ShareX.ImageEffectsLib.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />

--- a/ShareX.IndexerLib/ShareX.IndexerLib.csproj
+++ b/ShareX.IndexerLib/ShareX.IndexerLib.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />

--- a/ShareX.UploadersLib/ShareX.UploadersLib.csproj
+++ b/ShareX.UploadersLib/ShareX.UploadersLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
@@ -6,9 +6,9 @@
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="53.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+    <PackageReference Include="FluentFTP" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />

--- a/ShareX/ShareX.csproj
+++ b/ShareX/ShareX.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
     <OutputType>WinExe</OutputType>
@@ -15,9 +15,9 @@
     <CETCompat>false</CETCompat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="ZXing.Net" Version="0.16.11" />
-    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.14" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="ZXing.Net" />
+    <PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ImageEditor\src\ShareX.ImageEditor\ShareX.ImageEditor.csproj" />


### PR DESCRIPTION
This pull request introduces the NuGet [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) feature to streamline dependency management. Key benefits and changes include:

- **Centralized Version Management**: All NuGet package versions are now managed centrally in the `Directory.Packages.props` file. This ensures consistency across all projects in the repository.
  
- **Simplified Project Files**: The individual project files are simplified, as they no longer need to specify version numbers for NuGet packages. This change reduces duplication and the potential for version conflicts.
  
- **Ease of Updating Dependencies**: Updating a package version is now a matter of changing it in one place, making the process of keeping dependencies up-to-date more straightforward and less error-prone.

By implementing Central Package Versioning, you're taking a significant step towards more efficient and reliable dependency management. This change will be particularly beneficial to assist with tools like Dependabot. These tools automate dependency updates, and having a centralized versioning system significantly enhances their effectiveness, ensuring a smooth and consistent update process.