### PR TITLE
Fix region capture on multi-monitor setups with different DPI scales

### DIFF
--- a/ShareX.HelpersLib/Helpers/CaptureHelpers.cs
+++ b/ShareX.HelpersLib/Helpers/CaptureHelpers.cs
@@ -378,5 +378,49 @@ namespace ShareX.HelpersLib
             rect.Height -= rect.Height & 1;
             return rect;
         }
+
+        public static Rectangle GetScreenBoundsPhysical()
+        {
+            IntPtr previousContext = NativeMethods.SetDpiAwarenessForCapture();
+
+            try
+            {
+                int x = NativeMethods.GetSystemMetrics(SystemMetric.SM_XVIRTUALSCREEN);
+                int y = NativeMethods.GetSystemMetrics(SystemMetric.SM_YVIRTUALSCREEN);
+                int cx = NativeMethods.GetSystemMetrics(SystemMetric.SM_CXVIRTUALSCREEN);
+                int cy = NativeMethods.GetSystemMetrics(SystemMetric.SM_CYVIRTUALSCREEN);
+                return new Rectangle(x, y, cx, cy);
+            }
+            finally
+            {
+                NativeMethods.RestoreDpiAwareness(previousContext);
+            }
+        }
+
+        public static Rectangle GetActiveScreenBoundsPhysical()
+        {
+            IntPtr previousContext = NativeMethods.SetDpiAwarenessForCapture();
+
+            try
+            {
+                Point cursorPos = GetCursorPosition();
+                POINT pt = new POINT(cursorPos.X, cursorPos.Y);
+                IntPtr hMonitor = NativeMethods.MonitorFromPoint(pt, NativeConstants.MONITOR_DEFAULTTONEAREST);
+
+                MONITORINFO mi = new MONITORINFO();
+                mi.cbSize = System.Runtime.InteropServices.Marshal.SizeOf(typeof(MONITORINFO));
+
+                if (NativeMethods.GetMonitorInfo(hMonitor, ref mi))
+                {
+                    return mi.rcMonitor;
+                }
+
+                return Screen.FromPoint(cursorPos).Bounds;
+            }
+            finally
+            {
+                NativeMethods.RestoreDpiAwareness(previousContext);
+            }
+        }
     }
 }

--- a/ShareX.HelpersLib/Native/NativeConstants.cs
+++ b/ShareX.HelpersLib/Native/NativeConstants.cs
@@ -23,6 +23,8 @@
 
 #endregion License Information (GPL v3)
 
+using System;
+
 namespace ShareX.HelpersLib
 {
     public static class NativeConstants
@@ -130,5 +132,9 @@ namespace ShareX.HelpersLib
 
         public const int LWA_COLORKEY = 0x1;
         public const int LWA_ALPHA = 0x2;
+
+        public static readonly IntPtr DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = new IntPtr(-4);
+        public const uint MONITOR_DEFAULTTONEAREST = 2;
+        public const int MDT_EFFECTIVE_DPI = 0;
     }
 }

--- a/ShareX.HelpersLib/Native/NativeMethods.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods.cs
@@ -301,6 +301,15 @@ namespace ShareX.HelpersLib
         [DllImport("user32.dll")]
         public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
 
+        [DllImport("user32.dll")]
+        public static extern IntPtr SetThreadDpiAwarenessContext(IntPtr dpiContext);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+
         #endregion user32.dll
 
         #region kernel32.dll
@@ -482,6 +491,13 @@ namespace ShareX.HelpersLib
         public static extern uint TimeGetDevCaps(ref TimeCaps timeCaps, uint sizeTimeCaps);
 
         #endregion
+
+        #region shcore.dll
+
+        [DllImport("shcore.dll")]
+        public static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+        #endregion shcore.dll
 
         #region Other dll
 

--- a/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
+++ b/ShareX.HelpersLib/Native/NativeMethods_Helpers.cs
@@ -611,5 +611,63 @@ namespace ShareX.HelpersLib
 
             return hWnd;
         }
