### PR TITLE
Update dshow regex to work with latest ffmpeg

### DIFF
--- a/ShareX.MediaLib/FFmpegCLIManager.cs
+++ b/ShareX.MediaLib/FFmpegCLIManager.cs
@@ -230,7 +230,7 @@ namespace ShareX.MediaLib
             string output = Output.ToString();
             string[] lines = output.Lines();
             bool isAudio = false;
-            Regex regex = new Regex(@"\[dshow @ \w+\] +""(.+)""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Regex regex = new Regex(@"\[(?:dshow|in#0) @ \w+\] +""(.+)""", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
             foreach (string line in lines)
             {


### PR DESCRIPTION
From around the beginning of this month, when using the Master builds from https://github.com/BtbN/FFmpeg-Builds/releases in Sharex, the dshow device enumeration fails due to a change of how ffmpeg lists them in `"-list_devices true -f dshow -i dummy"`. Example:

`[in#0 @ 000001bd07e70b00] "screen-capture-recorder" (video)
[in#0 @ 000001bd07e70b00]   Alternative name "@device_sw_{860BB310-5D01-11D0-BD3B-00A0C911CE86}\{4EA69364-2C8A-4AE6-A561-56E4B5044439}"
[dshow @ 000002798dd4fb80] "virtual-audio-capturer" (audio)
[dshow @ 000002798dd4fb80]   Alternative name "@device_sw_{33D9A762-90C8-11D0-BD43-00A0C911CE86}\{8E146464-DB61-4309-AFA1-3578E927E935}"`

compared to:
`[dshow @ 000002798dd4fb80] "screen-capture-recorder" (video)
[dshow @ 000002798dd4fb80]   Alternative name "@device_sw_{860BB310-5D01-11D0-BD3B-00A0C911CE86}\{4EA69364-2C8A-4AE6-A561-56E4B5044439}"
[in#0 @ 000001bd07e70b00] "virtual-audio-capturer" (audio)
[in#0 @ 000001bd07e70b00]   Alternative name "@device_sw_{33D9A762-90C8-11D0-BD43-00A0C911CE86}\{8E146464-DB61-4309-AFA1-3578E927E935}"`

So I updated the regex to match both `dshow` and `in#0`.