### PR TITLE
Add smoothing and curve interpolation to freehand drawing tools

### DIFF
--- a/ShareX.HelpersLib/Extensions/Extensions.cs
+++ b/ShareX.HelpersLib/Extensions/Extensions.cs
@@ -400,6 +400,34 @@ namespace ShareX.HelpersLib
             return result;
         }
 
+        public static PointF SmoothPoint(this List<PointF> points, PointF currentPos, int smoothing)
+        {
+            smoothing = Math.Max(0, Math.Min(smoothing, 10));
+            int windowSize = Math.Min(smoothing * 4, points.Count);
+
+            if (windowSize < 1)
+            {
+                return currentPos;
+            }
+
+            float sumX = currentPos.X;
+            float sumY = currentPos.Y;
+            float weight = 1f;
+            float totalWeight = weight;
+            float decay = 0.6f + (smoothing * 0.0175f);
+
+            for (int i = 0; i < windowSize; i++)
+            {
+                PointF p = points[points.Count - 1 - i];
+                weight *= decay;
+                sumX += p.X * weight;
+                sumY += p.Y * weight;
+                totalWeight += weight;
+            }
+
+            return new PointF(sumX / totalWeight, sumY / totalWeight);
+        }
+
         public static Point Center(this Rectangle rect)
         {
             return new Point(rect.X + (rect.Width / 2), rect.Y + (rect.Height / 2));

--- a/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.Designer.cs
@@ -1596,6 +1596,24 @@ namespace ShareX.ScreenCaptureLib.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Smoothing:.
+        /// </summary>
+        internal static string ShapeManager_FreehandSmoothing {
+            get {
+                return ResourceManager.GetString("ShapeManager_FreehandSmoothing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Curve interpolation.
+        /// </summary>
+        internal static string ShapeManager_FreehandCurveInterpolation {
+            get {
+                return ResourceManager.GetString("ShapeManager_FreehandCurveInterpolation", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Border style:.
         /// </summary>
         internal static string ShapeManager_BorderStyle {

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ar-YE.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ar-YE.resx
@@ -252,6 +252,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>اتجاه رأس السهم:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>التنعيم:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>استيفاء المنحنى</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>إغلاق المحرّر بشكل تلقائي عند بدء مهمة</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.de.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.de.resx
@@ -381,6 +381,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Richtung der Pfeilspitze:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Glättung:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Kurveninterpolation</value>
+  </data>
   <data name="ShapeManager_CreateContextMenu_Capture_fullscreen" xml:space="preserve">
     <value>Vollbild aufnehmen</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.es-MX.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.es-MX.resx
@@ -384,6 +384,12 @@
   <data name="ShapeManager_CreateContextMenu_SwitchToSelectionToolAfterDrawing" xml:space="preserve">
     <value>Cambiar a herramienta de selección después de dibujar una forma</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Suavizado:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolación de curva</value>
+  </data>
   <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
     <value>Esta ventana se cerrará antes de abrir la página web de atajos de teclado. ¿Desea continuar?</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.es.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.es.resx
@@ -132,4 +132,10 @@
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Captura de rectángulo transparente</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Suavizado:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolación de curva</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.fa-IR.resx
@@ -285,4 +285,10 @@
   <data name="ShapeManager_CreateToolbar_Undo" xml:space="preserve">
     <value>برگرداندن</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>هموارسازی:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>درون‌یابی منحنی</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.fr.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.fr.resx
@@ -405,6 +405,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Direction de la tête de flêche :</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Lissage :</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolation de courbe</value>
+  </data>
   <data name="ImageUploading" xml:space="preserve">
     <value>Mise en ligne de l'image</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.he-IL.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.he-IL.resx
@@ -249,6 +249,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>כיוון ראש החץ:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>החלקה:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>אינטרפולציית עקומה</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>סגנון גבול:</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.hu.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.hu.resx
@@ -129,4 +129,10 @@
   <data name="BaseRegionForm_InitializeComponent_Region_capture" xml:space="preserve">
     <value>Régió felvétele</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Simítás:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Görbe interpoláció</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.id-ID.resx
@@ -354,4 +354,10 @@
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Pengambilan persegi panjang (transparan)</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Penghalusan:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolasi kurva</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.it-IT.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.it-IT.resx
@@ -279,4 +279,10 @@
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Cattura Rettangolare Trasparente</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Smussatura:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolazione curva</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ja-JP.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ja-JP.resx
@@ -399,6 +399,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>矢の先端の方向:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>スムージング:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>曲線補間</value>
+  </data>
   <data name="LockMenu" xml:space="preserve">
     <value>ツールバーメニューを固定する</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ko-KR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ko-KR.resx
@@ -360,4 +360,10 @@
   <data name="ThisWindowWillCloseBeforeOpeningKeybindsPageWantContinue" xml:space="preserve">
     <value>이 창은 keybinds 웹 페이지를 열기 전에 닫힙니다. 계속하시겠습니까?</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>부드럽게:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>곡선 보간</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.nl-NL.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.nl-NL.resx
@@ -201,4 +201,10 @@
   <data name="ShapeManager_CreateContextMenu_Pixel_size_" xml:space="preserve">
     <value>Pixel grootte:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Vloeiendheid:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Curve-interpolatie</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pl.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pl.resx
@@ -456,6 +456,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Kierunek grotu strzałki:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Wygładzanie:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolacja krzywej</value>
+  </data>
   <data name="RectangleTransparent_RectangleTransparent_Rectangle_capture_transparent" xml:space="preserve">
     <value>Przechwytywanie przezroczystego prostokąta</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-BR.resx
@@ -393,6 +393,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Direção da seta:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Suavização:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolação de curva</value>
+  </data>
   <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
     <value>Nova linha: Enter, OK: Ctrl + Enter</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.pt-PT.resx
@@ -387,4 +387,10 @@
   <data name="CloseEsc" xml:space="preserve">
     <value>Fechar (Esc)</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Suavização:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolação de curva</value>
+  </data>
 </root>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.resx
@@ -436,6 +436,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Arrow head direction:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Smoothing:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Curve interpolation</value>
+  </data>
   <data name="layer_shape_text" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\layer-shape-text.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ro.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ro.resx
@@ -165,6 +165,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Direcția capului de săgeată:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Netezire:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Interpolare curbă</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>Închideți automat editorul pe sarcină</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.ru.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.ru.resx
@@ -390,6 +390,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Направление стрелки:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Сглаживание:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Интерполяция кривой</value>
+  </data>
   <data name="NewLineEnterOKCtrlEnter" xml:space="preserve">
     <value>Новая строка: Enter, OK: Ctrl + Enter</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.tr.resx
@@ -351,6 +351,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Ok başı yönü:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Yumuşatma:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Eğri enterpolasyonu</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_AutoCloseEditorOnTask" xml:space="preserve">
     <value>Görevden sonra editörü otomatik kapat</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.uk.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.uk.resx
@@ -485,6 +485,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Напрямок стрілки:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Згладжування:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Інтерполяція кривої</value>
+  </data>
   <data name="ShapeManager_CreateToolbar_BringForward" xml:space="preserve">
     <value>Перемістити вперед</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.vi-VN.resx
@@ -468,6 +468,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>Hướng đầu mũi tên:</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>Làm mượt:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>Nội suy đường cong</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>Kiểu viền:</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-CN.resx
@@ -456,6 +456,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>箭头头部方向：</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>平滑度:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>曲线插值</value>
+  </data>
   <data name="ShapeManager_BorderStyle" xml:space="preserve">
     <value>边框样式：</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
+++ b/ShareX.ScreenCaptureLib/Properties/Resources.zh-TW.resx
@@ -482,6 +482,12 @@
   <data name="ShapeManager_ArrowHeadDirection" xml:space="preserve">
     <value>箭頭頭部方向：</value>
   </data>
+  <data name="ShapeManager_FreehandSmoothing" xml:space="preserve">
+    <value>平滑度:</value>
+  </data>
+  <data name="ShapeManager_FreehandCurveInterpolation" xml:space="preserve">
+    <value>曲線插值</value>
+  </data>
   <data name="CutOutEffectSize" xml:space="preserve">
     <value>剪紙效果大小：</value>
   </data>

--- a/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/AnnotationOptions.cs
@@ -49,6 +49,10 @@ namespace ShareX.ScreenCaptureLib
         public Color ShadowColor { get; set; } = Color.FromArgb(125, 0, 0, 0);
         public Point ShadowOffset { get; set; } = new Point(0, 1);
 
+        // Freehand drawing
+        public int FreehandSmoothing { get; set; } = 0;
+        public bool FreehandCurveInterpolation { get; set; } = true;
+
         // Line, arrow drawing
         public int LineCenterPointCount { get; set; } = 1;
 

--- a/ShareX.ScreenCaptureLib/Shapes/Drawing/FreehandDrawingShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Drawing/FreehandDrawingShape.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -40,6 +40,9 @@ namespace ShareX.ScreenCaptureLib
 
         public override bool IsSelectable => Manager.CurrentTool == ShapeType.ToolSelect;
 
+        public int Smoothing { get; set; }
+        public bool CurveInterpolation { get; set; }
+
         public PointF LastPosition
         {
             get
@@ -63,6 +66,20 @@ namespace ShareX.ScreenCaptureLib
         protected List<PointF> positions = new List<PointF>();
         private bool isPolygonMode;
 
+        public override void OnConfigLoad()
+        {
+            base.OnConfigLoad();
+            Smoothing = AnnotationOptions.FreehandSmoothing;
+            CurveInterpolation = AnnotationOptions.FreehandCurveInterpolation;
+        }
+
+        public override void OnConfigSave()
+        {
+            base.OnConfigSave();
+            AnnotationOptions.FreehandSmoothing = Smoothing;
+            AnnotationOptions.FreehandCurveInterpolation = CurveInterpolation;
+        }
+
         public override void ShowNodes()
         {
         }
@@ -81,6 +98,11 @@ namespace ShareX.ScreenCaptureLib
 
                     if (positions.Count == 0 || (!Manager.IsProportionalResizing && LastPosition != pos))
                     {
+                        if (Smoothing > 0 && positions.Count > 0 && !Manager.IsProportionalResizing)
+                        {
+                            pos = positions.SmoothPoint(pos, Smoothing);
+                        }
+
                         positions.Add(pos);
                     }
 
@@ -147,7 +169,14 @@ namespace ShareX.ScreenCaptureLib
                 {
                     using (Pen pen = CreatePen(borderColor, borderSize, borderStyle))
                     {
-                        g.DrawLines(pen, points.ToArray());
+                        if (CurveInterpolation && points.Length > 2)
+                        {
+                            g.DrawCurve(pen, points, 0.5f);
+                        }
+                        else
+                        {
+                            g.DrawLines(pen, points);
+                        }
                     }
                 }
 

--- a/ShareX.ScreenCaptureLib/Shapes/Region/FreehandRegionShape.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/Region/FreehandRegionShape.cs
@@ -1,4 +1,4 @@
-﻿#region License Information (GPL v3)
+#region License Information (GPL v3)
 
 /*
     ShareX - A program that allows you to take screenshots and share any file type
@@ -34,6 +34,9 @@ namespace ShareX.ScreenCaptureLib
     {
         public override ShapeType ShapeType { get; } = ShapeType.RegionFreehand;
 
+        public int Smoothing { get; set; }
+        public bool CurveInterpolation { get; set; }
+
         public PointF LastPosition
         {
             get
@@ -57,6 +60,18 @@ namespace ShareX.ScreenCaptureLib
         private List<PointF> points = new List<PointF>();
         private bool isPolygonMode;
 
+        public override void OnConfigLoad()
+        {
+            Smoothing = AnnotationOptions.FreehandSmoothing;
+            CurveInterpolation = AnnotationOptions.FreehandCurveInterpolation;
+        }
+
+        public override void OnConfigSave()
+        {
+            AnnotationOptions.FreehandSmoothing = Smoothing;
+            AnnotationOptions.FreehandCurveInterpolation = CurveInterpolation;
+        }
+
         protected override void UseLightResizeNodes()
         {
             ChangeNodeShape(NodeShape.Circle);
@@ -76,6 +91,11 @@ namespace ShareX.ScreenCaptureLib
 
                     if (points.Count == 0 || (!Manager.IsProportionalResizing && LastPosition != pos))
                     {
+                        if (Smoothing > 0 && points.Count > 0 && !Manager.IsProportionalResizing)
+                        {
+                            pos = points.SmoothPoint(pos, Smoothing);
+                        }
+
                         points.Add(pos);
                     }
 
@@ -104,7 +124,14 @@ namespace ShareX.ScreenCaptureLib
         {
             if (points.Count > 2)
             {
-                gp.AddPolygon(points.ToArray());
+                if (CurveInterpolation)
+                {
+                    gp.AddClosedCurve(points.ToArray(), 0.5f);
+                }
+                else
+                {
+                    gp.AddPolygon(points.ToArray());
+                }
             }
             else if (points.Count == 2)
             {

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -50,9 +50,10 @@ namespace ShareX.ScreenCaptureLib
         private ToolStripDropDownButton tsddbShapeOptions;
         private ToolStripMenuItem tsmiShadow, tsmiShadowColor, tsmiUndo, tsmiRedo, tsmiDuplicate, tsmiDelete, tsmiDeleteAll,
             tsmiMoveTop, tsmiMoveUp, tsmiMoveDown, tsmiMoveBottom, tsmiRegionCapture, tsmiQuickCrop, tsmiShowMagnifier, tsmiCutOutBackgroundColor,
-            tsmiSpotlightEllipse;
+            tsmiSpotlightEllipse, tsmiFreehandCurveInterpolation;
         private ToolStripLabeledNumericUpDown tslnudBorderSize, tslnudCornerRadius, tslnudCenterPoints, tslnudBlurRadius, tslnudPixelateSize, tslnudStepFontSize,
-            tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength, tslnudCutOutEffectSize, tslnudSpotlightDim, tslnudSpotlightBlur;
+            tslnudMagnifierPixelCount, tslnudStartingStepValue, tslnudMagnifyStrength, tslnudCutOutEffectSize, tslnudSpotlightDim, tslnudSpotlightBlur,
+            tslnudFreehandSmoothing;
         private ToolStripLabel tslDragLeft, tslDragRight;
         private ToolStripLabeledComboBox tscbBorderStyle, tscbArrowHeadDirection, tscbImageInterpolationMode, tscbCursorTypes, tscbStepType, tscbCutOutEffectType;
 
@@ -595,6 +596,25 @@ namespace ShareX.ScreenCaptureLib
                 UpdateCurrentShape();
             };
             tsddbShapeOptions.DropDownItems.Add(tscbArrowHeadDirection);
+
+            tslnudFreehandSmoothing = new ToolStripLabeledNumericUpDown(Resources.ShapeManager_FreehandSmoothing);
+            tslnudFreehandSmoothing.Content.Minimum = 0;
+            tslnudFreehandSmoothing.Content.Maximum = 10;
+            tslnudFreehandSmoothing.Content.ValueChanged = (sender, e) =>
+            {
+                AnnotationOptions.FreehandSmoothing = (int)tslnudFreehandSmoothing.Content.Value;
+                UpdateCurrentShape();
+            };
+            tsddbShapeOptions.DropDownItems.Add(tslnudFreehandSmoothing);
+
+            tsmiFreehandCurveInterpolation = new ToolStripMenuItem(Resources.ShapeManager_FreehandCurveInterpolation);
+            tsmiFreehandCurveInterpolation.CheckOnClick = true;
+            tsmiFreehandCurveInterpolation.Click += (sender, e) =>
+            {
+                AnnotationOptions.FreehandCurveInterpolation = tsmiFreehandCurveInterpolation.Checked;
+                UpdateCurrentShape();
+            };
+            tsddbShapeOptions.DropDownItems.Add(tsmiFreehandCurveInterpolation);
 
             tslnudStepFontSize = new ToolStripLabeledNumericUpDown(Resources.ShapeManager_CreateToolbar_FontSize);
             tslnudStepFontSize.Content.Minimum = 10;
@@ -1546,6 +1566,9 @@ namespace ShareX.ScreenCaptureLib
 
             tscbArrowHeadDirection.Content.SelectedIndex = (int)AnnotationOptions.ArrowHeadDirection;
 
+            tslnudFreehandSmoothing.Content.Value = AnnotationOptions.FreehandSmoothing;
+            tsmiFreehandCurveInterpolation.Checked = AnnotationOptions.FreehandCurveInterpolation;
+
             tslnudSpotlightDim.Content.Value = AnnotationOptions.SpotlightDim;
             tslnudSpotlightBlur.Content.Value = AnnotationOptions.SpotlightBlur;
             tsmiSpotlightEllipse.Checked = AnnotationOptions.SpotlightEllipse;
@@ -1563,6 +1586,7 @@ namespace ShareX.ScreenCaptureLib
                     tsddbShapeOptions.Visible = false;
                     break;
                 case ShapeType.RegionRectangle:
+                case ShapeType.RegionFreehand:
                 case ShapeType.DrawingRectangle:
                 case ShapeType.DrawingEllipse:
                 case ShapeType.DrawingFreehand:
@@ -1661,6 +1685,8 @@ namespace ShareX.ScreenCaptureLib
 
             tslnudCenterPoints.Visible = shapeType == ShapeType.DrawingLine || shapeType == ShapeType.DrawingArrow;
             tscbArrowHeadDirection.Visible = shapeType == ShapeType.DrawingArrow || shapeType == ShapeType.DrawingFreehandArrow;
+            tslnudFreehandSmoothing.Visible = tsmiFreehandCurveInterpolation.Visible =
+                shapeType == ShapeType.DrawingFreehand || shapeType == ShapeType.DrawingFreehandArrow || shapeType == ShapeType.RegionFreehand;
             tscbImageInterpolationMode.Visible = shapeType == ShapeType.DrawingImage || shapeType == ShapeType.DrawingImageScreen || shapeType == ShapeType.DrawingMagnify;
             tslnudStartingStepValue.Visible = shapeType == ShapeType.DrawingStep;
             tslnudStepFontSize.Visible = tscbStepType.Visible = shapeType == ShapeType.DrawingStep;


### PR DESCRIPTION
Add two new options to freehand pen, freehand arrow, and freehand region select tools:

- Smoothing (0-10): Applies an exponentially-weighted moving average to mouse input during drawing, acting as brush stabilization to produce smoother, cleaner lines.
![2026-03-01_19-57-34_NVIDIA_Overlay](https://github.com/user-attachments/assets/fd93ee32-1cab-405c-8d5d-36c1f30cde14)

- Curve interpolation: Replaces straight line segment rendering with Catmull-Rom cardinal splines (DrawCurve/AddClosedCurve), fixing the jagged appearance when drawing fast curves. This only differs from the straight line method when the mouse position samples are far apart with large angles, so behavior when moving slowly is unaffected.
![comparison_compressed](https://github.com/user-attachments/assets/3e52a7d9-bbc7-45aa-8909-f004aa1a71f6)

Also added associated localization entries. The default state of smoothing will be off, while the default state of interpolation will be on.