+
+        public static uint GetDpiForMonitor(Point screenPoint)
+        {
+            try
+            {
+                POINT pt = new POINT(screenPoint.X, screenPoint.Y);
+                IntPtr hMonitor = MonitorFromPoint(pt, NativeConstants.MONITOR_DEFAULTTONEAREST);
+
+                if (hMonitor != IntPtr.Zero)
+                {
+                    int result = GetDpiForMonitor(hMonitor, NativeConstants.MDT_EFFECTIVE_DPI, out uint dpiX, out uint dpiY);
+
+                    if (result == 0)
+                    {
+                        return dpiX;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+            }
+
+            return 96;
+        }
+
+        public static float GetScalingFactorForMonitor(Point screenPoint)
+        {
+            return GetDpiForMonitor(screenPoint) / 96f;
+        }
+
+        public static IntPtr SetDpiAwarenessForCapture()
+        {
+            try
+            {
+                return SetThreadDpiAwarenessContext(NativeConstants.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            }
+            catch (Exception e)
+            {
+                DebugHelper.WriteException(e);
+                return IntPtr.Zero;
+            }
+        }
+
+        public static void RestoreDpiAwareness(IntPtr previousContext)
+        {
+            if (previousContext != IntPtr.Zero)
+            {
+                try
+                {
+                    SetThreadDpiAwarenessContext(previousContext);
+                }
+                catch (Exception e)
+                {
+                    DebugHelper.WriteException(e);
+                }
+            }
+        }
     }
 }

--- a/ShareX.HelpersLib/Native/NativeStructs.cs
+++ b/ShareX.HelpersLib/Native/NativeStructs.cs
@@ -228,6 +228,15 @@ namespace ShareX.HelpersLib
         }
     }
 
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct MONITORINFO
+    {
+        public int cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     public struct WINDOWINFO
     {

--- a/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
+++ b/ShareX.ScreenCaptureLib/Forms/RegionCaptureForm.cs
@@ -114,7 +114,7 @@ namespace ShareX.ScreenCaptureLib
 
             if (IsFullscreen && Options.ActiveMonitorMode)
             {
-                ScreenBounds = CaptureHelpers.GetActiveScreenBounds();
+                ScreenBounds = CaptureHelpers.GetActiveScreenBoundsPhysical();
 
                 if (canvas == null)
                 {
@@ -125,7 +125,7 @@ namespace ShareX.ScreenCaptureLib
             }
             else
             {
-                ScreenBounds = CaptureHelpers.GetScreenBounds();
+                ScreenBounds = CaptureHelpers.GetScreenBoundsPhysical();
 
                 if (canvas == null)
                 {
@@ -133,7 +133,7 @@ namespace ShareX.ScreenCaptureLib
                 }
             }
 
-            ClientArea = new Rectangle(0, 0, ScreenBounds.Width, ScreenBounds.Height);
+            ClientArea = new Rectangle(0, 0, canvas.Width, canvas.Height);
             CanvasRectangle = ClientArea;
 
             timerStart = new Stopwatch();
@@ -872,6 +872,20 @@ namespace ShareX.ScreenCaptureLib
             {
                 UpdateTitle();
             }
+        }
+
+        private const int WM_DPICHANGED = 0x02E0;
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_DPICHANGED && IsFullscreen)
+            {
+                // Block WinForms from resizing the fullscreen form due to DPI change.
+                // The form bounds are already set to physical pixel coordinates.
+                return;
+            }
+
+            base.WndProc(ref m);
         }
 
         protected override void OnPaintBackground(PaintEventArgs e)

