### PR TITLE
fix: correct alignment text in zh-CN and zh-TW resource files

### DIFF
--- a/ShareX.HelpersLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.HelpersLib/Properties/Resources.zh-CN.resx
@@ -1050,7 +1050,7 @@
     <value>正上</value>
   </data>
   <data name="ContentAlignment_TopRight" xml:space="preserve">
-    <value>右下</value>
+    <value>右上</value>
   </data>
   <data name="ContentAlignment_MiddleLeft" xml:space="preserve">
     <value>左中</value>

--- a/ShareX.HelpersLib/Properties/Resources.zh-TW.resx
+++ b/ShareX.HelpersLib/Properties/Resources.zh-TW.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1050,7 +1050,7 @@
     <value>正上</value>
   </data>
   <data name="ContentAlignment_TopRight" xml:space="preserve">
-    <value>左上</value>
+    <value>右上</value>
   </data>
   <data name="ContentAlignment_MiddleLeft" xml:space="preserve">
     <value>左中</value>


### PR DESCRIPTION
## Summary
Fixes the Chinese translation for the Brief Notifications **Location** option (Task Settings → General → Notifications → Brief Notifications).

## Changes
- **zh-CN (Simplified Chinese):** `ContentAlignment_TopRight` — 右下 (bottom right) → **右上** (top right)
- **zh-TW (Traditional Chinese):** `ContentAlignment_TopRight` — 左上 (top left) → **右上** (top right)

The first option in the Location dropdown now correctly shows “top right” in both Chinese locales.

Closes #8401