--- a/ShareX.ScreenCaptureLib/Screenshot.cs
+++ b/ShareX.ScreenCaptureLib/Screenshot.cs
@@ -41,18 +41,27 @@ namespace ShareX.ScreenCaptureLib
 
         public Bitmap CaptureRectangle(Rectangle rect)
         {
-            if (RemoveOutsideScreenArea)
-            {
-                Rectangle bounds = CaptureHelpers.GetScreenBounds();
-                rect = Rectangle.Intersect(bounds, rect);
-            }
+            IntPtr previousContext = NativeMethods.SetDpiAwarenessForCapture();
 
-            return CaptureRectangleNative(rect, CaptureCursor);
+            try
+            {
+                if (RemoveOutsideScreenArea)
+                {
+                    Rectangle bounds = CaptureHelpers.GetScreenBoundsPhysical();
+                    rect = Rectangle.Intersect(bounds, rect);
+                }
+
+                return CaptureRectangleNative(rect, CaptureCursor);
+            }
+            finally
+            {
+                NativeMethods.RestoreDpiAwareness(previousContext);
+            }
         }
 
         public Bitmap CaptureFullscreen()
         {
-            Rectangle bounds = CaptureHelpers.GetScreenBounds();
+            Rectangle bounds = CaptureHelpers.GetScreenBoundsPhysical();
 
             return CaptureRectangle(bounds);
         }
@@ -104,7 +113,7 @@ namespace ShareX.ScreenCaptureLib
 
         public Bitmap CaptureActiveMonitor()
         {
-            Rectangle bounds = CaptureHelpers.GetActiveScreenBounds();
+            Rectangle bounds = CaptureHelpers.GetActiveScreenBoundsPhysical();
 
             return CaptureRectangle(bounds);
         }

--- a/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
+++ b/ShareX.ScreenCaptureLib/Shapes/ShapeManagerMenu.cs
@@ -85,7 +85,7 @@ namespace ShareX.ScreenCaptureLib
 
             if (Options.MenuIconSize == 0)
             {
-                Options.MenuIconSize = (int)(16 * NativeMethods.GetScreenScalingFactor());
+                Options.MenuIconSize = (int)(16 * NativeMethods.GetScalingFactorForMonitor(CaptureHelpers.GetCursorPosition()));
             }
 
             int imageScalingSize = Options.MenuIconSize.Clamp(16, 64);


### PR DESCRIPTION
## Summary

- Fixes the region capture overlay appearing as a tiny window on secondary monitors with different DPI scaling, trapping the cursor in a small area
- The root cause was WinForms' default `WM_DPICHANGED` handler resizing the fullscreen capture form when it appeared on a non-primary monitor with different DPI
- Adds per-monitor DPI-aware screen bounds detection using Win32 APIs (`GetMonitorInfo`, `MonitorFromPoint`, `GetDpiForMonitor`) to ensure correct physical pixel coordinates for capture

## Changes

### Core fix
- **RegionCaptureForm**: Block `WM_DPICHANGED` when the form is fullscreen, since the bounds are already set to correct physical pixel coordinates. This prevents WinForms from resizing the capture overlay.

### Supporting improvements
- **NativeMethods**: Add P/Invoke for `SetThreadDpiAwarenessContext`, `MonitorFromPoint`, `GetMonitorInfo`, `GetDpiForMonitor`
- **NativeConstants**: Add `DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2`, `MONITOR_DEFAULTTONEAREST`, `MDT_EFFECTIVE_DPI`
- **NativeStructs**: Add `MONITORINFO` struct
- **NativeMethods_Helpers**: Add per-monitor DPI helpers (`GetDpiForMonitor`, `GetScalingFactorForMonitor`, `SetDpiAwarenessForCapture`, `RestoreDpiAwareness`)
- **CaptureHelpers**: Add `GetScreenBoundsPhysical()` and `GetActiveScreenBoundsPhysical()` using raw Win32 APIs instead of .NET `Screen` class
- **Screenshot**: Wrap `CaptureRectangle` in PMv2 DPI context, use physical pixel bounds for screen clipping
- **ShapeManagerMenu**: Use per-monitor DPI for menu icon scaling

## Test plan

- [x] Single monitor at 100% DPI — verify no regression in all capture modes
- [x] Multi-monitor same DPI — verify no regression
- [x] Multi-monitor different DPI (e.g., primary 100%, secondary 200%) — region capture overlay should cover full secondary screen
- [x] Multi-monitor different DPI — fullscreen and active monitor capture should produce correct resolution bitmaps
- [x] Verify cursor is not trapped in a small area on secondary monitors

Fixes #5312 #7713 #3578 #8238